### PR TITLE
update to forkrun v1.1.2

### DIFF
--- a/META
+++ b/META
@@ -1,2 +1,2 @@
 NAME: forkrun
-VERSION: v1.1.1
+VERSION: v1.1.2

--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@
 
 <sup>1: bash 5.1+ is preffered and much better tested. A few basic filesystem operations (`rm`, `mkdir`) must also be available. `fallocate` and `inotifywait` are not required; but, if present, will be used to lower runtime resource usage.</sup>
 
-**CURRENT VERSION**: forkrun v1.1.1
+**CURRENT VERSION**: forkrun v1.1.2
 
 **PREVIOUS VERION**: forkrun v1.0
 
 **CHANGES**: 2 new flags (`-b <bytes>` and `-B <bytes>`) that cause forkrun to split up stdin into blocks of `<bytes>` bytes. `-B` will wait and accululate blocks of exactly `<bytes>` bytes, `-b` will not. The `-I` flag has been expanded so that if `-k` (or `-n`) is also passed then a second susbstitution is made, swapping `{IND}` for the batch ordering index (the same thing that `-n` outputs at the start of each block) (`{ID}` will still be swapped for coproc ID). A handful of optimizations and bug-fixes have also been implemented (notably with how the coproc source code is dynamically generated). Lastly. the forkrun repo had some changes to how it is organized.
 
-NOTE: for the `-b` and `-B` flags to have the sort of effeciency and speed that forkrun typically has, you need to have GNU `dd` available. If you dont, `forkrun` will try to use `head -c` (which is *much* slower), and if thats unavailable itll use the `read -N` builtin (which is *much much* slower still and will mangle binary data since it will drop NULL's). You *really* want to use GNU `dd` here. Also, if passing binary data you should use the `-S` flag to pass it via stdin and avoid having bash process it and mangle it.
+NOTE: for the `-b` and `-B` flags to have the sort of effeciency and speed that forkrun typically has, you need to have GNU `dd` available. If you dont, `forkrun` will try to use `head -c` (which is *much* slower), and if thats unavailable itll use the `read` builtin with either `-n` or `-N` (which is *much* slower still...You *really* want to use GNU `dd` here). Also, when using these flags the `-S` flag is auomatically selected, meaning data is passed to the function being parallelized via its stdin. This is to avoid mangling binary data passed on stdin. This can be overruled by passing the`+S` flag, but all NULLs in stdin will be dropped.
 
 ***
 

--- a/forkrun.bash
+++ b/forkrun.bash
@@ -732,13 +732,7 @@ if ${readBytesFlag}; then
             else
                 printf '%s ' ${fd_read}
             fi
-            echo """
-            if [[ \${REPLY} ]]; then
-                echo \"\${REPLY}\" >\"${tmpDir}\"/.stdin.tmp.{<#>}
-                A=('')
-            else
-                A=()
-            fi"""
+            echo '-a A'
         fi
         ;;
     esac
@@ -804,7 +798,7 @@ ${subshellRunFlag} && echo '(' || echo '{'
 ${exportOrderFlag} && echo "printf '\034%s:\035\n' \"\${nOrder0}\""
 ${noFuncFlag} && echo 'IFS=$'"'"'\n'"'"
 printf '%s ' "${runCmd[@]}"
-if ${readBytesFlag}; then
+if ${readBytesFlag} && ! { [[ ${readBytesProg} == 'bash' ]] && ! ${stdinRunFlag}; }; then
     if ${stdinRunFlag} || ${noFuncFlag}; then 
         printf '<"%s"/%s' "${tmpDir}" '.stdin.tmp.{<#>}'
     else

--- a/forkrun.bash
+++ b/forkrun.bash
@@ -1,10 +1,6 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2004,SC2015,SC2016,SC2028,SC2162 source=/dev/null
 
-# TO DO: try implementing `-b`` flag (when reading with bash) using 
-# `read -r -n ${nBytes} -d ''; A+="$REPLY"` until correct number of bytes read, 
-# then replace "${A[@]}" with "$(printf '%s\0' "${A[@]}")" when running the command.
-
 shopt -s extglob
 
 forkrun() {
@@ -728,7 +724,7 @@ else
         echo """
         [[ \${#A[@]} == 0 ]] || {
             [[ \"\${A[-1]: -1}\" == ${delimiterVal} ]] || {"""
-                (( ${verboseLevel} > 2 )) && echo """
+        (( ${verboseLevel} > 2 )) && echo """
                 echo \"Partial read at: \${A[-1]}\" >&${fd_stderr}"""
         echo """
                 until read -r -u ${fd_read} ${delimiterReadStr}; do 
@@ -764,15 +760,16 @@ ${nLinesAutoFlag} && { printf '%s' """
     ${fallocateFlag} && printf '%s' ' || ' || echo
 }
 ${fallocateFlag} && echo "printf '\\n' >&\${fd_nAuto0}"
-${pipeReadFlag} || ${nullDelimiterFlag} || ${readBytesFlag} || echo """
+${pipeReadFlag} || ${nullDelimiterFlag} || ${readBytesFlag} || {
+    echo """
         { [[ \"\${A[*]##*${delimiterVal}}\" ]] || [[ -z \${A[0]} ]]; } && {"""
-(( ${verboseLevel} > 2 )) && echo "echo \"FIXING SPLIT READ\" >&${fd_stderr}"
-echo """
+    (( ${verboseLevel} > 2 )) && echo "echo \"FIXING SPLIT READ\" >&${fd_stderr}"
+    echo """
             A[-1]=\"\${A[-1]%${delimiterVal}}\"
             IFS=
             mapfile ${delimiterReadStr} A <<<\"\${A[*]}\"
-        }
-"""
+        }"""
+}
 ${subshellRunFlag} && echo '(' || echo '{'
 { ${exportOrderFlag} || { ${nOrderFlag} && ${substituteStringIDFlag}; }; } && echo 'nOrder0="$(( ${nOrder##*(9)*(0)} + ${nOrder%%*(0)${nOrder##*(9)*(0)}}0 - 9 ))"'
 ${exportOrderFlag} && echo "printf '\034%s:\035\n' \"\${nOrder0}\""


### PR DESCRIPTION
Main changes:

1. -S flag (passing data to function being parallelized via its stdin) is now enabled by default when (-b|-B) flag is passed
2. When (-b|-B) flag is used and neither `dd` (GNU) nor `head` are available and `-S` flag is enabled, data is read (with the `read` builtin) in a way that NULLs are not dropped from the data (making it feasible/safe to use `forkrun` with binary data)
3. The "no function" mode was partially rewritten to avoid unnecessary command substitutions, making it a good deal faster.
4. Miscellaneous other minor optimizations and bug fixes.

This will *probably* be the last 1.1.x release, as the "splitting reads by byte count" functionality seems to be fully functional now.