### PR TITLE
Update lseek.c

### DIFF
--- a/FlameCharts/forkrun_flamechart.bash
+++ b/FlameCharts/forkrun_flamechart.bash
@@ -66,3 +66,6 @@ for nn in "${A[@]}"; do
     sleep 1
 done
 
+# ./flamegraph.pl --title="forkrun flamechart" --subtitle='combined hash algs | dynamic coproc count' --flamechart --minwidth 1 --height 20 --width 4200  out.folded  >forkrun_flamechart.svg
+
+

--- a/FlameCharts/forkrun_flamechart_combined_dynamic-coproc.svg
+++ b/FlameCharts/forkrun_flamechart_combined_dynamic-coproc.svg
@@ -1,0 +1,17239 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" width="4200" height="2674" onload="init(evt)" viewBox="0 0 4200 2674" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<!-- Flame graph stack visualization. See https://github.com/brendangregg/FlameGraph for latest version, and http://www.brendangregg.com/flamegraphs.html for examples. -->
+<!-- NOTES:  -->
+<defs>
+	<linearGradient id="background" y1="0" y2="1" x1="0" x2="0" >
+		<stop stop-color="#eeeeee" offset="5%" />
+		<stop stop-color="#eeeeb0" offset="95%" />
+	</linearGradient>
+</defs>
+<style type="text/css">
+	text { font-family:Verdana; font-size:12px; fill:rgb(0,0,0); }
+	#search, #ignorecase { opacity:0.1; cursor:pointer; }
+	#search:hover, #search.show, #ignorecase:hover, #ignorecase.show { opacity:1; }
+	#subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
+	#title { text-anchor:middle; font-size:17px}
+	#unzoom { cursor:pointer; }
+	#frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
+	.hide { display:none; }
+	.parent { opacity:0.5; }
+</style>
+<script type="text/ecmascript">
+<![CDATA[
+	"use strict";
+	var details, searchbtn, unzoombtn, matchedtxt, svg, searching, currentSearchTerm, ignorecase, ignorecaseBtn;
+	function init(evt) {
+		details = document.getElementById("details").firstChild;
+		searchbtn = document.getElementById("search");
+		ignorecaseBtn = document.getElementById("ignorecase");
+		unzoombtn = document.getElementById("unzoom");
+		matchedtxt = document.getElementById("matched");
+		svg = document.getElementsByTagName("svg")[0];
+		searching = 0;
+		currentSearchTerm = null;
+
+		// use GET parameters to restore a flamegraphs state.
+		var params = get_params();
+		if (params.x && params.y)
+			zoom(find_group(document.querySelector('[x="' + params.x + '"][y="' + params.y + '"]')));
+                if (params.s) search(params.s);
+	}
+
+	// event listeners
+	window.addEventListener("click", function(e) {
+		var target = find_group(e.target);
+		if (target) {
+			if (target.nodeName == "a") {
+				if (e.ctrlKey === false) return;
+				e.preventDefault();
+			}
+			if (target.classList.contains("parent")) unzoom(true);
+			zoom(target);
+			if (!document.querySelector('.parent')) {
+				// we have basically done a clearzoom so clear the url
+				var params = get_params();
+				if (params.x) delete params.x;
+				if (params.y) delete params.y;
+				history.replaceState(null, null, parse_params(params));
+				unzoombtn.classList.add("hide");
+				return;
+			}
+
+			// set parameters for zoom state
+			var el = target.querySelector("rect");
+			if (el && el.attributes && el.attributes.y && el.attributes._orig_x) {
+				var params = get_params()
+				params.x = el.attributes._orig_x.value;
+				params.y = el.attributes.y.value;
+				history.replaceState(null, null, parse_params(params));
+			}
+		}
+		else if (e.target.id == "unzoom") clearzoom();
+		else if (e.target.id == "search") search_prompt();
+		else if (e.target.id == "ignorecase") toggle_ignorecase();
+	}, false)
+
+	// mouse-over for info
+	// show
+	window.addEventListener("mouseover", function(e) {
+		var target = find_group(e.target);
+		if (target) details.nodeValue = "Function: " + g_to_text(target);
+	}, false)
+
+	// clear
+	window.addEventListener("mouseout", function(e) {
+		var target = find_group(e.target);
+		if (target) details.nodeValue = ' ';
+	}, false)
+
+	// ctrl-F for search
+	// ctrl-I to toggle case-sensitive search
+	window.addEventListener("keydown",function (e) {
+		if (e.keyCode === 114 || (e.ctrlKey && e.keyCode === 70)) {
+			e.preventDefault();
+			search_prompt();
+		}
+		else if (e.ctrlKey && e.keyCode === 73) {
+			e.preventDefault();
+			toggle_ignorecase();
+		}
+	}, false)
+
+	// functions
+	function get_params() {
+		var params = {};
+		var paramsarr = window.location.search.substr(1).split('&');
+		for (var i = 0; i < paramsarr.length; ++i) {
+			var tmp = paramsarr[i].split("=");
+			if (!tmp[0] || !tmp[1]) continue;
+			params[tmp[0]]  = decodeURIComponent(tmp[1]);
+		}
+		return params;
+	}
+	function parse_params(params) {
+		var uri = "?";
+		for (var key in params) {
+			uri += key + '=' + encodeURIComponent(params[key]) + '&';
+		}
+		if (uri.slice(-1) == "&")
+			uri = uri.substring(0, uri.length - 1);
+		if (uri == '?')
+			uri = window.location.href.split('?')[0];
+		return uri;
+	}
+	function find_child(node, selector) {
+		var children = node.querySelectorAll(selector);
+		if (children.length) return children[0];
+	}
+	function find_group(node) {
+		var parent = node.parentElement;
+		if (!parent) return;
+		if (parent.id == "frames") return node;
+		return find_group(parent);
+	}
+	function orig_save(e, attr, val) {
+		if (e.attributes["_orig_" + attr] != undefined) return;
+		if (e.attributes[attr] == undefined) return;
+		if (val == undefined) val = e.attributes[attr].value;
+		e.setAttribute("_orig_" + attr, val);
+	}
+	function orig_load(e, attr) {
+		if (e.attributes["_orig_"+attr] == undefined) return;
+		e.attributes[attr].value = e.attributes["_orig_" + attr].value;
+		e.removeAttribute("_orig_"+attr);
+	}
+	function g_to_text(e) {
+		var text = find_child(e, "title").firstChild.nodeValue;
+		return (text)
+	}
+	function g_to_func(e) {
+		var func = g_to_text(e);
+		// if there's any manipulation we want to do to the function
+		// name before it's searched, do it here before returning.
+		return (func);
+	}
+	function update_text(e) {
+		var r = find_child(e, "rect");
+		var t = find_child(e, "text");
+		var w = parseFloat(r.attributes.width.value) -3;
+		var txt = find_child(e, "title").textContent.replace(/\([^(]*\)$/,"");
+		t.attributes.x.value = parseFloat(r.attributes.x.value) + 3;
+
+		// Smaller than this size won't fit anything
+		if (w < 2 * 12 * 0.59) {
+			t.textContent = "";
+			return;
+		}
+
+		t.textContent = txt;
+		var sl = t.getSubStringLength(0, txt.length);
+		// check if only whitespace or if we can fit the entire string into width w
+		if (/^ *$/.test(txt) || sl < w)
+			return;
+
+		// this isn't perfect, but gives a good starting point
+		// and avoids calling getSubStringLength too often
+		var start = Math.floor((w/sl) * txt.length);
+		for (var x = start; x > 0; x = x-2) {
+			if (t.getSubStringLength(0, x + 2) <= w) {
+				t.textContent = txt.substring(0, x) + "..";
+				return;
+			}
+		}
+		t.textContent = "";
+	}
+
+	// zoom
+	function zoom_reset(e) {
+		if (e.attributes != undefined) {
+			orig_load(e, "x");
+			orig_load(e, "width");
+		}
+		if (e.childNodes == undefined) return;
+		for (var i = 0, c = e.childNodes; i < c.length; i++) {
+			zoom_reset(c[i]);
+		}
+	}
+	function zoom_child(e, x, ratio) {
+		if (e.attributes != undefined) {
+			if (e.attributes.x != undefined) {
+				orig_save(e, "x");
+				e.attributes.x.value = (parseFloat(e.attributes.x.value) - x - 10) * ratio + 10;
+				if (e.tagName == "text")
+					e.attributes.x.value = find_child(e.parentNode, "rect[x]").attributes.x.value + 3;
+			}
+			if (e.attributes.width != undefined) {
+				orig_save(e, "width");
+				e.attributes.width.value = parseFloat(e.attributes.width.value) * ratio;
+			}
+		}
+
+		if (e.childNodes == undefined) return;
+		for (var i = 0, c = e.childNodes; i < c.length; i++) {
+			zoom_child(c[i], x - 10, ratio);
+		}
+	}
+	function zoom_parent(e) {
+		if (e.attributes) {
+			if (e.attributes.x != undefined) {
+				orig_save(e, "x");
+				e.attributes.x.value = 10;
+			}
+			if (e.attributes.width != undefined) {
+				orig_save(e, "width");
+				e.attributes.width.value = parseInt(svg.width.baseVal.value) - (10 * 2);
+			}
+		}
+		if (e.childNodes == undefined) return;
+		for (var i = 0, c = e.childNodes; i < c.length; i++) {
+			zoom_parent(c[i]);
+		}
+	}
+	function zoom(node) {
+		var attr = find_child(node, "rect").attributes;
+		var width = parseFloat(attr.width.value);
+		var xmin = parseFloat(attr.x.value);
+		var xmax = parseFloat(xmin + width);
+		var ymin = parseFloat(attr.y.value);
+		var ratio = (svg.width.baseVal.value - 2 * 10) / width;
+
+		// XXX: Workaround for JavaScript float issues (fix me)
+		var fudge = 0.0001;
+
+		unzoombtn.classList.remove("hide");
+
+		var el = document.getElementById("frames").children;
+		for (var i = 0; i < el.length; i++) {
+			var e = el[i];
+			var a = find_child(e, "rect").attributes;
+			var ex = parseFloat(a.x.value);
+			var ew = parseFloat(a.width.value);
+			var upstack;
+			// Is it an ancestor
+			if (0 == 0) {
+				upstack = parseFloat(a.y.value) > ymin;
+			} else {
+				upstack = parseFloat(a.y.value) < ymin;
+			}
+			if (upstack) {
+				// Direct ancestor
+				if (ex <= xmin && (ex+ew+fudge) >= xmax) {
+					e.classList.add("parent");
+					zoom_parent(e);
+					update_text(e);
+				}
+				// not in current path
+				else
+					e.classList.add("hide");
+			}
+			// Children maybe
+			else {
+				// no common path
+				if (ex < xmin || ex + fudge >= xmax) {
+					e.classList.add("hide");
+				}
+				else {
+					zoom_child(e, xmin, ratio);
+					update_text(e);
+				}
+			}
+		}
+		search();
+	}
+	function unzoom(dont_update_text) {
+		unzoombtn.classList.add("hide");
+		var el = document.getElementById("frames").children;
+		for(var i = 0; i < el.length; i++) {
+			el[i].classList.remove("parent");
+			el[i].classList.remove("hide");
+			zoom_reset(el[i]);
+			if(!dont_update_text) update_text(el[i]);
+		}
+		search();
+	}
+	function clearzoom() {
+		unzoom();
+
+		// remove zoom state
+		var params = get_params();
+		if (params.x) delete params.x;
+		if (params.y) delete params.y;
+		history.replaceState(null, null, parse_params(params));
+	}
+
+	// search
+	function toggle_ignorecase() {
+		ignorecase = !ignorecase;
+		if (ignorecase) {
+			ignorecaseBtn.classList.add("show");
+		} else {
+			ignorecaseBtn.classList.remove("show");
+		}
+		reset_search();
+		search();
+	}
+	function reset_search() {
+		var el = document.querySelectorAll("#frames rect");
+		for (var i = 0; i < el.length; i++) {
+			orig_load(el[i], "fill")
+		}
+		var params = get_params();
+		delete params.s;
+		history.replaceState(null, null, parse_params(params));
+	}
+	function search_prompt() {
+		if (!searching) {
+			var term = prompt("Enter a search term (regexp " +
+			    "allowed, eg: ^ext4_)"
+			    + (ignorecase ? ", ignoring case" : "")
+			    + "\nPress Ctrl-i to toggle case sensitivity", "");
+			if (term != null) search(term);
+		} else {
+			reset_search();
+			searching = 0;
+			currentSearchTerm = null;
+			searchbtn.classList.remove("show");
+			searchbtn.firstChild.nodeValue = "Search"
+			matchedtxt.classList.add("hide");
+			matchedtxt.firstChild.nodeValue = ""
+		}
+	}
+	function search(term) {
+		if (term) currentSearchTerm = term;
+		if (currentSearchTerm === null) return;
+
+		var re = new RegExp(currentSearchTerm, ignorecase ? 'i' : '');
+		var el = document.getElementById("frames").children;
+		var matches = new Object();
+		var maxwidth = 0;
+		for (var i = 0; i < el.length; i++) {
+			var e = el[i];
+			var func = g_to_func(e);
+			var rect = find_child(e, "rect");
+			if (func == null || rect == null)
+				continue;
+
+			// Save max width. Only works as we have a root frame
+			var w = parseFloat(rect.attributes.width.value);
+			if (w > maxwidth)
+				maxwidth = w;
+
+			if (func.match(re)) {
+				// highlight
+				var x = parseFloat(rect.attributes.x.value);
+				orig_save(rect, "fill");
+				rect.attributes.fill.value = "rgb(230,0,230)";
+
+				// remember matches
+				if (matches[x] == undefined) {
+					matches[x] = w;
+				} else {
+					if (w > matches[x]) {
+						// overwrite with parent
+						matches[x] = w;
+					}
+				}
+				searching = 1;
+			}
+		}
+		if (!searching)
+			return;
+		var params = get_params();
+		params.s = currentSearchTerm;
+		history.replaceState(null, null, parse_params(params));
+
+		searchbtn.classList.add("show");
+		searchbtn.firstChild.nodeValue = "Reset Search";
+
+		// calculate percent matched, excluding vertical overlap
+		var count = 0;
+		var lastx = -1;
+		var lastw = 0;
+		var keys = Array();
+		for (k in matches) {
+			if (matches.hasOwnProperty(k))
+				keys.push(k);
+		}
+		// sort the matched frames by their x location
+		// ascending, then width descending
+		keys.sort(function(a, b){
+			return a - b;
+		});
+		// Step through frames saving only the biggest bottom-up frames
+		// thanks to the sort order. This relies on the tree property
+		// where children are always smaller than their parents.
+		var fudge = 0.0001;	// JavaScript floating point
+		for (var k in keys) {
+			var x = parseFloat(keys[k]);
+			var w = matches[keys[k]];
+			if (x >= lastx + lastw - fudge) {
+				count += w;
+				lastx = x;
+				lastw = w;
+			}
+		}
+		// display matched percent
+		matchedtxt.classList.remove("hide");
+		var pct = 100 * count / maxwidth;
+		if (pct != 100) pct = pct.toFixed(1)
+		matchedtxt.firstChild.nodeValue = "Matched: " + pct + "%";
+	}
+]]>
+</script>
+<rect x="0.0" y="0" width="4200.0" height="2674.0" fill="url(#background)"  />
+<text id="title" x="2100.00" y="24" >forkrun flamechart</text>
+<text id="subtitle" x="2100.00" y="48" >combined hash algs | dynamic coproc count</text>
+<text id="details" x="10.00" y="2657" > </text>
+<text id="unzoom" x="10.00" y="24" class="hide">Reset Zoom</text>
+<text id="search" x="4090.00" y="24" >Search</text>
+<text id="ignorecase" x="4174.00" y="24" >ic</text>
+<text id="matched" x="4090.00" y="2657" > </text>
+<g id="frames">
+<g >
+<title>execute_command (7,320,320,919 samples, 1.15%)</title><rect x="307.9" y="1261" width="48.0" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="310.95" y="1273.5" >exec..</text>
+</g>
+<g >
+<title>execute_command (5,904,507,473 samples, 0.92%)</title><rect x="356.1" y="1181" width="38.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="359.07" y="1193.5" >exe..</text>
+</g>
+<g >
+<title>__x64_sys_openat (2,688,962,721 samples, 0.42%)</title><rect x="2023.1" y="2341" width="17.6" height="19.0" fill="rgb(208,15,3)" rx="2" ry="2" />
+<text  x="2026.14" y="2353.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (483,985,097 samples, 0.08%)</title><rect x="276.9" y="2321" width="3.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="279.92" y="2333.5" ></text>
+</g>
+<g >
+<title>[bash] (1,514,691,150 samples, 0.24%)</title><rect x="339.4" y="701" width="9.9" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="342.40" y="713.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (62,850,774,146 samples, 9.84%)</title><rect x="395.1" y="1861" width="411.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="398.06" y="1873.5" >execute_command_internal</text>
+</g>
+<g >
+<title>execute_command (713,462,810 samples, 0.11%)</title><rect x="280.1" y="901" width="4.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="283.11" y="913.5" ></text>
+</g>
+<g >
+<title>shmem_file_read_iter (4,495,655,516 samples, 0.70%)</title><rect x="3956.8" y="2361" width="29.4" height="19.0" fill="rgb(238,152,36)" rx="2" ry="2" />
+<text  x="3959.77" y="2373.5" >sh..</text>
+</g>
+<g >
+<title>execute_command_internal (1,261,220,789 samples, 0.20%)</title><rect x="860.3" y="841" width="8.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.32" y="853.5" ></text>
+</g>
+<g >
+<title>filemap_get_entry (226,854,699 samples, 0.04%)</title><rect x="1523.3" y="2301" width="1.5" height="19.0" fill="rgb(253,222,53)" rx="2" ry="2" />
+<text  x="1526.29" y="2313.5" ></text>
+</g>
+<g >
+<title>[bash] (299,426,565 samples, 0.05%)</title><rect x="337.0" y="561" width="1.9" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="339.96" y="573.5" ></text>
+</g>
+<g >
+<title>[bash] (716,095,135 samples, 0.11%)</title><rect x="852.2" y="401" width="4.7" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="855.18" y="413.5" ></text>
+</g>
+<g >
+<title>execute_command (891,895,571 samples, 0.14%)</title><rect x="851.1" y="1941" width="5.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="854.08" y="1953.5" ></text>
+</g>
+<g >
+<title>execute_command (323,026,366 samples, 0.05%)</title><rect x="868.7" y="1321" width="2.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="871.70" y="1333.5" ></text>
+</g>
+<g >
+<title>execute_command (5,738,175,803 samples, 0.90%)</title><rect x="356.8" y="861" width="37.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="359.81" y="873.5" >exe..</text>
+</g>
+<g >
+<title>execute_command_internal (1,147,316,451 samples, 0.18%)</title><rect x="827.6" y="1301" width="7.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.59" y="1313.5" ></text>
+</g>
+<g >
+<title>copy_page_to_iter (1,960,259,961 samples, 0.31%)</title><rect x="3349.8" y="2341" width="12.8" height="19.0" fill="rgb(216,52,12)" rx="2" ry="2" />
+<text  x="3352.76" y="2353.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (215,132,849 samples, 0.03%)</title><rect x="842.8" y="1481" width="1.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="845.81" y="1493.5" ></text>
+</g>
+<g >
+<title>execute_command (713,521,499 samples, 0.11%)</title><rect x="296.5" y="1541" width="4.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="299.45" y="1553.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (713,521,499 samples, 0.11%)</title><rect x="296.5" y="2241" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.45" y="2253.5" ></text>
+</g>
+<g >
+<title>execute_command (169,623,683 samples, 0.03%)</title><rect x="871.9" y="761" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="874.90" y="773.5" ></text>
+</g>
+<g >
+<title>[bash] (432,000,163 samples, 0.07%)</title><rect x="791.8" y="1321" width="2.8" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="794.81" y="1333.5" ></text>
+</g>
+<g >
+<title>expand_downwards (163,552,422 samples, 0.03%)</title><rect x="667.4" y="1201" width="1.1" height="19.0" fill="rgb(209,18,4)" rx="2" ry="2" />
+<text  x="670.45" y="1213.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (13,303,298,561 samples, 2.08%)</title><rect x="307.9" y="1521" width="87.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="310.94" y="1533.5" >execute_co..</text>
+</g>
+<g >
+<title>execute_command_internal (1,256,343,819 samples, 0.20%)</title><rect x="860.3" y="481" width="8.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.32" y="493.5" ></text>
+</g>
+<g >
+<title>execute_command (212,197,076 samples, 0.03%)</title><rect x="895.4" y="321" width="1.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="898.39" y="333.5" ></text>
+</g>
+<g >
+<title>__printf_chk (2,595,504,323 samples, 0.41%)</title><rect x="2621.3" y="2501" width="17.0" height="19.0" fill="rgb(212,36,8)" rx="2" ry="2" />
+<text  x="2624.30" y="2513.5" ></text>
+</g>
+<g >
+<title>__libc_start_call_main (12,982,226,773 samples, 2.03%)</title><rect x="2123.3" y="2541" width="85.0" height="19.0" fill="rgb(210,26,6)" rx="2" ry="2" />
+<text  x="2126.33" y="2553.5" >__libc_sta..</text>
+</g>
+<g >
+<title>execute_command_internal (166,042,857 samples, 0.03%)</title><rect x="836.5" y="1661" width="1.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="839.46" y="1673.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (215,748,926 samples, 0.03%)</title><rect x="842.8" y="1661" width="1.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="845.80" y="1673.5" ></text>
+</g>
+<g >
+<title>execute_command (483,985,097 samples, 0.08%)</title><rect x="276.9" y="2301" width="3.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="279.92" y="2313.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,147,316,451 samples, 0.18%)</title><rect x="827.6" y="1141" width="7.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.59" y="1153.5" ></text>
+</g>
+<g >
+<title>posix_fadvise (696,654,944 samples, 0.11%)</title><rect x="2638.5" y="2501" width="4.6" height="19.0" fill="rgb(245,186,44)" rx="2" ry="2" />
+<text  x="2641.54" y="2513.5" ></text>
+</g>
+<g >
+<title>execute_command (179,777,548 samples, 0.03%)</title><rect x="878.5" y="1361" width="1.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="881.48" y="1373.5" ></text>
+</g>
+<g >
+<title>syscall_return_via_sysret (218,970,591 samples, 0.03%)</title><rect x="3334.7" y="2381" width="1.4" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="3337.66" y="2393.5" ></text>
+</g>
+<g >
+<title>unmap_vmas (481,913,882 samples, 0.08%)</title><rect x="292.8" y="2381" width="3.2" height="19.0" fill="rgb(249,206,49)" rx="2" ry="2" />
+<text  x="295.80" y="2393.5" ></text>
+</g>
+<g >
+<title>execute_command (1,146,830,397 samples, 0.18%)</title><rect x="827.6" y="1001" width="7.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="830.59" y="1013.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (596,118,643 samples, 0.09%)</title><rect x="891.4" y="1321" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.42" y="1333.5" ></text>
+</g>
+<g >
+<title>[bash] (429,175,385 samples, 0.07%)</title><rect x="791.8" y="1301" width="2.8" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="794.82" y="1313.5" ></text>
+</g>
+<g >
+<title>do_wp_page (1,357,537,101 samples, 0.21%)</title><rect x="765.8" y="1201" width="8.9" height="19.0" fill="rgb(219,66,15)" rx="2" ry="2" />
+<text  x="768.85" y="1213.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (554,006,342 samples, 0.09%)</title><rect x="273.3" y="2281" width="3.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="276.29" y="2293.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (578,444,541 samples, 0.09%)</title><rect x="891.4" y="381" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.42" y="393.5" ></text>
+</g>
+<g >
+<title>execute_command (685,976,378 samples, 0.11%)</title><rect x="268.8" y="881" width="4.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="271.79" y="893.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (849,509,116 samples, 0.13%)</title><rect x="895.3" y="2521" width="5.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.35" y="2533.5" ></text>
+</g>
+<g >
+<title>__libc_start_call_main (23,218,195,870 samples, 3.64%)</title><rect x="4033.5" y="2541" width="152.0" height="19.0" fill="rgb(210,26,6)" rx="2" ry="2" />
+<text  x="4036.49" y="2553.5" >__libc_start_call_m..</text>
+</g>
+<g >
+<title>execute_command (483,985,097 samples, 0.08%)</title><rect x="276.9" y="1621" width="3.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="279.92" y="1633.5" ></text>
+</g>
+<g >
+<title>execute_command (1,900,834,313 samples, 0.30%)</title><rect x="835.1" y="2141" width="12.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="838.10" y="2153.5" ></text>
+</g>
+<g >
+<title>[bash] (156,818,888 samples, 0.02%)</title><rect x="870.9" y="461" width="1.0" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="873.86" y="473.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (195,916,485 samples, 0.03%)</title><rect x="835.2" y="1441" width="1.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="838.17" y="1453.5" ></text>
+</g>
+<g >
+<title>execute_command (516,725,798 samples, 0.08%)</title><rect x="856.9" y="1721" width="3.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="859.92" y="1733.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (480,699,859 samples, 0.08%)</title><rect x="276.9" y="601" width="3.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="279.94" y="613.5" ></text>
+</g>
+<g >
+<title>execute_command (483,985,097 samples, 0.08%)</title><rect x="276.9" y="1541" width="3.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="279.92" y="1553.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (840,181,758 samples, 0.13%)</title><rect x="895.4" y="581" width="5.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.39" y="593.5" ></text>
+</g>
+<g >
+<title>__printf_buffer_write (247,827,157 samples, 0.04%)</title><rect x="250.5" y="2441" width="1.6" height="19.0" fill="rgb(220,73,17)" rx="2" ry="2" />
+<text  x="253.51" y="2453.5" ></text>
+</g>
+<g >
+<title>execute_command (595,672,870 samples, 0.09%)</title><rect x="891.4" y="881" width="3.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="894.42" y="893.5" ></text>
+</g>
+<g >
+<title>execute_command (578,068,287 samples, 0.09%)</title><rect x="884.6" y="2061" width="3.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="887.62" y="2073.5" ></text>
+</g>
+<g >
+<title>execute_command (891,895,571 samples, 0.14%)</title><rect x="851.1" y="1541" width="5.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="854.08" y="1553.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (713,521,499 samples, 0.11%)</title><rect x="296.5" y="1401" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.45" y="1413.5" ></text>
+</g>
+<g >
+<title>__printf_buffer_flush_to_file (229,735,823 samples, 0.04%)</title><rect x="2106.6" y="2441" width="1.5" height="19.0" fill="rgb(247,197,47)" rx="2" ry="2" />
+<text  x="2109.63" y="2453.5" ></text>
+</g>
+<g >
+<title>_dl_relocate_object (309,649,683 samples, 0.05%)</title><rect x="3306.9" y="2501" width="2.0" height="19.0" fill="rgb(231,120,28)" rx="2" ry="2" />
+<text  x="3309.85" y="2513.5" ></text>
+</g>
+<g >
+<title>execute_command (713,521,499 samples, 0.11%)</title><rect x="296.5" y="2481" width="4.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="299.45" y="2493.5" ></text>
+</g>
+<g >
+<title>__GI___libc_open (4,387,408,880 samples, 0.69%)</title><rect x="4120.0" y="2421" width="28.7" height="19.0" fill="rgb(249,202,48)" rx="2" ry="2" />
+<text  x="4123.03" y="2433.5" >__..</text>
+</g>
+<g >
+<title>execute_command_internal (1,381,857,513 samples, 0.22%)</title><rect x="868.6" y="1941" width="9.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="871.57" y="1953.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (481,813,209 samples, 0.08%)</title><rect x="276.9" y="1361" width="3.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="279.93" y="1373.5" ></text>
+</g>
+<g >
+<title>[sha224sum] (12,905,077,170 samples, 2.02%)</title><rect x="2123.4" y="2521" width="84.5" height="19.0" fill="rgb(248,201,48)" rx="2" ry="2" />
+<text  x="2126.41" y="2533.5" >[sha224sum]</text>
+</g>
+<g >
+<title>execute_command (163,954,022 samples, 0.03%)</title><rect x="870.8" y="921" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="873.82" y="933.5" ></text>
+</g>
+<g >
+<title>path_lookupat (1,905,363,438 samples, 0.30%)</title><rect x="4165.9" y="2361" width="12.5" height="19.0" fill="rgb(206,8,1)" rx="2" ry="2" />
+<text  x="4168.93" y="2373.5" ></text>
+</g>
+<g >
+<title>llseek@GLIBC_2.2.5 (638,227,578 samples, 0.10%)</title><rect x="3379.0" y="2481" width="4.2" height="19.0" fill="rgb(239,156,37)" rx="2" ry="2" />
+<text  x="3382.03" y="2493.5" ></text>
+</g>
+<g >
+<title>do_filp_open (2,929,796,453 samples, 0.46%)</title><rect x="4122.4" y="2321" width="19.1" height="19.0" fill="rgb(217,58,13)" rx="2" ry="2" />
+<text  x="4125.35" y="2333.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (215,132,849 samples, 0.03%)</title><rect x="842.8" y="1321" width="1.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="845.81" y="1333.5" ></text>
+</g>
+<g >
+<title>execute_command (1,146,830,397 samples, 0.18%)</title><rect x="827.6" y="761" width="7.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="830.59" y="773.5" ></text>
+</g>
+<g >
+<title>__d_lookup_rcu (207,102,981 samples, 0.03%)</title><rect x="4132.8" y="2221" width="1.4" height="19.0" fill="rgb(235,139,33)" rx="2" ry="2" />
+<text  x="4135.82" y="2233.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (13,257,342,939 samples, 2.08%)</title><rect x="307.9" y="1361" width="86.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="310.94" y="1373.5" >execute_co..</text>
+</g>
+<g >
+<title>execute_command_internal (251,238,033 samples, 0.04%)</title><rect x="858.5" y="261" width="1.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="861.52" y="273.5" ></text>
+</g>
+<g >
+<title>[md5sum] (8,715,146,739 samples, 1.36%)</title><rect x="1590.1" y="2501" width="57.0" height="19.0" fill="rgb(229,113,27)" rx="2" ry="2" />
+<text  x="1593.05" y="2513.5" >[md5sum]</text>
+</g>
+<g >
+<title>__alloc_pages_noprof (301,637,758 samples, 0.05%)</title><rect x="772.6" y="1121" width="2.0" height="19.0" fill="rgb(212,34,8)" rx="2" ry="2" />
+<text  x="775.62" y="1133.5" ></text>
+</g>
+<g >
+<title>execute_command (13,303,442,796 samples, 2.08%)</title><rect x="307.9" y="1541" width="87.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="310.94" y="1553.5" >execute_co..</text>
+</g>
+<g >
+<title>dispose_command (278,638,452 samples, 0.04%)</title><rect x="840.5" y="261" width="1.8" height="19.0" fill="rgb(248,201,48)" rx="2" ry="2" />
+<text  x="843.48" y="273.5" ></text>
+</g>
+<g >
+<title>rep_movs_alternative (1,844,698,607 samples, 0.29%)</title><rect x="3350.5" y="2301" width="12.1" height="19.0" fill="rgb(211,31,7)" rx="2" ry="2" />
+<text  x="3353.51" y="2313.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (891,895,571 samples, 0.14%)</title><rect x="851.1" y="1841" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.08" y="1853.5" ></text>
+</g>
+<g >
+<title>[bash] (794,949,141 samples, 0.12%)</title><rect x="829.8" y="301" width="5.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="832.82" y="313.5" ></text>
+</g>
+<g >
+<title>__d_lookup_rcu (205,576,360 samples, 0.03%)</title><rect x="3322.2" y="2201" width="1.3" height="19.0" fill="rgb(235,139,33)" rx="2" ry="2" />
+<text  x="3325.20" y="2213.5" ></text>
+</g>
+<g >
+<title>execute_command (483,985,097 samples, 0.08%)</title><rect x="276.9" y="2261" width="3.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="279.92" y="2273.5" ></text>
+</g>
+<g >
+<title>execute_command (513,428,353 samples, 0.08%)</title><rect x="856.9" y="801" width="3.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="859.94" y="813.5" ></text>
+</g>
+<g >
+<title>inode_permission (164,598,968 samples, 0.03%)</title><rect x="3910.9" y="2261" width="1.1" height="19.0" fill="rgb(215,48,11)" rx="2" ry="2" />
+<text  x="3913.92" y="2273.5" ></text>
+</g>
+<g >
+<title>printf_builtin (223,847,879 samples, 0.04%)</title><rect x="798.0" y="1401" width="1.4" height="19.0" fill="rgb(239,159,38)" rx="2" ry="2" />
+<text  x="800.97" y="1413.5" ></text>
+</g>
+<g >
+<title>execute_command (481,191,724 samples, 0.08%)</title><rect x="276.9" y="1101" width="3.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="279.94" y="1113.5" ></text>
+</g>
+<g >
+<title>ksys_read (265,280,234 samples, 0.04%)</title><rect x="498.9" y="1001" width="1.8" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="501.92" y="1013.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (573,854,343 samples, 0.09%)</title><rect x="884.6" y="561" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="887.64" y="573.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (432,872,015 samples, 0.07%)</title><rect x="888.6" y="1021" width="2.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="891.57" y="1033.5" ></text>
+</g>
+<g >
+<title>[bash] (189,994,420 samples, 0.03%)</title><rect x="837.6" y="521" width="1.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="840.56" y="533.5" ></text>
+</g>
+<g >
+<title>new_do_write (652,142,764 samples, 0.10%)</title><rect x="2616.4" y="2461" width="4.3" height="19.0" fill="rgb(206,5,1)" rx="2" ry="2" />
+<text  x="2619.45" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (320,440,447 samples, 0.05%)</title><rect x="868.7" y="581" width="2.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="871.70" y="593.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,263,560,140 samples, 0.20%)</title><rect x="860.3" y="1561" width="8.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.30" y="1573.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (866,614,713 samples, 0.14%)</title><rect x="301.1" y="1381" width="5.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.12" y="1393.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (713,462,810 samples, 0.11%)</title><rect x="280.1" y="761" width="4.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.11" y="773.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,646,888,065 samples, 0.26%)</title><rect x="316.3" y="641" width="10.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="319.30" y="653.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (13,302,820,220 samples, 2.08%)</title><rect x="307.9" y="1481" width="87.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="310.94" y="1493.5" >execute_co..</text>
+</g>
+<g >
+<title>execute_command (866,614,713 samples, 0.14%)</title><rect x="301.1" y="1641" width="5.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="304.12" y="1653.5" ></text>
+</g>
+<g >
+<title>execute_command (483,985,097 samples, 0.08%)</title><rect x="276.9" y="1861" width="3.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="279.92" y="1873.5" ></text>
+</g>
+<g >
+<title>bpf_prog_e8932b6bae2b9745_restrict_filesystems (153,171,609 samples, 0.02%)</title><rect x="3928.0" y="2181" width="1.0" height="19.0" fill="rgb(225,96,23)" rx="2" ry="2" />
+<text  x="3931.04" y="2193.5" ></text>
+</g>
+<g >
+<title>handle_mm_fault (1,523,949,770 samples, 0.24%)</title><rect x="765.2" y="1241" width="9.9" height="19.0" fill="rgb(240,165,39)" rx="2" ry="2" />
+<text  x="768.15" y="1253.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (348,900,254 samples, 0.05%)</title><rect x="886.0" y="321" width="2.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="889.05" y="333.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (76,226,519,498 samples, 11.94%)</title><rect x="307.9" y="2241" width="499.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="310.93" y="2253.5" >execute_command_internal</text>
+</g>
+<g >
+<title>execute_command_internal (713,521,499 samples, 0.11%)</title><rect x="296.5" y="1361" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.45" y="1373.5" ></text>
+</g>
+<g >
+<title>__libc_start_call_main (17,640,028,547 samples, 2.76%)</title><rect x="3310.0" y="2541" width="115.5" height="19.0" fill="rgb(210,26,6)" rx="2" ry="2" />
+<text  x="3313.02" y="2553.5" >__libc_start_c..</text>
+</g>
+<g >
+<title>__d_lookup_rcu (220,141,976 samples, 0.03%)</title><rect x="3323.6" y="2241" width="1.4" height="19.0" fill="rgb(235,139,33)" rx="2" ry="2" />
+<text  x="3326.56" y="2253.5" ></text>
+</g>
+<g >
+<title>execute_command (554,006,342 samples, 0.09%)</title><rect x="273.3" y="2221" width="3.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="276.29" y="2233.5" ></text>
+</g>
+<g >
+<title>folio_alloc_mpol_noprof (320,585,357 samples, 0.05%)</title><rect x="772.6" y="1161" width="2.1" height="19.0" fill="rgb(225,94,22)" rx="2" ry="2" />
+<text  x="775.55" y="1173.5" ></text>
+</g>
+<g >
+<title>make_child (499,599,197 samples, 0.08%)</title><rect x="862.9" y="221" width="3.3" height="19.0" fill="rgb(242,170,40)" rx="2" ry="2" />
+<text  x="865.89" y="233.5" ></text>
+</g>
+<g >
+<title>parse_and_execute (188,519,652 samples, 0.03%)</title><rect x="271.7" y="281" width="1.3" height="19.0" fill="rgb(243,178,42)" rx="2" ry="2" />
+<text  x="274.74" y="293.5" ></text>
+</g>
+<g >
+<title>[bash] (159,710,185 samples, 0.03%)</title><rect x="875.9" y="1681" width="1.1" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="878.92" y="1693.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (575,800,354 samples, 0.09%)</title><rect x="884.6" y="1481" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="887.64" y="1493.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (849,509,116 samples, 0.13%)</title><rect x="895.3" y="1901" width="5.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.35" y="1913.5" ></text>
+</g>
+<g >
+<title>vfs_open (665,249,034 samples, 0.10%)</title><rect x="4137.2" y="2281" width="4.3" height="19.0" fill="rgb(238,154,37)" rx="2" ry="2" />
+<text  x="4140.18" y="2293.5" ></text>
+</g>
+<g >
+<title>[bash] (383,377,679 samples, 0.06%)</title><rect x="277.5" y="401" width="2.5" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="280.53" y="413.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,150,422,968 samples, 0.18%)</title><rect x="827.6" y="2461" width="7.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.57" y="2473.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (276,697,455 samples, 0.04%)</title><rect x="900.9" y="2481" width="1.9" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="903.94" y="2493.5" ></text>
+</g>
+<g >
+<title>memset_orig (179,645,241 samples, 0.03%)</title><rect x="2560.2" y="2261" width="1.2" height="19.0" fill="rgb(253,224,53)" rx="2" ry="2" />
+<text  x="2563.18" y="2273.5" ></text>
+</g>
+<g >
+<title>execute_command (195,916,485 samples, 0.03%)</title><rect x="835.2" y="1341" width="1.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="838.17" y="1353.5" ></text>
+</g>
+<g >
+<title>execute_command (1,887,176,866 samples, 0.30%)</title><rect x="868.6" y="2121" width="12.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="871.57" y="2133.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (615,948,466 samples, 0.10%)</title><rect x="388.7" y="501" width="4.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="391.67" y="513.5" ></text>
+</g>
+<g >
+<title>execute_command (554,006,342 samples, 0.09%)</title><rect x="273.3" y="2341" width="3.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="276.29" y="2353.5" ></text>
+</g>
+<g >
+<title>[bash] (762,678,240 samples, 0.12%)</title><rect x="310.2" y="561" width="5.0" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="313.22" y="573.5" ></text>
+</g>
+<g >
+<title>vma_alloc_folio_noprof (337,365,193 samples, 0.05%)</title><rect x="772.5" y="1181" width="2.2" height="19.0" fill="rgb(224,91,21)" rx="2" ry="2" />
+<text  x="775.51" y="1193.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (516,725,798 samples, 0.08%)</title><rect x="856.9" y="2261" width="3.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="859.92" y="2273.5" ></text>
+</g>
+<g >
+<title>_dl_start (397,105,035 samples, 0.06%)</title><rect x="4186.5" y="2561" width="2.6" height="19.0" fill="rgb(237,151,36)" rx="2" ry="2" />
+<text  x="4189.47" y="2573.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (686,486,049 samples, 0.11%)</title><rect x="268.8" y="1241" width="4.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="271.78" y="1253.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (2,934,255,296 samples, 0.46%)</title><rect x="2543.1" y="2381" width="19.2" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="2546.13" y="2393.5" ></text>
+</g>
+<g >
+<title>_int_malloc (347,195,478 samples, 0.05%)</title><rect x="640.3" y="1261" width="2.3" height="19.0" fill="rgb(215,47,11)" rx="2" ry="2" />
+<text  x="643.31" y="1273.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (219,908,120 samples, 0.03%)</title><rect x="362.2" y="241" width="1.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="365.21" y="253.5" ></text>
+</g>
+<g >
+<title>strncpy_from_user (163,188,081 samples, 0.03%)</title><rect x="3931.9" y="2301" width="1.1" height="19.0" fill="rgb(254,228,54)" rx="2" ry="2" />
+<text  x="3934.94" y="2313.5" ></text>
+</g>
+<g >
+<title>zread (251,019,128 samples, 0.04%)</title><rect x="312.9" y="501" width="1.7" height="19.0" fill="rgb(213,41,9)" rx="2" ry="2" />
+<text  x="315.95" y="513.5" ></text>
+</g>
+<g >
+<title>vfs_read (4,794,897,302 samples, 0.75%)</title><rect x="3954.8" y="2381" width="31.4" height="19.0" fill="rgb(230,118,28)" rx="2" ry="2" />
+<text  x="3957.81" y="2393.5" >vf..</text>
+</g>
+<g >
+<title>parse_and_execute (354,507,027 samples, 0.06%)</title><rect x="886.0" y="341" width="2.4" height="19.0" fill="rgb(243,178,42)" rx="2" ry="2" />
+<text  x="889.04" y="353.5" ></text>
+</g>
+<g >
+<title>[bash] (190,014,181 samples, 0.03%)</title><rect x="837.6" y="541" width="1.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="840.56" y="553.5" ></text>
+</g>
+<g >
+<title>syscall_return_via_sysret (299,717,050 samples, 0.05%)</title><rect x="1573.8" y="2481" width="1.9" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="1576.77" y="2493.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,150,422,968 samples, 0.18%)</title><rect x="827.6" y="1581" width="7.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.57" y="1593.5" ></text>
+</g>
+<g >
+<title>execute_command (483,985,097 samples, 0.08%)</title><rect x="276.9" y="2181" width="3.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="279.92" y="2193.5" ></text>
+</g>
+<g >
+<title>execute_command (1,957,552,560 samples, 0.31%)</title><rect x="868.6" y="2201" width="12.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="871.57" y="2213.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (164,731,865 samples, 0.03%)</title><rect x="836.5" y="961" width="1.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="839.46" y="973.5" ></text>
+</g>
+<g >
+<title>__fput (270,299,710 samples, 0.04%)</title><rect x="4152.3" y="2381" width="1.7" height="19.0" fill="rgb(205,0,0)" rx="2" ry="2" />
+<text  x="4155.28" y="2393.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,887,176,866 samples, 0.30%)</title><rect x="868.6" y="2101" width="12.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="871.57" y="2113.5" ></text>
+</g>
+<g >
+<title>link_path_walk.part.0.constprop.0 (1,020,546,417 samples, 0.16%)</title><rect x="3316.9" y="2261" width="6.6" height="19.0" fill="rgb(254,229,54)" rx="2" ry="2" />
+<text  x="3319.86" y="2273.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (688,777,208 samples, 0.11%)</title><rect x="268.8" y="1981" width="4.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="271.77" y="1993.5" ></text>
+</g>
+<g >
+<title>do_sys_openat2 (4,163,103,994 samples, 0.65%)</title><rect x="1470.4" y="2321" width="27.2" height="19.0" fill="rgb(209,21,5)" rx="2" ry="2" />
+<text  x="1473.37" y="2333.5" >d..</text>
+</g>
+<g >
+<title>dl_main (534,946,061 samples, 0.08%)</title><rect x="2535.0" y="2521" width="3.5" height="19.0" fill="rgb(236,145,34)" rx="2" ry="2" />
+<text  x="2537.99" y="2533.5" ></text>
+</g>
+<g >
+<title>execute_command (195,267,188 samples, 0.03%)</title><rect x="835.2" y="1101" width="1.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="838.18" y="1113.5" ></text>
+</g>
+<g >
+<title>syscall_return_via_sysret (158,299,588 samples, 0.02%)</title><rect x="235.1" y="2421" width="1.1" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="238.14" y="2433.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (688,777,208 samples, 0.11%)</title><rect x="268.8" y="1821" width="4.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="271.77" y="1833.5" ></text>
+</g>
+<g >
+<title>execute_command (308,734,873 samples, 0.05%)</title><rect x="401.4" y="941" width="2.0" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="404.39" y="953.5" ></text>
+</g>
+<g >
+<title>security_file_open (234,681,628 samples, 0.04%)</title><rect x="2558.2" y="2221" width="1.5" height="19.0" fill="rgb(215,47,11)" rx="2" ry="2" />
+<text  x="2561.16" y="2233.5" ></text>
+</g>
+<g >
+<title>execute_command (573,854,343 samples, 0.09%)</title><rect x="884.6" y="581" width="3.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="887.64" y="593.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (159,710,185 samples, 0.03%)</title><rect x="875.9" y="1841" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="878.92" y="1853.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,392,938,192 samples, 0.22%)</title><rect x="835.1" y="1921" width="9.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="838.10" y="1933.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (713,521,499 samples, 0.11%)</title><rect x="296.5" y="1561" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.45" y="1573.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (354,998,378 samples, 0.06%)</title><rect x="840.5" y="1501" width="2.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="843.48" y="1513.5" ></text>
+</g>
+<g >
+<title>copy_page_to_iter (2,298,793,607 samples, 0.36%)</title><rect x="2578.8" y="2341" width="15.1" height="19.0" fill="rgb(216,52,12)" rx="2" ry="2" />
+<text  x="2581.85" y="2353.5" ></text>
+</g>
+<g >
+<title>dispose_command (278,788,607 samples, 0.04%)</title><rect x="840.5" y="521" width="1.8" height="19.0" fill="rgb(248,201,48)" rx="2" ry="2" />
+<text  x="843.48" y="533.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (163,385,330 samples, 0.03%)</title><rect x="870.8" y="621" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="873.82" y="633.5" ></text>
+</g>
+<g >
+<title>execute_command (713,521,499 samples, 0.11%)</title><rect x="296.5" y="2261" width="4.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="299.45" y="2273.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (319,836,513 samples, 0.05%)</title><rect x="351.6" y="661" width="2.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="354.64" y="673.5" ></text>
+</g>
+<g >
+<title>[bash] (924,236,250 samples, 0.14%)</title><rect x="789.9" y="1401" width="6.0" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="792.86" y="1413.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (717,313,739 samples, 0.11%)</title><rect x="280.1" y="1961" width="4.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.09" y="1973.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (575,800,354 samples, 0.09%)</title><rect x="884.6" y="1201" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="887.64" y="1213.5" ></text>
+</g>
+<g >
+<title>__handle_mm_fault (337,083,978 samples, 0.05%)</title><rect x="454.8" y="941" width="2.2" height="19.0" fill="rgb(213,39,9)" rx="2" ry="2" />
+<text  x="457.76" y="953.5" ></text>
+</g>
+<g >
+<title>__x64_sys_openat (2,234,473,991 samples, 0.35%)</title><rect x="3024.5" y="2341" width="14.6" height="19.0" fill="rgb(208,15,3)" rx="2" ry="2" />
+<text  x="3027.45" y="2353.5" ></text>
+</g>
+<g >
+<title>dl_main (349,137,142 samples, 0.05%)</title><rect x="4028.9" y="2521" width="2.3" height="19.0" fill="rgb(236,145,34)" rx="2" ry="2" />
+<text  x="4031.92" y="2533.5" ></text>
+</g>
+<g >
+<title>execute_command (516,725,798 samples, 0.08%)</title><rect x="856.9" y="1841" width="3.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="859.92" y="1853.5" ></text>
+</g>
+<g >
+<title>execute_command (436,055,112 samples, 0.07%)</title><rect x="888.5" y="1601" width="2.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="891.55" y="1613.5" ></text>
+</g>
+<g >
+<title>__libc_start_main@@GLIBC_2.34 (866,614,713 samples, 0.14%)</title><rect x="301.1" y="2581" width="5.7" height="19.0" fill="rgb(229,113,27)" rx="2" ry="2" />
+<text  x="304.12" y="2593.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (861,612,432 samples, 0.13%)</title><rect x="301.2" y="961" width="5.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.16" y="973.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (713,462,810 samples, 0.11%)</title><rect x="280.1" y="681" width="4.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.11" y="693.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (685,976,378 samples, 0.11%)</title><rect x="268.8" y="1061" width="4.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="271.79" y="1073.5" ></text>
+</g>
+<g >
+<title>[bash] (179,777,548 samples, 0.03%)</title><rect x="878.5" y="821" width="1.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="881.48" y="833.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (821,054,811 samples, 0.13%)</title><rect x="835.1" y="1841" width="5.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="838.10" y="1853.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (7,350,331,725 samples, 1.15%)</title><rect x="307.9" y="1281" width="48.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="310.95" y="1293.5" >exec..</text>
+</g>
+<g >
+<title>execute_command_internal (1,038,049,074 samples, 0.16%)</title><rect x="273.3" y="2561" width="6.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="276.29" y="2573.5" ></text>
+</g>
+<g >
+<title>__libc_start_call_main (416,070,235 samples, 0.07%)</title><rect x="900.9" y="2541" width="2.7" height="19.0" fill="rgb(210,26,6)" rx="2" ry="2" />
+<text  x="903.92" y="2553.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (62,848,199,560 samples, 9.84%)</title><rect x="395.1" y="1821" width="411.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="398.07" y="1833.5" >execute_command_internal</text>
+</g>
+<g >
+<title>execute_command_internal (889,542,281 samples, 0.14%)</title><rect x="851.1" y="1041" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.09" y="1053.5" ></text>
+</g>
+<g >
+<title>_IO_file_xsgetn (1,067,118,134 samples, 0.17%)</title><rect x="2565.8" y="2461" width="7.0" height="19.0" fill="rgb(207,11,2)" rx="2" ry="2" />
+<text  x="2568.79" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command (578,068,287 samples, 0.09%)</title><rect x="884.6" y="1621" width="3.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="887.62" y="1633.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (705,583,873 samples, 0.11%)</title><rect x="296.5" y="1001" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.50" y="1013.5" ></text>
+</g>
+<g >
+<title>execute_command (1,150,422,968 samples, 0.18%)</title><rect x="827.6" y="1921" width="7.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="830.57" y="1933.5" ></text>
+</g>
+<g >
+<title>[bash] (348,723,339 samples, 0.05%)</title><rect x="886.0" y="301" width="2.3" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="889.05" y="313.5" ></text>
+</g>
+<g >
+<title>realloc (409,477,427 samples, 0.06%)</title><rect x="584.5" y="1301" width="2.7" height="19.0" fill="rgb(246,189,45)" rx="2" ry="2" />
+<text  x="587.52" y="1313.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (862,395,726 samples, 0.14%)</title><rect x="301.2" y="1261" width="5.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.15" y="1273.5" ></text>
+</g>
+<g >
+<title>execute_command (481,191,724 samples, 0.08%)</title><rect x="276.9" y="781" width="3.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="279.94" y="793.5" ></text>
+</g>
+<g >
+<title>copy_page_to_iter (1,977,464,224 samples, 0.31%)</title><rect x="2155.9" y="2341" width="12.9" height="19.0" fill="rgb(216,52,12)" rx="2" ry="2" />
+<text  x="2158.85" y="2353.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (516,725,798 samples, 0.08%)</title><rect x="856.9" y="1581" width="3.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="859.92" y="1593.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (483,985,097 samples, 0.08%)</title><rect x="276.9" y="1961" width="3.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="279.92" y="1973.5" ></text>
+</g>
+<g >
+<title>do_sys_openat2 (2,310,266,648 samples, 0.36%)</title><rect x="2126.7" y="2321" width="15.1" height="19.0" fill="rgb(209,21,5)" rx="2" ry="2" />
+<text  x="2129.70" y="2333.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (708,952,744 samples, 0.11%)</title><rect x="302.0" y="281" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.97" y="293.5" ></text>
+</g>
+<g >
+<title>__printf_buffer_flush_to_file (331,515,559 samples, 0.05%)</title><rect x="2633.3" y="2441" width="2.1" height="19.0" fill="rgb(247,197,47)" rx="2" ry="2" />
+<text  x="2636.28" y="2453.5" ></text>
+</g>
+<g >
+<title>execute_command (713,462,810 samples, 0.11%)</title><rect x="280.1" y="701" width="4.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="283.11" y="713.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (432,726,851 samples, 0.07%)</title><rect x="888.6" y="621" width="2.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="891.57" y="633.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (3,073,386,755 samples, 0.48%)</title><rect x="4161.3" y="2461" width="20.2" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="4164.34" y="2473.5" ></text>
+</g>
+<g >
+<title>entry_SYSRETQ_unsafe_stack (245,606,174 samples, 0.04%)</title><rect x="1561.4" y="2461" width="1.6" height="19.0" fill="rgb(213,37,8)" rx="2" ry="2" />
+<text  x="1564.43" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (2,022,660,615 samples, 0.32%)</title><rect x="868.6" y="2261" width="13.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="871.57" y="2273.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (179,777,548 samples, 0.03%)</title><rect x="878.5" y="1581" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="881.48" y="1593.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (299,120,335 samples, 0.05%)</title><rect x="3384.5" y="2421" width="1.9" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="3387.49" y="2433.5" ></text>
+</g>
+<g >
+<title>execute_command (215,132,849 samples, 0.03%)</title><rect x="842.8" y="1141" width="1.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="845.81" y="1153.5" ></text>
+</g>
+<g >
+<title>_IO_file_xsgetn (1,007,176,517 samples, 0.16%)</title><rect x="3337.6" y="2461" width="6.6" height="19.0" fill="rgb(207,11,2)" rx="2" ry="2" />
+<text  x="3340.56" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (596,118,643 samples, 0.09%)</title><rect x="891.4" y="1061" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.42" y="1073.5" ></text>
+</g>
+<g >
+<title>do_dentry_open (407,581,795 samples, 0.06%)</title><rect x="3328.1" y="2241" width="2.6" height="19.0" fill="rgb(249,205,49)" rx="2" ry="2" />
+<text  x="3331.06" y="2253.5" ></text>
+</g>
+<g >
+<title>[bash] (179,777,548 samples, 0.03%)</title><rect x="878.5" y="941" width="1.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="881.48" y="953.5" ></text>
+</g>
+<g >
+<title>__GI___fread_unlocked (4,197,741,687 samples, 0.66%)</title><rect x="1437.8" y="2441" width="27.5" height="19.0" fill="rgb(220,71,17)" rx="2" ry="2" />
+<text  x="1440.83" y="2453.5" >_..</text>
+</g>
+<g >
+<title>execute_command (220,491,022 samples, 0.03%)</title><rect x="895.4" y="361" width="1.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="898.39" y="373.5" ></text>
+</g>
+<g >
+<title>execute_command (13,306,226,362 samples, 2.08%)</title><rect x="307.9" y="1701" width="87.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="310.94" y="1713.5" >execute_co..</text>
+</g>
+<g >
+<title>execute_command_internal (713,462,810 samples, 0.11%)</title><rect x="280.1" y="921" width="4.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.11" y="933.5" ></text>
+</g>
+<g >
+<title>bash (96,659,218,911 samples, 15.14%)</title><rect x="268.2" y="2601" width="632.7" height="19.0" fill="rgb(239,157,37)" rx="2" ry="2" />
+<text  x="271.17" y="2613.5" >bash</text>
+</g>
+<g >
+<title>rep_movs_alternative (2,171,117,161 samples, 0.34%)</title><rect x="2579.7" y="2301" width="14.2" height="19.0" fill="rgb(211,31,7)" rx="2" ry="2" />
+<text  x="2582.68" y="2313.5" ></text>
+</g>
+<g >
+<title>[bash] (166,912,719 samples, 0.03%)</title><rect x="871.9" y="521" width="1.1" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="874.92" y="533.5" ></text>
+</g>
+<g >
+<title>execute_command (215,132,849 samples, 0.03%)</title><rect x="842.8" y="1341" width="1.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="845.81" y="1353.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (448,334,258 samples, 0.07%)</title><rect x="3373.6" y="2441" width="3.0" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="3376.62" y="2453.5" ></text>
+</g>
+<g >
+<title>folios_put_refs (349,275,505 samples, 0.05%)</title><rect x="290.4" y="2321" width="2.3" height="19.0" fill="rgb(211,29,7)" rx="2" ry="2" />
+<text  x="293.43" y="2333.5" ></text>
+</g>
+<g >
+<title>[bash] (2,926,932,189 samples, 0.46%)</title><rect x="363.7" y="241" width="19.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="366.71" y="253.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (320,852,930 samples, 0.05%)</title><rect x="868.7" y="701" width="2.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="871.70" y="713.5" ></text>
+</g>
+<g >
+<title>execute_command (1,150,422,968 samples, 0.18%)</title><rect x="827.6" y="1961" width="7.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="830.57" y="1973.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (512,251,839 samples, 0.08%)</title><rect x="856.9" y="661" width="3.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="859.94" y="673.5" ></text>
+</g>
+<g >
+<title>filemap_get_entry (312,858,795 samples, 0.05%)</title><rect x="2595.2" y="2321" width="2.1" height="19.0" fill="rgb(253,222,53)" rx="2" ry="2" />
+<text  x="2598.24" y="2333.5" ></text>
+</g>
+<g >
+<title>_IO_doallocbuf (1,398,560,942 samples, 0.22%)</title><rect x="4056.9" y="2421" width="9.2" height="19.0" fill="rgb(214,45,10)" rx="2" ry="2" />
+<text  x="4059.89" y="2433.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (256,869,487 samples, 0.04%)</title><rect x="853.2" y="201" width="1.7" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="856.18" y="213.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (713,521,499 samples, 0.11%)</title><rect x="296.5" y="1881" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.45" y="1893.5" ></text>
+</g>
+<g >
+<title>execute_command (513,428,353 samples, 0.08%)</title><rect x="856.9" y="841" width="3.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="859.94" y="853.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (2,232,210,552 samples, 0.35%)</title><rect x="1591.6" y="2381" width="14.6" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="1594.59" y="2393.5" ></text>
+</g>
+<g >
+<title>vfs_read (3,275,380,071 samples, 0.51%)</title><rect x="2576.3" y="2381" width="21.5" height="19.0" fill="rgb(230,118,28)" rx="2" ry="2" />
+<text  x="2579.34" y="2393.5" >v..</text>
+</g>
+<g >
+<title>execute_command_internal (171,847,094 samples, 0.03%)</title><rect x="871.9" y="1641" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="874.89" y="1653.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,693,874,404 samples, 0.27%)</title><rect x="868.6" y="2021" width="11.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="871.57" y="2033.5" ></text>
+</g>
+<g >
+<title>[bash] (179,777,548 samples, 0.03%)</title><rect x="878.5" y="1621" width="1.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="881.48" y="1633.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (550,598,300 samples, 0.09%)</title><rect x="273.3" y="1161" width="3.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="276.32" y="1173.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (705,583,873 samples, 0.11%)</title><rect x="296.5" y="1041" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.50" y="1053.5" ></text>
+</g>
+<g >
+<title>execute_command (1,250,197,920 samples, 0.20%)</title><rect x="860.3" y="421" width="8.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="863.32" y="433.5" ></text>
+</g>
+<g >
+<title>[bash] (433,500,595 samples, 0.07%)</title><rect x="888.6" y="1301" width="2.8" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="891.56" y="1313.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (3,714,430,474 samples, 0.58%)</title><rect x="860.3" y="2541" width="24.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.30" y="2553.5" >e..</text>
+</g>
+<g >
+<title>execute_command_internal (433,500,595 samples, 0.07%)</title><rect x="888.6" y="1341" width="2.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="891.56" y="1353.5" ></text>
+</g>
+<g >
+<title>do_user_addr_fault (848,955,373 samples, 0.13%)</title><rect x="734.7" y="1201" width="5.6" height="19.0" fill="rgb(235,138,33)" rx="2" ry="2" />
+<text  x="737.74" y="1213.5" ></text>
+</g>
+<g >
+<title>execute_command (480,699,859 samples, 0.08%)</title><rect x="276.9" y="661" width="3.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="279.94" y="673.5" ></text>
+</g>
+<g >
+<title>execute_command (554,006,342 samples, 0.09%)</title><rect x="273.3" y="2181" width="3.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="276.29" y="2193.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (717,313,739 samples, 0.11%)</title><rect x="280.1" y="2241" width="4.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.09" y="2253.5" ></text>
+</g>
+<g >
+<title>execute_command (169,651,850 samples, 0.03%)</title><rect x="871.9" y="881" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="874.90" y="893.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (158,744,410 samples, 0.02%)</title><rect x="875.9" y="1461" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="878.93" y="1473.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (215,748,926 samples, 0.03%)</title><rect x="842.8" y="1721" width="1.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="845.80" y="1733.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (713,521,499 samples, 0.11%)</title><rect x="296.5" y="2161" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.45" y="2173.5" ></text>
+</g>
+<g >
+<title>execute_command (861,612,432 samples, 0.13%)</title><rect x="301.2" y="841" width="5.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="304.16" y="853.5" ></text>
+</g>
+<g >
+<title>execute_command (215,748,926 samples, 0.03%)</title><rect x="842.8" y="1781" width="1.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="845.80" y="1793.5" ></text>
+</g>
+<g >
+<title>execute_command (891,895,571 samples, 0.14%)</title><rect x="851.1" y="2261" width="5.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="854.08" y="2273.5" ></text>
+</g>
+<g >
+<title>execute_command (578,068,287 samples, 0.09%)</title><rect x="884.6" y="2101" width="3.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="887.62" y="2113.5" ></text>
+</g>
+<g >
+<title>execute_command (225,755,347 samples, 0.04%)</title><rect x="362.2" y="261" width="1.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="365.18" y="273.5" ></text>
+</g>
+<g >
+<title>path_openat (253,235,456 samples, 0.04%)</title><rect x="345.5" y="521" width="1.6" height="19.0" fill="rgb(205,2,0)" rx="2" ry="2" />
+<text  x="348.46" y="533.5" ></text>
+</g>
+<g >
+<title>execute_command (595,672,870 samples, 0.09%)</title><rect x="891.4" y="681" width="3.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="894.42" y="693.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (849,509,116 samples, 0.13%)</title><rect x="895.3" y="2381" width="5.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.35" y="2393.5" ></text>
+</g>
+<g >
+<title>shmem_file_read_iter (2,633,968,083 samples, 0.41%)</title><rect x="3348.7" y="2361" width="17.2" height="19.0" fill="rgb(238,152,36)" rx="2" ry="2" />
+<text  x="3351.70" y="2373.5" ></text>
+</g>
+<g >
+<title>[unknown] (503,654,834 samples, 0.08%)</title><rect x="284.8" y="2581" width="3.3" height="19.0" fill="rgb(210,24,5)" rx="2" ry="2" />
+<text  x="287.80" y="2593.5" ></text>
+</g>
+<g >
+<title>execute_command (193,994,695 samples, 0.03%)</title><rect x="835.2" y="741" width="1.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="838.18" y="753.5" ></text>
+</g>
+<g >
+<title>vfs_read (4,854,920,548 samples, 0.76%)</title><rect x="4073.9" y="2361" width="31.8" height="19.0" fill="rgb(230,118,28)" rx="2" ry="2" />
+<text  x="4076.89" y="2373.5" >vf..</text>
+</g>
+<g >
+<title>__fput (288,015,312 samples, 0.05%)</title><rect x="1551.3" y="2381" width="1.9" height="19.0" fill="rgb(205,0,0)" rx="2" ry="2" />
+<text  x="1554.26" y="2393.5" ></text>
+</g>
+<g >
+<title>__printf_buffer (1,739,549,754 samples, 0.27%)</title><rect x="240.9" y="2461" width="11.4" height="19.0" fill="rgb(219,68,16)" rx="2" ry="2" />
+<text  x="243.89" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command (322,256,264 samples, 0.05%)</title><rect x="868.7" y="921" width="2.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="871.70" y="933.5" ></text>
+</g>
+<g >
+<title>parse_and_execute (188,398,812 samples, 0.03%)</title><rect x="837.6" y="501" width="1.2" height="19.0" fill="rgb(243,178,42)" rx="2" ry="2" />
+<text  x="840.57" y="513.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (433,500,595 samples, 0.07%)</title><rect x="888.6" y="1381" width="2.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="891.56" y="1393.5" ></text>
+</g>
+<g >
+<title>execute_command (474,319,738 samples, 0.07%)</title><rect x="276.9" y="541" width="3.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="279.94" y="553.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (215,748,926 samples, 0.03%)</title><rect x="842.8" y="1641" width="1.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="845.80" y="1653.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (891,984,310 samples, 0.14%)</title><rect x="851.1" y="2501" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.08" y="2513.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (595,672,870 samples, 0.09%)</title><rect x="891.4" y="661" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.42" y="673.5" ></text>
+</g>
+<g >
+<title>_IO_file_open (3,260,124,856 samples, 0.51%)</title><rect x="2022.0" y="2421" width="21.4" height="19.0" fill="rgb(249,205,49)" rx="2" ry="2" />
+<text  x="2025.05" y="2433.5" >_..</text>
+</g>
+<g >
+<title>[bash] (976,095,848 samples, 0.15%)</title><rect x="862.0" y="261" width="6.4" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="864.98" y="273.5" ></text>
+</g>
+<g >
+<title>__GI___fstatat64 (196,266,928 samples, 0.03%)</title><rect x="407.7" y="1021" width="1.3" height="19.0" fill="rgb(227,101,24)" rx="2" ry="2" />
+<text  x="410.70" y="1033.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (432,872,015 samples, 0.07%)</title><rect x="888.6" y="781" width="2.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="891.57" y="793.5" ></text>
+</g>
+<g >
+<title>execute_command (866,614,713 samples, 0.14%)</title><rect x="301.1" y="2001" width="5.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="304.12" y="2013.5" ></text>
+</g>
+<g >
+<title>execute_command (554,006,342 samples, 0.09%)</title><rect x="273.3" y="2421" width="3.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="276.29" y="2433.5" ></text>
+</g>
+<g >
+<title>execute_command (195,916,485 samples, 0.03%)</title><rect x="835.2" y="1301" width="1.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="838.17" y="1313.5" ></text>
+</g>
+<g >
+<title>cfree@GLIBC_2.2.5 (3,882,949,673 samples, 0.61%)</title><rect x="757.0" y="1341" width="25.5" height="19.0" fill="rgb(233,131,31)" rx="2" ry="2" />
+<text  x="760.04" y="1353.5" >c..</text>
+</g>
+<g >
+<title>execute_command_internal (889,542,281 samples, 0.14%)</title><rect x="851.1" y="1001" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.09" y="1013.5" ></text>
+</g>
+<g >
+<title>entry_SYSRETQ_unsafe_stack (319,417,975 samples, 0.05%)</title><rect x="3066.2" y="2441" width="2.1" height="19.0" fill="rgb(213,37,8)" rx="2" ry="2" />
+<text  x="3069.22" y="2453.5" ></text>
+</g>
+<g >
+<title>security_inode_permission (326,020,274 samples, 0.05%)</title><rect x="1595.3" y="2241" width="2.2" height="19.0" fill="rgb(215,47,11)" rx="2" ry="2" />
+<text  x="1598.35" y="2253.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (2,639,689,767 samples, 0.41%)</title><rect x="1508.1" y="2421" width="17.3" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="1511.10" y="2433.5" ></text>
+</g>
+<g >
+<title>dl_main (673,688,962 samples, 0.11%)</title><rect x="3681.6" y="2521" width="4.4" height="19.0" fill="rgb(236,145,34)" rx="2" ry="2" />
+<text  x="3684.63" y="2533.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (578,068,287 samples, 0.09%)</title><rect x="884.6" y="2161" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="887.62" y="2173.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (284,722,941 samples, 0.04%)</title><rect x="2179.2" y="2421" width="1.9" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="2182.23" y="2433.5" ></text>
+</g>
+<g >
+<title>execute_command (513,954,307 samples, 0.08%)</title><rect x="856.9" y="1281" width="3.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="859.94" y="1293.5" ></text>
+</g>
+<g >
+<title>_IO_file_xsputn@@GLIBC_2.2.5 (233,472,527 samples, 0.04%)</title><rect x="254.4" y="2421" width="1.5" height="19.0" fill="rgb(242,171,41)" rx="2" ry="2" />
+<text  x="257.39" y="2433.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (276,401,919 samples, 0.04%)</title><rect x="900.9" y="2461" width="1.9" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="903.94" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (713,521,499 samples, 0.11%)</title><rect x="296.5" y="1961" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.45" y="1973.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (2,154,496,094 samples, 0.34%)</title><rect x="1592.1" y="2361" width="14.1" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="1595.10" y="2373.5" ></text>
+</g>
+<g >
+<title>syscall_return_via_sysret (193,586,548 samples, 0.03%)</title><rect x="2096.8" y="2421" width="1.2" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="2099.76" y="2433.5" ></text>
+</g>
+<g >
+<title>_IO_file_xsputn@@GLIBC_2.2.5 (153,839,759 samples, 0.02%)</title><rect x="2633.9" y="2421" width="1.0" height="19.0" fill="rgb(242,171,41)" rx="2" ry="2" />
+<text  x="2636.92" y="2433.5" ></text>
+</g>
+<g >
+<title>shmem_file_read_iter (2,215,249,200 samples, 0.35%)</title><rect x="203.8" y="2341" width="14.5" height="19.0" fill="rgb(238,152,36)" rx="2" ry="2" />
+<text  x="206.81" y="2353.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (207,378,880 samples, 0.03%)</title><rect x="869.4" y="381" width="1.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="872.43" y="393.5" ></text>
+</g>
+<g >
+<title>execute_command (159,029,721 samples, 0.02%)</title><rect x="362.2" y="221" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="365.24" y="233.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (548,839,992 samples, 0.09%)</title><rect x="273.3" y="641" width="3.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="276.32" y="653.5" ></text>
+</g>
+<g >
+<title>execute_command (685,976,378 samples, 0.11%)</title><rect x="268.8" y="1081" width="4.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="271.79" y="1093.5" ></text>
+</g>
+<g >
+<title>execute_command (192,670,319 samples, 0.03%)</title><rect x="837.6" y="1101" width="1.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="840.55" y="1113.5" ></text>
+</g>
+<g >
+<title>execute_command (163,954,022 samples, 0.03%)</title><rect x="870.8" y="1041" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="873.82" y="1053.5" ></text>
+</g>
+<g >
+<title>execute_command (883,778,724 samples, 0.14%)</title><rect x="851.1" y="541" width="5.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="854.09" y="553.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (436,055,112 samples, 0.07%)</title><rect x="888.5" y="2021" width="2.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="891.55" y="2033.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (164,808,262 samples, 0.03%)</title><rect x="870.8" y="1481" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="873.81" y="1493.5" ></text>
+</g>
+<g >
+<title>asm_exc_page_fault (468,414,529 samples, 0.07%)</title><rect x="589.2" y="1301" width="3.1" height="19.0" fill="rgb(231,123,29)" rx="2" ry="2" />
+<text  x="592.25" y="1313.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (436,055,112 samples, 0.07%)</title><rect x="888.5" y="1941" width="2.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="891.55" y="1953.5" ></text>
+</g>
+<g >
+<title>bpf_lsm_file_open (252,459,102 samples, 0.04%)</title><rect x="1491.7" y="2201" width="1.7" height="19.0" fill="rgb(227,105,25)" rx="2" ry="2" />
+<text  x="1494.72" y="2213.5" ></text>
+</g>
+<g >
+<title>__do_sys_clone (181,373,291 samples, 0.03%)</title><rect x="273.8" y="281" width="1.2" height="19.0" fill="rgb(217,57,13)" rx="2" ry="2" />
+<text  x="276.84" y="293.5" ></text>
+</g>
+<g >
+<title>xas_load (183,371,216 samples, 0.03%)</title><rect x="3984.2" y="2301" width="1.2" height="19.0" fill="rgb(224,88,21)" rx="2" ry="2" />
+<text  x="3987.22" y="2313.5" ></text>
+</g>
+<g >
+<title>lookup_fast (171,598,606 samples, 0.03%)</title><rect x="184.7" y="2261" width="1.1" height="19.0" fill="rgb(226,97,23)" rx="2" ry="2" />
+<text  x="187.66" y="2273.5" ></text>
+</g>
+<g >
+<title>llseek@GLIBC_2.2.5 (1,005,521,367 samples, 0.16%)</title><rect x="1558.4" y="2481" width="6.6" height="19.0" fill="rgb(239,156,37)" rx="2" ry="2" />
+<text  x="1561.38" y="2493.5" ></text>
+</g>
+<g >
+<title>parse_and_execute (179,777,548 samples, 0.03%)</title><rect x="878.5" y="801" width="1.2" height="19.0" fill="rgb(243,178,42)" rx="2" ry="2" />
+<text  x="881.48" y="813.5" ></text>
+</g>
+<g >
+<title>execute_command (578,068,287 samples, 0.09%)</title><rect x="884.6" y="2461" width="3.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="887.62" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (179,777,548 samples, 0.03%)</title><rect x="878.5" y="1261" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="881.48" y="1273.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (598,514,664 samples, 0.09%)</title><rect x="891.4" y="1421" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.40" y="1433.5" ></text>
+</g>
+<g >
+<title>execute_command (179,777,548 samples, 0.03%)</title><rect x="878.5" y="1561" width="1.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="881.48" y="1573.5" ></text>
+</g>
+<g >
+<title>do_dentry_open (559,499,498 samples, 0.09%)</title><rect x="4137.9" y="2261" width="3.6" height="19.0" fill="rgb(249,205,49)" rx="2" ry="2" />
+<text  x="4140.87" y="2273.5" ></text>
+</g>
+<g >
+<title>__GI___sigprocmask (193,539,260 samples, 0.03%)</title><rect x="784.5" y="1361" width="1.3" height="19.0" fill="rgb(246,193,46)" rx="2" ry="2" />
+<text  x="787.55" y="1373.5" ></text>
+</g>
+<g >
+<title>execute_command (1,590,990,109 samples, 0.25%)</title><rect x="399.7" y="1141" width="10.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="402.66" y="1153.5" ></text>
+</g>
+<g >
+<title>execute_command (170,489,782 samples, 0.03%)</title><rect x="871.9" y="1081" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="874.90" y="1093.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (163,954,022 samples, 0.03%)</title><rect x="870.8" y="1281" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="873.82" y="1293.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (158,744,410 samples, 0.02%)</title><rect x="875.9" y="1221" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="878.93" y="1233.5" ></text>
+</g>
+<g >
+<title>execute_command (432,872,015 samples, 0.07%)</title><rect x="888.6" y="881" width="2.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="891.57" y="893.5" ></text>
+</g>
+<g >
+<title>do_dentry_open (382,119,750 samples, 0.06%)</title><rect x="2035.9" y="2241" width="2.5" height="19.0" fill="rgb(249,205,49)" rx="2" ry="2" />
+<text  x="2038.93" y="2253.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (164,072,262 samples, 0.03%)</title><rect x="836.5" y="681" width="1.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="839.46" y="693.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,261,568,072 samples, 0.20%)</title><rect x="860.3" y="1161" width="8.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.31" y="1173.5" ></text>
+</g>
+<g >
+<title>execute_command (513,954,307 samples, 0.08%)</title><rect x="856.9" y="1241" width="3.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="859.94" y="1253.5" ></text>
+</g>
+<g >
+<title>execute_command (685,976,378 samples, 0.11%)</title><rect x="268.8" y="801" width="4.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="271.79" y="813.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (513,954,307 samples, 0.08%)</title><rect x="856.9" y="1421" width="3.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="859.94" y="1433.5" ></text>
+</g>
+<g >
+<title>malloc (1,237,123,533 samples, 0.19%)</title><rect x="418.6" y="1041" width="8.1" height="19.0" fill="rgb(230,119,28)" rx="2" ry="2" />
+<text  x="421.63" y="1053.5" ></text>
+</g>
+<g >
+<title>[bash] (849,509,116 samples, 0.13%)</title><rect x="895.3" y="2401" width="5.6" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="898.35" y="2413.5" ></text>
+</g>
+<g >
+<title>__fstat64 (943,830,965 samples, 0.15%)</title><rect x="2566.5" y="2421" width="6.2" height="19.0" fill="rgb(224,88,21)" rx="2" ry="2" />
+<text  x="2569.47" y="2433.5" ></text>
+</g>
+<g >
+<title>execute_command (164,731,865 samples, 0.03%)</title><rect x="836.5" y="981" width="1.0" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="839.46" y="993.5" ></text>
+</g>
+<g >
+<title>ptep_clear_flush (237,758,662 samples, 0.04%)</title><rect x="770.9" y="1181" width="1.5" height="19.0" fill="rgb(214,41,9)" rx="2" ry="2" />
+<text  x="773.88" y="1193.5" ></text>
+</g>
+<g >
+<title>syscall_return_via_sysret (192,169,727 samples, 0.03%)</title><rect x="3377.7" y="2441" width="1.2" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="3380.69" y="2453.5" ></text>
+</g>
+<g >
+<title>__d_lookup_rcu (185,606,150 samples, 0.03%)</title><rect x="2030.4" y="2201" width="1.2" height="19.0" fill="rgb(235,139,33)" rx="2" ry="2" />
+<text  x="2033.41" y="2213.5" ></text>
+</g>
+<g >
+<title>_dl_start (175,794,660 samples, 0.03%)</title><rect x="266.6" y="2561" width="1.2" height="19.0" fill="rgb(237,151,36)" rx="2" ry="2" />
+<text  x="269.62" y="2573.5" ></text>
+</g>
+<g >
+<title>do_redirections (190,014,181 samples, 0.03%)</title><rect x="837.6" y="621" width="1.2" height="19.0" fill="rgb(247,193,46)" rx="2" ry="2" />
+<text  x="840.56" y="633.5" ></text>
+</g>
+<g >
+<title>new_do_write (664,755,312 samples, 0.10%)</title><rect x="2093.7" y="2461" width="4.3" height="19.0" fill="rgb(206,5,1)" rx="2" ry="2" />
+<text  x="2096.68" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command (169,596,485 samples, 0.03%)</title><rect x="871.9" y="721" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="874.90" y="733.5" ></text>
+</g>
+<g >
+<title>malloc (338,933,158 samples, 0.05%)</title><rect x="629.6" y="1281" width="2.2" height="19.0" fill="rgb(230,119,28)" rx="2" ry="2" />
+<text  x="632.58" y="1293.5" ></text>
+</g>
+<g >
+<title>execute_command (6,056,191,471 samples, 0.95%)</title><rect x="309.8" y="801" width="39.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="312.77" y="813.5" >exe..</text>
+</g>
+<g >
+<title>execute_command (713,521,499 samples, 0.11%)</title><rect x="296.5" y="1981" width="4.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="299.45" y="1993.5" ></text>
+</g>
+<g >
+<title>[bash] (467,938,705 samples, 0.07%)</title><rect x="857.2" y="461" width="3.1" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="860.22" y="473.5" ></text>
+</g>
+<g >
+<title>make_child (197,153,189 samples, 0.03%)</title><rect x="886.7" y="221" width="1.3" height="19.0" fill="rgb(242,170,40)" rx="2" ry="2" />
+<text  x="889.70" y="233.5" ></text>
+</g>
+<g >
+<title>[xxhsum] (3,044,731,594 samples, 0.48%)</title><rect x="4035.9" y="2461" width="19.9" height="19.0" fill="rgb(249,206,49)" rx="2" ry="2" />
+<text  x="4038.86" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (551,359,579 samples, 0.09%)</title><rect x="273.3" y="1481" width="3.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="276.31" y="1493.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (717,313,739 samples, 0.11%)</title><rect x="280.1" y="1521" width="4.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.09" y="1533.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (481,813,209 samples, 0.08%)</title><rect x="276.9" y="1321" width="3.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="279.93" y="1333.5" ></text>
+</g>
+<g >
+<title>[bash] (215,748,926 samples, 0.03%)</title><rect x="842.8" y="1681" width="1.4" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="845.80" y="1693.5" ></text>
+</g>
+<g >
+<title>execute_command (575,055,300 samples, 0.09%)</title><rect x="884.6" y="1101" width="3.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="887.64" y="1113.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (481,813,209 samples, 0.08%)</title><rect x="276.9" y="1241" width="3.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="279.93" y="1253.5" ></text>
+</g>
+<g >
+<title>[bash] (713,521,499 samples, 0.11%)</title><rect x="296.5" y="2541" width="4.6" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="299.45" y="2553.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (574,375,983 samples, 0.09%)</title><rect x="884.6" y="601" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="887.64" y="613.5" ></text>
+</g>
+<g >
+<title>execute_command (164,072,262 samples, 0.03%)</title><rect x="836.5" y="701" width="1.0" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="839.46" y="713.5" ></text>
+</g>
+<g >
+<title>execute_command (516,725,798 samples, 0.08%)</title><rect x="856.9" y="2121" width="3.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="859.92" y="2133.5" ></text>
+</g>
+<g >
+<title>execute_command (575,055,300 samples, 0.09%)</title><rect x="884.6" y="981" width="3.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="887.64" y="993.5" ></text>
+</g>
+<g >
+<title>[bash] (354,911,948 samples, 0.06%)</title><rect x="840.5" y="801" width="2.3" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="843.48" y="813.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,263,560,140 samples, 0.20%)</title><rect x="860.3" y="2001" width="8.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.30" y="2013.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (595,672,870 samples, 0.09%)</title><rect x="891.4" y="1001" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.42" y="1013.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (889,542,281 samples, 0.14%)</title><rect x="851.1" y="681" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.09" y="693.5" ></text>
+</g>
+<g >
+<title>kernel_clone (2,121,561,795 samples, 0.33%)</title><rect x="694.3" y="1221" width="13.8" height="19.0" fill="rgb(248,199,47)" rx="2" ry="2" />
+<text  x="697.26" y="1233.5" ></text>
+</g>
+<g >
+<title>execute_command (1,540,901,264 samples, 0.24%)</title><rect x="339.3" y="741" width="10.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="342.30" y="753.5" ></text>
+</g>
+<g >
+<title>lookup_fast (222,574,892 samples, 0.03%)</title><rect x="3323.5" y="2261" width="1.5" height="19.0" fill="rgb(226,97,23)" rx="2" ry="2" />
+<text  x="3326.55" y="2273.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (179,777,548 samples, 0.03%)</title><rect x="878.5" y="1421" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="881.48" y="1433.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (717,313,739 samples, 0.11%)</title><rect x="280.1" y="2401" width="4.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.09" y="2413.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (76,537,418,554 samples, 11.99%)</title><rect x="307.1" y="2341" width="501.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="310.06" y="2353.5" >execute_command_internal</text>
+</g>
+<g >
+<title>execute_command_internal (513,954,307 samples, 0.08%)</title><rect x="856.9" y="1501" width="3.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="859.94" y="1513.5" ></text>
+</g>
+<g >
+<title>execute_command (717,313,739 samples, 0.11%)</title><rect x="280.1" y="1461" width="4.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="283.09" y="1473.5" ></text>
+</g>
+<g >
+<title>posix_fadvise (680,834,229 samples, 0.11%)</title><rect x="2110.3" y="2501" width="4.5" height="19.0" fill="rgb(245,186,44)" rx="2" ry="2" />
+<text  x="2113.33" y="2513.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (891,895,571 samples, 0.14%)</title><rect x="851.1" y="2161" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.08" y="2173.5" ></text>
+</g>
+<g >
+<title>dispose_command (278,788,607 samples, 0.04%)</title><rect x="840.5" y="481" width="1.8" height="19.0" fill="rgb(248,201,48)" rx="2" ry="2" />
+<text  x="843.48" y="493.5" ></text>
+</g>
+<g >
+<title>execute_command (2,022,660,615 samples, 0.32%)</title><rect x="868.6" y="2281" width="13.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="871.57" y="2293.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (215,132,849 samples, 0.03%)</title><rect x="842.8" y="1081" width="1.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="845.81" y="1093.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (596,118,643 samples, 0.09%)</title><rect x="891.4" y="1301" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.42" y="1313.5" ></text>
+</g>
+<g >
+<title>execute_command (1,144,745,070 samples, 0.18%)</title><rect x="827.6" y="521" width="7.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="830.59" y="533.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (322,256,264 samples, 0.05%)</title><rect x="868.7" y="901" width="2.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="871.70" y="913.5" ></text>
+</g>
+<g >
+<title>execute_command (578,068,287 samples, 0.09%)</title><rect x="884.6" y="1941" width="3.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="887.62" y="1953.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (849,509,116 samples, 0.13%)</title><rect x="895.3" y="2421" width="5.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.35" y="2433.5" ></text>
+</g>
+<g >
+<title>llseek@GLIBC_2.2.5 (557,099,659 samples, 0.09%)</title><rect x="2183.1" y="2481" width="3.6" height="19.0" fill="rgb(239,156,37)" rx="2" ry="2" />
+<text  x="2186.08" y="2493.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (481,813,209 samples, 0.08%)</title><rect x="276.9" y="1401" width="3.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="279.93" y="1413.5" ></text>
+</g>
+<g >
+<title>_IO_file_xsgetn (1,046,578,792 samples, 0.16%)</title><rect x="2044.2" y="2461" width="6.9" height="19.0" fill="rgb(207,11,2)" rx="2" ry="2" />
+<text  x="2047.25" y="2473.5" ></text>
+</g>
+<g >
+<title>kernel_wait4 (207,226,765 samples, 0.03%)</title><rect x="785.9" y="1281" width="1.4" height="19.0" fill="rgb(206,7,1)" rx="2" ry="2" />
+<text  x="788.95" y="1293.5" ></text>
+</g>
+<g >
+<title>[bash] (190,014,181 samples, 0.03%)</title><rect x="837.6" y="561" width="1.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="840.56" y="573.5" ></text>
+</g>
+<g >
+<title>execute_command (207,539,560 samples, 0.03%)</title><rect x="835.1" y="1661" width="1.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="838.10" y="1673.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (195,916,485 samples, 0.03%)</title><rect x="835.2" y="1321" width="1.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="838.17" y="1333.5" ></text>
+</g>
+<g >
+<title>execute_command (215,132,849 samples, 0.03%)</title><rect x="842.8" y="901" width="1.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="845.81" y="913.5" ></text>
+</g>
+<g >
+<title>execute_command (158,599,791 samples, 0.02%)</title><rect x="875.9" y="921" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="878.93" y="933.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (188,328,554 samples, 0.03%)</title><rect x="837.6" y="481" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="840.57" y="493.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (195,267,188 samples, 0.03%)</title><rect x="835.2" y="1261" width="1.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="838.18" y="1273.5" ></text>
+</g>
+<g >
+<title>execute_command (1,150,422,968 samples, 0.18%)</title><rect x="827.6" y="1761" width="7.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="830.57" y="1773.5" ></text>
+</g>
+<g >
+<title>execute_command (889,542,281 samples, 0.14%)</title><rect x="851.1" y="941" width="5.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="854.09" y="953.5" ></text>
+</g>
+<g >
+<title>_copy_to_iter (1,928,210,691 samples, 0.30%)</title><rect x="3350.0" y="2321" width="12.6" height="19.0" fill="rgb(234,134,32)" rx="2" ry="2" />
+<text  x="3352.97" y="2333.5" ></text>
+</g>
+<g >
+<title>finish_task_switch.isra.0 (217,588,907 samples, 0.03%)</title><rect x="708.7" y="1221" width="1.4" height="19.0" fill="rgb(252,219,52)" rx="2" ry="2" />
+<text  x="711.66" y="1233.5" ></text>
+</g>
+<g >
+<title>new_do_write (538,233,682 samples, 0.08%)</title><rect x="3080.5" y="2461" width="3.5" height="19.0" fill="rgb(206,5,1)" rx="2" ry="2" />
+<text  x="3083.47" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command (3,250,591,335 samples, 0.51%)</title><rect x="361.8" y="301" width="21.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="364.82" y="313.5" >e..</text>
+</g>
+<g >
+<title>execute_command (62,166,399,318 samples, 9.74%)</title><rect x="396.3" y="1501" width="407.0" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="399.32" y="1513.5" >execute_command</text>
+</g>
+<g >
+<title>begin_new_exec (1,260,500,822 samples, 0.20%)</title><rect x="288.1" y="2441" width="8.2" height="19.0" fill="rgb(251,213,51)" rx="2" ry="2" />
+<text  x="291.10" y="2453.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (4,974,302,072 samples, 0.78%)</title><rect x="360.1" y="521" width="32.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="363.14" y="533.5" >ex..</text>
+</g>
+<g >
+<title>execute_command_internal (1,263,560,140 samples, 0.20%)</title><rect x="860.3" y="2441" width="8.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.30" y="2453.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (356,134,455 samples, 0.06%)</title><rect x="840.5" y="1761" width="2.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="843.47" y="1773.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,150,422,968 samples, 0.18%)</title><rect x="827.6" y="2181" width="7.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.57" y="2193.5" ></text>
+</g>
+<g >
+<title>execute_command (1,261,568,072 samples, 0.20%)</title><rect x="860.3" y="1141" width="8.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="863.31" y="1153.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,261,220,789 samples, 0.20%)</title><rect x="860.3" y="801" width="8.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.32" y="813.5" ></text>
+</g>
+<g >
+<title>execute_command (1,147,316,451 samples, 0.18%)</title><rect x="827.6" y="1321" width="7.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="830.59" y="1333.5" ></text>
+</g>
+<g >
+<title>__printf_chk (1,124,242,193 samples, 0.18%)</title><rect x="1651.6" y="2501" width="7.4" height="19.0" fill="rgb(212,36,8)" rx="2" ry="2" />
+<text  x="1654.61" y="2513.5" ></text>
+</g>
+<g >
+<title>execute_command (432,872,015 samples, 0.07%)</title><rect x="888.6" y="921" width="2.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="891.57" y="933.5" ></text>
+</g>
+<g >
+<title>[bash] (195,267,188 samples, 0.03%)</title><rect x="835.2" y="1241" width="1.3" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="838.18" y="1253.5" ></text>
+</g>
+<g >
+<title>[bash] (467,908,159 samples, 0.07%)</title><rect x="857.2" y="421" width="3.1" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="860.22" y="433.5" ></text>
+</g>
+<g >
+<title>__x64_sys_close (251,078,658 samples, 0.04%)</title><rect x="3072.6" y="2401" width="1.7" height="19.0" fill="rgb(238,153,36)" rx="2" ry="2" />
+<text  x="3075.63" y="2413.5" ></text>
+</g>
+<g >
+<title>execute_command (158,599,791 samples, 0.02%)</title><rect x="875.9" y="1041" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="878.93" y="1053.5" ></text>
+</g>
+<g >
+<title>do_group_exit (2,964,126,674 samples, 0.46%)</title><rect x="808.2" y="2501" width="19.4" height="19.0" fill="rgb(226,97,23)" rx="2" ry="2" />
+<text  x="811.16" y="2513.5" ></text>
+</g>
+<g >
+<title>_dl_start (563,965,232 samples, 0.09%)</title><rect x="2534.9" y="2561" width="3.7" height="19.0" fill="rgb(237,151,36)" rx="2" ry="2" />
+<text  x="2537.89" y="2573.5" ></text>
+</g>
+<g >
+<title>execute_command (1,150,422,968 samples, 0.18%)</title><rect x="827.6" y="1481" width="7.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="830.57" y="1493.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (713,521,499 samples, 0.11%)</title><rect x="296.5" y="2401" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.45" y="2413.5" ></text>
+</g>
+<g >
+<title>malloc (791,530,199 samples, 0.12%)</title><rect x="522.3" y="1181" width="5.2" height="19.0" fill="rgb(230,119,28)" rx="2" ry="2" />
+<text  x="525.29" y="1193.5" ></text>
+</g>
+<g >
+<title>path_openat (2,378,855,628 samples, 0.37%)</title><rect x="3315.2" y="2281" width="15.5" height="19.0" fill="rgb(205,2,0)" rx="2" ry="2" />
+<text  x="3318.15" y="2293.5" ></text>
+</g>
+<g >
+<title>execute_command (1,150,422,968 samples, 0.18%)</title><rect x="827.6" y="2201" width="7.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="830.57" y="2213.5" ></text>
+</g>
+<g >
+<title>__vfprintf_internal (863,772,024 samples, 0.14%)</title><rect x="4048.4" y="2421" width="5.7" height="19.0" fill="rgb(232,125,30)" rx="2" ry="2" />
+<text  x="4051.44" y="2433.5" ></text>
+</g>
+<g >
+<title>execute_command (483,985,097 samples, 0.08%)</title><rect x="276.9" y="2341" width="3.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="279.92" y="2353.5" ></text>
+</g>
+<g >
+<title>[bash] (468,670,318 samples, 0.07%)</title><rect x="857.2" y="501" width="3.1" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="860.22" y="513.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (554,006,342 samples, 0.09%)</title><rect x="273.3" y="1761" width="3.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="276.29" y="1773.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,531,110,849 samples, 0.24%)</title><rect x="339.4" y="721" width="10.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="342.36" y="733.5" ></text>
+</g>
+<g >
+<title>[bash] (5,902,692,960 samples, 0.92%)</title><rect x="356.1" y="1101" width="38.6" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="359.07" y="1113.5" >[ba..</text>
+</g>
+<g >
+<title>execute_command_internal (688,777,208 samples, 0.11%)</title><rect x="268.8" y="1901" width="4.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="271.77" y="1913.5" ></text>
+</g>
+<g >
+<title>_dl_catch_exception (176,448,166 samples, 0.03%)</title><rect x="3682.0" y="2481" width="1.1" height="19.0" fill="rgb(253,223,53)" rx="2" ry="2" />
+<text  x="3684.99" y="2493.5" ></text>
+</g>
+<g >
+<title>[b2sum] (32,510,657,859 samples, 5.09%)</title><rect x="10.8" y="2481" width="212.8" height="19.0" fill="rgb(216,50,12)" rx="2" ry="2" />
+<text  x="13.77" y="2493.5" >[b2sum]</text>
+</g>
+<g >
+<title>execute_command (554,006,342 samples, 0.09%)</title><rect x="273.3" y="2141" width="3.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="276.29" y="2153.5" ></text>
+</g>
+<g >
+<title>_dl_start_user (547,432,284 samples, 0.09%)</title><rect x="1843.0" y="2581" width="3.6" height="19.0" fill="rgb(236,145,34)" rx="2" ry="2" />
+<text  x="1845.97" y="2593.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (853,210,202 samples, 0.13%)</title><rect x="301.2" y="461" width="5.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.16" y="473.5" ></text>
+</g>
+<g >
+<title>execute_command (483,985,097 samples, 0.08%)</title><rect x="276.9" y="2141" width="3.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="279.92" y="2153.5" ></text>
+</g>
+<g >
+<title>execute_command (686,486,049 samples, 0.11%)</title><rect x="268.8" y="1201" width="4.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="271.78" y="1213.5" ></text>
+</g>
+<g >
+<title>kernel_clone (159,753,816 samples, 0.03%)</title><rect x="886.7" y="101" width="1.1" height="19.0" fill="rgb(248,199,47)" rx="2" ry="2" />
+<text  x="889.71" y="113.5" ></text>
+</g>
+<g >
+<title>__fstat64 (678,326,998 samples, 0.11%)</title><rect x="1502.9" y="2401" width="4.4" height="19.0" fill="rgb(224,88,21)" rx="2" ry="2" />
+<text  x="1505.91" y="2413.5" ></text>
+</g>
+<g >
+<title>[bash] (1,150,422,968 samples, 0.18%)</title><rect x="827.6" y="2541" width="7.5" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="830.57" y="2553.5" ></text>
+</g>
+<g >
+<title>do_redirections (179,777,548 samples, 0.03%)</title><rect x="878.5" y="921" width="1.2" height="19.0" fill="rgb(247,193,46)" rx="2" ry="2" />
+<text  x="881.48" y="933.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (346,158,915 samples, 0.05%)</title><rect x="889.1" y="481" width="2.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="892.08" y="493.5" ></text>
+</g>
+<g >
+<title>[bash] (303,470,028 samples, 0.05%)</title><rect x="892.8" y="201" width="2.0" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="895.77" y="213.5" ></text>
+</g>
+<g >
+<title>execute_command (215,748,926 samples, 0.03%)</title><rect x="842.8" y="1581" width="1.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="845.80" y="1593.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (5,263,042,878 samples, 0.82%)</title><rect x="359.4" y="721" width="34.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="362.42" y="733.5" >ex..</text>
+</g>
+<g >
+<title>execute_command (883,153,075 samples, 0.14%)</title><rect x="851.1" y="501" width="5.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="854.09" y="513.5" ></text>
+</g>
+<g >
+<title>execute_command (180,216,075 samples, 0.03%)</title><rect x="878.5" y="1681" width="1.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="881.48" y="1693.5" ></text>
+</g>
+<g >
+<title>parse_and_execute (195,762,914 samples, 0.03%)</title><rect x="855.3" y="261" width="1.3" height="19.0" fill="rgb(243,178,42)" rx="2" ry="2" />
+<text  x="858.31" y="273.5" ></text>
+</g>
+<g >
+<title>syscall_return_via_sysret (308,628,418 samples, 0.05%)</title><rect x="3946.2" y="2401" width="2.0" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="3949.15" y="2413.5" ></text>
+</g>
+<g >
+<title>execute_command (483,985,097 samples, 0.08%)</title><rect x="276.9" y="1581" width="3.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="279.92" y="1593.5" ></text>
+</g>
+<g >
+<title>execute_command (891,895,571 samples, 0.14%)</title><rect x="851.1" y="1621" width="5.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="854.08" y="1633.5" ></text>
+</g>
+<g >
+<title>execute_command (513,428,353 samples, 0.08%)</title><rect x="856.9" y="1041" width="3.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="859.94" y="1053.5" ></text>
+</g>
+<g >
+<title>execute_command (516,725,798 samples, 0.08%)</title><rect x="856.9" y="1601" width="3.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="859.92" y="1613.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (168,201,373 samples, 0.03%)</title><rect x="280.1" y="201" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.12" y="213.5" ></text>
+</g>
+<g >
+<title>execute_command (575,055,300 samples, 0.09%)</title><rect x="884.6" y="941" width="3.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="887.64" y="953.5" ></text>
+</g>
+<g >
+<title>bpf_trampoline_6442533562 (237,324,967 samples, 0.04%)</title><rect x="4139.4" y="2201" width="1.5" height="19.0" fill="rgb(221,78,18)" rx="2" ry="2" />
+<text  x="4142.40" y="2213.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (516,725,798 samples, 0.08%)</title><rect x="856.9" y="2541" width="3.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="859.92" y="2553.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (550,598,300 samples, 0.09%)</title><rect x="273.3" y="801" width="3.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="276.32" y="813.5" ></text>
+</g>
+<g >
+<title>read (3,629,514,249 samples, 0.57%)</title><rect x="1614.7" y="2461" width="23.8" height="19.0" fill="rgb(252,216,51)" rx="2" ry="2" />
+<text  x="1617.71" y="2473.5" >r..</text>
+</g>
+<g >
+<title>execute_command_internal (551,359,579 samples, 0.09%)</title><rect x="273.3" y="1521" width="3.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="276.31" y="1533.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (679,254,761 samples, 0.11%)</title><rect x="268.8" y="501" width="4.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="271.79" y="513.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (195,916,485 samples, 0.03%)</title><rect x="835.2" y="1521" width="1.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="838.17" y="1533.5" ></text>
+</g>
+<g >
+<title>entry_SYSRETQ_unsafe_stack (173,671,550 samples, 0.03%)</title><rect x="3386.4" y="2421" width="1.2" height="19.0" fill="rgb(213,37,8)" rx="2" ry="2" />
+<text  x="3389.45" y="2433.5" ></text>
+</g>
+<g >
+<title>execute_command (1,844,466,299 samples, 0.29%)</title><rect x="327.2" y="701" width="12.0" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="330.16" y="713.5" ></text>
+</g>
+<g >
+<title>exit_mmap (2,833,164,052 samples, 0.44%)</title><rect x="808.2" y="2441" width="18.5" height="19.0" fill="rgb(242,173,41)" rx="2" ry="2" />
+<text  x="811.18" y="2453.5" ></text>
+</g>
+<g >
+<title>execute_command (1,146,830,397 samples, 0.18%)</title><rect x="827.6" y="961" width="7.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="830.59" y="973.5" ></text>
+</g>
+<g >
+<title>strncpy_from_user (162,553,481 samples, 0.03%)</title><rect x="1496.3" y="2281" width="1.1" height="19.0" fill="rgb(254,228,54)" rx="2" ry="2" />
+<text  x="1499.34" y="2293.5" ></text>
+</g>
+<g >
+<title>execute_command (329,739,906 samples, 0.05%)</title><rect x="410.3" y="1121" width="2.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="413.27" y="1133.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (891,895,571 samples, 0.14%)</title><rect x="851.1" y="2321" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.08" y="2333.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (175,629,128 samples, 0.03%)</title><rect x="271.8" y="261" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="274.76" y="273.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (843,061,254 samples, 0.13%)</title><rect x="895.4" y="1141" width="5.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.39" y="1153.5" ></text>
+</g>
+<g >
+<title>execute_command (481,191,724 samples, 0.08%)</title><rect x="276.9" y="1061" width="3.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="279.94" y="1073.5" ></text>
+</g>
+<g >
+<title>selinux_inode_permission (554,114,933 samples, 0.09%)</title><rect x="3912.7" y="2241" width="3.7" height="19.0" fill="rgb(238,156,37)" rx="2" ry="2" />
+<text  x="3915.72" y="2253.5" ></text>
+</g>
+<g >
+<title>__fstat64 (719,383,701 samples, 0.11%)</title><rect x="3042.9" y="2421" width="4.7" height="19.0" fill="rgb(224,88,21)" rx="2" ry="2" />
+<text  x="3045.89" y="2433.5" ></text>
+</g>
+<g >
+<title>[b2sum] (38,976,505,576 samples, 6.10%)</title><rect x="10.0" y="2581" width="255.2" height="19.0" fill="rgb(216,50,12)" rx="2" ry="2" />
+<text  x="13.00" y="2593.5" >[b2sum]</text>
+</g>
+<g >
+<title>execute_command_internal (5,856,487,838 samples, 0.92%)</title><rect x="356.1" y="1061" width="38.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="359.08" y="1073.5" >exe..</text>
+</g>
+<g >
+<title>execute_command (550,598,300 samples, 0.09%)</title><rect x="273.3" y="861" width="3.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="276.32" y="873.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (5,906,567,737 samples, 0.93%)</title><rect x="356.1" y="1301" width="38.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="359.06" y="1313.5" >exe..</text>
+</g>
+<g >
+<title>execute_command (192,670,319 samples, 0.03%)</title><rect x="837.6" y="1261" width="1.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="840.55" y="1273.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (425,053,821 samples, 0.07%)</title><rect x="888.6" y="501" width="2.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="891.57" y="513.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (849,509,116 samples, 0.13%)</title><rect x="895.3" y="1821" width="5.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.35" y="1833.5" ></text>
+</g>
+<g >
+<title>selinux_inode_permission (533,571,043 samples, 0.08%)</title><rect x="4169.6" y="2301" width="3.5" height="19.0" fill="rgb(238,156,37)" rx="2" ry="2" />
+<text  x="4172.56" y="2313.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (7,231,962,642 samples, 1.13%)</title><rect x="308.5" y="1221" width="47.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="311.52" y="1233.5" >exec..</text>
+</g>
+<g >
+<title>execute_command (354,998,378 samples, 0.06%)</title><rect x="840.5" y="1221" width="2.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="843.48" y="1233.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (248,359,625 samples, 0.04%)</title><rect x="3044.0" y="2381" width="1.6" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="3046.97" y="2393.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (4,324,936,725 samples, 0.68%)</title><rect x="360.3" y="481" width="28.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="363.35" y="493.5" >e..</text>
+</g>
+<g >
+<title>[bash] (862,729,528 samples, 0.14%)</title><rect x="328.8" y="541" width="5.6" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="331.78" y="553.5" ></text>
+</g>
+<g >
+<title>walk_component (345,754,358 samples, 0.05%)</title><rect x="1481.2" y="2241" width="2.2" height="19.0" fill="rgb(247,197,47)" rx="2" ry="2" />
+<text  x="1484.15" y="2253.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (480,699,859 samples, 0.08%)</title><rect x="276.9" y="681" width="3.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="279.94" y="693.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (157,001,214 samples, 0.02%)</title><rect x="870.9" y="601" width="1.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="873.86" y="613.5" ></text>
+</g>
+<g >
+<title>parse_and_execute (62,812,137,204 samples, 9.84%)</title><rect x="395.1" y="1681" width="411.2" height="19.0" fill="rgb(243,178,42)" rx="2" ry="2" />
+<text  x="398.13" y="1693.5" >parse_and_execute</text>
+</g>
+<g >
+<title>[bash] (395,283,021 samples, 0.06%)</title><rect x="339.8" y="641" width="2.5" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="342.75" y="653.5" ></text>
+</g>
+<g >
+<title>[bash] (466,937,454 samples, 0.07%)</title><rect x="897.3" y="221" width="3.0" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="900.29" y="233.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (598,514,664 samples, 0.09%)</title><rect x="891.4" y="2141" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.40" y="2153.5" ></text>
+</g>
+<g >
+<title>make_child (156,368,512 samples, 0.02%)</title><rect x="275.5" y="261" width="1.0" height="19.0" fill="rgb(242,170,40)" rx="2" ry="2" />
+<text  x="278.51" y="273.5" ></text>
+</g>
+<g >
+<title>[bash] (551,359,579 samples, 0.09%)</title><rect x="273.3" y="1381" width="3.6" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="276.31" y="1393.5" ></text>
+</g>
+<g >
+<title>string_list_internal (909,990,287 samples, 0.14%)</title><rect x="552.0" y="1201" width="5.9" height="19.0" fill="rgb(223,83,19)" rx="2" ry="2" />
+<text  x="554.96" y="1213.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,261,568,072 samples, 0.20%)</title><rect x="860.3" y="1081" width="8.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.31" y="1093.5" ></text>
+</g>
+<g >
+<title>__vfprintf_internal (1,569,238,498 samples, 0.25%)</title><rect x="2193.7" y="2481" width="10.2" height="19.0" fill="rgb(232,125,30)" rx="2" ry="2" />
+<text  x="2196.67" y="2493.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (468,670,318 samples, 0.07%)</title><rect x="857.2" y="521" width="3.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="860.22" y="533.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (155,977,481 samples, 0.02%)</title><rect x="836.5" y="441" width="1.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="839.51" y="453.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (704,492,242 samples, 0.11%)</title><rect x="296.5" y="561" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.51" y="573.5" ></text>
+</g>
+<g >
+<title>execute_command (195,267,188 samples, 0.03%)</title><rect x="835.2" y="861" width="1.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="838.18" y="873.5" ></text>
+</g>
+<g >
+<title>mapfile_builtin (14,198,699,427 samples, 2.22%)</title><rect x="414.8" y="1121" width="92.9" height="19.0" fill="rgb(205,1,0)" rx="2" ry="2" />
+<text  x="417.76" y="1133.5" >mapfile_bui..</text>
+</g>
+<g >
+<title>vfs_write (275,823,493 samples, 0.04%)</title><rect x="900.9" y="2421" width="1.9" height="19.0" fill="rgb(207,9,2)" rx="2" ry="2" />
+<text  x="903.95" y="2433.5" ></text>
+</g>
+<g >
+<title>strnlen_user (321,029,121 samples, 0.05%)</title><rect x="669.9" y="1221" width="2.1" height="19.0" fill="rgb(218,63,15)" rx="2" ry="2" />
+<text  x="672.91" y="1233.5" ></text>
+</g>
+<g >
+<title>__handle_mm_fault (158,283,939 samples, 0.02%)</title><rect x="1583.6" y="2401" width="1.0" height="19.0" fill="rgb(213,39,9)" rx="2" ry="2" />
+<text  x="1586.59" y="2413.5" ></text>
+</g>
+<g >
+<title>[cksum] (85,645,580,777 samples, 13.41%)</title><rect x="905.4" y="2461" width="560.7" height="19.0" fill="rgb(241,167,40)" rx="2" ry="2" />
+<text  x="908.43" y="2473.5" >[cksum]</text>
+</g>
+<g >
+<title>execute_command_internal (433,500,595 samples, 0.07%)</title><rect x="888.6" y="1461" width="2.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="891.56" y="1473.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (481,191,724 samples, 0.08%)</title><rect x="276.9" y="1141" width="3.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="279.94" y="1153.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (172,325,912 samples, 0.03%)</title><rect x="869.6" y="301" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="872.64" y="313.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (686,486,049 samples, 0.11%)</title><rect x="268.8" y="1341" width="4.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="271.78" y="1353.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (215,132,849 samples, 0.03%)</title><rect x="842.8" y="881" width="1.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="845.81" y="893.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (843,061,254 samples, 0.13%)</title><rect x="895.4" y="1301" width="5.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.39" y="1313.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (866,614,713 samples, 0.14%)</title><rect x="301.1" y="1861" width="5.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.12" y="1873.5" ></text>
+</g>
+<g >
+<title>[bash] (708,334,361 samples, 0.11%)</title><rect x="302.0" y="261" width="4.6" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="304.97" y="273.5" ></text>
+</g>
+<g >
+<title>execute_command (1,263,560,140 samples, 0.20%)</title><rect x="860.3" y="1461" width="8.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="863.30" y="1473.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (843,061,254 samples, 0.13%)</title><rect x="895.4" y="1241" width="5.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.39" y="1253.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (842,511,421 samples, 0.13%)</title><rect x="895.4" y="981" width="5.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.39" y="993.5" ></text>
+</g>
+<g >
+<title>[cksum] (100,956,048,300 samples, 15.81%)</title><rect x="904.1" y="2501" width="660.9" height="19.0" fill="rgb(241,167,40)" rx="2" ry="2" />
+<text  x="907.09" y="2513.5" >[cksum]</text>
+</g>
+<g >
+<title>execute_command (578,068,287 samples, 0.09%)</title><rect x="884.6" y="2301" width="3.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="887.62" y="2313.5" ></text>
+</g>
+<g >
+<title>execute_command (554,006,342 samples, 0.09%)</title><rect x="273.3" y="1821" width="3.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="276.29" y="1833.5" ></text>
+</g>
+<g >
+<title>_copy_to_iter (1,586,215,984 samples, 0.25%)</title><rect x="1447.7" y="2281" width="10.4" height="19.0" fill="rgb(234,134,32)" rx="2" ry="2" />
+<text  x="1450.69" y="2293.5" ></text>
+</g>
+<g >
+<title>execute_command (163,954,022 samples, 0.03%)</title><rect x="870.8" y="1121" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="873.82" y="1133.5" ></text>
+</g>
+<g >
+<title>bpf_lsm_file_open (165,041,361 samples, 0.03%)</title><rect x="2037.0" y="2201" width="1.1" height="19.0" fill="rgb(227,105,25)" rx="2" ry="2" />
+<text  x="2040.01" y="2213.5" ></text>
+</g>
+<g >
+<title>execute_command (483,985,097 samples, 0.08%)</title><rect x="276.9" y="2061" width="3.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="279.92" y="2073.5" ></text>
+</g>
+<g >
+<title>__libc_start_call_main (15,825,414,099 samples, 2.48%)</title><rect x="2540.1" y="2541" width="103.6" height="19.0" fill="rgb(210,26,6)" rx="2" ry="2" />
+<text  x="2543.07" y="2553.5" >__libc_start..</text>
+</g>
+<g >
+<title>execute_command_internal (171,847,094 samples, 0.03%)</title><rect x="871.9" y="1541" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="874.89" y="1553.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (595,971,768 samples, 0.09%)</title><rect x="350.2" y="841" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="353.21" y="853.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (483,985,097 samples, 0.08%)</title><rect x="276.9" y="1761" width="3.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="279.92" y="1773.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (713,521,499 samples, 0.11%)</title><rect x="296.5" y="2001" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.45" y="2013.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (578,068,287 samples, 0.09%)</title><rect x="884.6" y="2441" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="887.62" y="2453.5" ></text>
+</g>
+<g >
+<title>do_filp_open (1,951,722,012 samples, 0.31%)</title><rect x="2127.1" y="2301" width="12.7" height="19.0" fill="rgb(217,58,13)" rx="2" ry="2" />
+<text  x="2130.05" y="2313.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (574,909,828 samples, 0.09%)</title><rect x="884.6" y="721" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="887.64" y="733.5" ></text>
+</g>
+<g >
+<title>execute_command (1,150,422,968 samples, 0.18%)</title><rect x="827.6" y="1641" width="7.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="830.57" y="1653.5" ></text>
+</g>
+<g >
+<title>execute_command (849,509,116 samples, 0.13%)</title><rect x="895.3" y="1841" width="5.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="898.35" y="1853.5" ></text>
+</g>
+<g >
+<title>execute_command (190,829,147 samples, 0.03%)</title><rect x="837.6" y="701" width="1.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="840.55" y="713.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (481,191,724 samples, 0.08%)</title><rect x="276.9" y="881" width="3.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="279.94" y="893.5" ></text>
+</g>
+<g >
+<title>execute_command (1,177,189,266 samples, 0.18%)</title><rect x="835.1" y="1901" width="7.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="838.10" y="1913.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (427,429,248 samples, 0.07%)</title><rect x="407.2" y="1101" width="2.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="410.24" y="1113.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (685,594,707 samples, 0.11%)</title><rect x="268.8" y="581" width="4.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="271.79" y="593.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (596,118,643 samples, 0.09%)</title><rect x="891.4" y="1361" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.42" y="1373.5" ></text>
+</g>
+<g >
+<title>execute_command (17,527,272,405 samples, 2.74%)</title><rect x="398.0" y="1421" width="114.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="401.03" y="1433.5" >execute_command</text>
+</g>
+<g >
+<title>vfs_read (2,813,413,727 samples, 0.44%)</title><rect x="2153.7" y="2381" width="18.4" height="19.0" fill="rgb(230,118,28)" rx="2" ry="2" />
+<text  x="2156.71" y="2393.5" ></text>
+</g>
+<g >
+<title>lookup_fast (205,958,899 samples, 0.03%)</title><rect x="2551.3" y="2221" width="1.4" height="19.0" fill="rgb(226,97,23)" rx="2" ry="2" />
+<text  x="2554.32" y="2233.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,150,422,968 samples, 0.18%)</title><rect x="827.6" y="1861" width="7.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.57" y="1873.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (419,550,691 samples, 0.07%)</title><rect x="4059.4" y="2361" width="2.8" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="4062.41" y="2373.5" ></text>
+</g>
+<g >
+<title>__d_lookup_rcu (187,608,070 samples, 0.03%)</title><rect x="2551.4" y="2201" width="1.3" height="19.0" fill="rgb(235,139,33)" rx="2" ry="2" />
+<text  x="2554.44" y="2213.5" ></text>
+</g>
+<g >
+<title>vfs_open (677,230,455 samples, 0.11%)</title><rect x="1489.5" y="2261" width="4.4" height="19.0" fill="rgb(238,154,37)" rx="2" ry="2" />
+<text  x="1492.48" y="2273.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,263,560,140 samples, 0.20%)</title><rect x="860.3" y="2081" width="8.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.30" y="2093.5" ></text>
+</g>
+<g >
+<title>link_path_walk.part.0.constprop.0 (1,471,295,182 samples, 0.23%)</title><rect x="1473.8" y="2261" width="9.6" height="19.0" fill="rgb(254,229,54)" rx="2" ry="2" />
+<text  x="1476.79" y="2273.5" ></text>
+</g>
+<g >
+<title>_int_free (244,968,384 samples, 0.04%)</title><rect x="530.6" y="1181" width="1.7" height="19.0" fill="rgb(247,196,46)" rx="2" ry="2" />
+<text  x="533.65" y="1193.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (275,660,695 samples, 0.04%)</title><rect x="351.7" y="561" width="1.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="354.71" y="573.5" ></text>
+</g>
+<g >
+<title>syscall_return_via_sysret (477,092,077 samples, 0.07%)</title><rect x="3368.9" y="2441" width="3.1" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="3371.87" y="2453.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (688,777,208 samples, 0.11%)</title><rect x="268.8" y="2181" width="4.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="271.77" y="2193.5" ></text>
+</g>
+<g >
+<title>bpf_trampoline_6442533562 (246,003,753 samples, 0.04%)</title><rect x="3927.4" y="2201" width="1.6" height="19.0" fill="rgb(221,78,18)" rx="2" ry="2" />
+<text  x="3930.43" y="2213.5" ></text>
+</g>
+<g >
+<title>execute_command (3,714,430,474 samples, 0.58%)</title><rect x="860.3" y="2561" width="24.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="863.30" y="2573.5" >e..</text>
+</g>
+<g >
+<title>execute_command (574,375,983 samples, 0.09%)</title><rect x="884.6" y="621" width="3.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="887.64" y="633.5" ></text>
+</g>
+<g >
+<title>execute_command (578,068,287 samples, 0.09%)</title><rect x="884.6" y="1661" width="3.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="887.62" y="1673.5" ></text>
+</g>
+<g >
+<title>_IO_file_fopen@@GLIBC_2.2.5 (2,952,966,024 samples, 0.46%)</title><rect x="2125.0" y="2441" width="19.3" height="19.0" fill="rgb(237,148,35)" rx="2" ry="2" />
+<text  x="2127.96" y="2453.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (190,071,010 samples, 0.03%)</title><rect x="2111.0" y="2481" width="1.3" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="2114.01" y="2493.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (890,006,400 samples, 0.14%)</title><rect x="851.1" y="1401" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.09" y="1413.5" ></text>
+</g>
+<g >
+<title>execute_command (1,989,848,818 samples, 0.31%)</title><rect x="835.1" y="2261" width="13.0" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="838.10" y="2273.5" ></text>
+</g>
+<g >
+<title>execute_command (554,006,342 samples, 0.09%)</title><rect x="273.3" y="2021" width="3.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="276.29" y="2033.5" ></text>
+</g>
+<g >
+<title>main (866,614,713 samples, 0.14%)</title><rect x="301.1" y="2541" width="5.7" height="19.0" fill="rgb(243,179,42)" rx="2" ry="2" />
+<text  x="304.12" y="2553.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (481,191,724 samples, 0.08%)</title><rect x="276.9" y="721" width="3.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="279.94" y="733.5" ></text>
+</g>
+<g >
+<title>execute_command (554,006,342 samples, 0.09%)</title><rect x="273.3" y="1901" width="3.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="276.29" y="1913.5" ></text>
+</g>
+<g >
+<title>execute_command (164,731,865 samples, 0.03%)</title><rect x="836.5" y="1101" width="1.0" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="839.46" y="1113.5" ></text>
+</g>
+<g >
+<title>__fread_unlocked_chk (5,931,538,693 samples, 0.93%)</title><rect x="2565.6" y="2481" width="38.9" height="19.0" fill="rgb(225,94,22)" rx="2" ry="2" />
+<text  x="2568.65" y="2493.5" >__f..</text>
+</g>
+<g >
+<title>do_execveat_common.isra.0 (1,260,500,822 samples, 0.20%)</title><rect x="288.1" y="2501" width="8.2" height="19.0" fill="rgb(238,153,36)" rx="2" ry="2" />
+<text  x="291.10" y="2513.5" ></text>
+</g>
+<g >
+<title>execute_command (483,985,097 samples, 0.08%)</title><rect x="276.9" y="2461" width="3.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="279.92" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command (685,976,378 samples, 0.11%)</title><rect x="268.8" y="721" width="4.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="271.79" y="733.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (685,976,378 samples, 0.11%)</title><rect x="268.8" y="1021" width="4.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="271.79" y="1033.5" ></text>
+</g>
+<g >
+<title>shmem_file_read_iter (4,522,161,212 samples, 0.71%)</title><rect x="4076.1" y="2341" width="29.6" height="19.0" fill="rgb(238,152,36)" rx="2" ry="2" />
+<text  x="4079.07" y="2353.5" >sh..</text>
+</g>
+<g >
+<title>__libc_start_call_main (102,680,360,274 samples, 16.08%)</title><rect x="903.8" y="2541" width="672.2" height="19.0" fill="rgb(210,26,6)" rx="2" ry="2" />
+<text  x="906.84" y="2553.5" >__libc_start_call_main</text>
+</g>
+<g >
+<title>_IO_file_xsgetn (816,390,640 samples, 0.13%)</title><rect x="1609.3" y="2461" width="5.4" height="19.0" fill="rgb(207,11,2)" rx="2" ry="2" />
+<text  x="1612.32" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (575,055,300 samples, 0.09%)</title><rect x="884.6" y="1041" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="887.64" y="1053.5" ></text>
+</g>
+<g >
+<title>_int_malloc (407,050,517 samples, 0.06%)</title><rect x="584.5" y="1261" width="2.7" height="19.0" fill="rgb(215,47,11)" rx="2" ry="2" />
+<text  x="587.53" y="1273.5" ></text>
+</g>
+<g >
+<title>execute_command (433,500,595 samples, 0.07%)</title><rect x="888.6" y="1441" width="2.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="891.56" y="1453.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (262,895,564 samples, 0.04%)</title><rect x="832.9" y="221" width="1.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="835.86" y="233.5" ></text>
+</g>
+<g >
+<title>execute_command (849,509,116 samples, 0.13%)</title><rect x="895.3" y="2241" width="5.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="898.35" y="2253.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (320,467,680 samples, 0.05%)</title><rect x="868.7" y="661" width="2.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="871.70" y="673.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (598,514,664 samples, 0.09%)</title><rect x="891.4" y="1701" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.40" y="1713.5" ></text>
+</g>
+<g >
+<title>execute_command (717,313,739 samples, 0.11%)</title><rect x="280.1" y="1821" width="4.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="283.09" y="1833.5" ></text>
+</g>
+<g >
+<title>execute_command (190,516,532 samples, 0.03%)</title><rect x="895.4" y="281" width="1.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="898.39" y="293.5" ></text>
+</g>
+<g >
+<title>__do_sys_newfstat (218,229,633 samples, 0.03%)</title><rect x="1611.0" y="2361" width="1.4" height="19.0" fill="rgb(225,96,23)" rx="2" ry="2" />
+<text  x="1613.99" y="2373.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (685,594,707 samples, 0.11%)</title><rect x="268.8" y="621" width="4.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="271.79" y="633.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (578,068,287 samples, 0.09%)</title><rect x="884.6" y="2281" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="887.62" y="2293.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (506,573,132 samples, 0.08%)</title><rect x="868.6" y="1661" width="3.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="871.57" y="1673.5" ></text>
+</g>
+<g >
+<title>walk_component (336,263,649 samples, 0.05%)</title><rect x="4176.2" y="2341" width="2.2" height="19.0" fill="rgb(247,197,47)" rx="2" ry="2" />
+<text  x="4179.20" y="2353.5" ></text>
+</g>
+<g >
+<title>getname_flags.part.0 (307,127,038 samples, 0.05%)</title><rect x="2038.6" y="2301" width="2.0" height="19.0" fill="rgb(213,39,9)" rx="2" ry="2" />
+<text  x="2041.60" y="2313.5" ></text>
+</g>
+<g >
+<title>_dl_start_user (723,051,726 samples, 0.11%)</title><rect x="2117.3" y="2581" width="4.7" height="19.0" fill="rgb(236,145,34)" rx="2" ry="2" />
+<text  x="2120.26" y="2593.5" ></text>
+</g>
+<g >
+<title>execute_command (889,542,281 samples, 0.14%)</title><rect x="851.1" y="981" width="5.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="854.09" y="993.5" ></text>
+</g>
+<g >
+<title>[bash] (339,880,830 samples, 0.05%)</title><rect x="298.3" y="181" width="2.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="301.31" y="193.5" ></text>
+</g>
+<g >
+<title>[bash] (1,146,830,397 samples, 0.18%)</title><rect x="827.6" y="1061" width="7.5" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="830.59" y="1073.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (891,895,571 samples, 0.14%)</title><rect x="851.1" y="1521" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.08" y="1533.5" ></text>
+</g>
+<g >
+<title>__libc_start_main@@GLIBC_2.34 (23,219,248,933 samples, 3.64%)</title><rect x="4033.5" y="2561" width="152.0" height="19.0" fill="rgb(229,113,27)" rx="2" ry="2" />
+<text  x="4036.49" y="2573.5" >__libc_start_main@@..</text>
+</g>
+<g >
+<title>syscall_return_via_sysret (377,439,280 samples, 0.06%)</title><rect x="220.7" y="2421" width="2.4" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="223.66" y="2433.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (883,778,724 samples, 0.14%)</title><rect x="851.1" y="521" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.09" y="533.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (13,304,985,322 samples, 2.08%)</title><rect x="307.9" y="1601" width="87.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="310.94" y="1613.5" >execute_co..</text>
+</g>
+<g >
+<title>execute_command_internal (323,026,366 samples, 0.05%)</title><rect x="868.7" y="1441" width="2.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="871.70" y="1453.5" ></text>
+</g>
+<g >
+<title>do_group_exit (207,707,782 samples, 0.03%)</title><rect x="1585.8" y="2501" width="1.4" height="19.0" fill="rgb(226,97,23)" rx="2" ry="2" />
+<text  x="1588.83" y="2513.5" ></text>
+</g>
+<g >
+<title>__printf_buffer_flush_to_file (501,258,647 samples, 0.08%)</title><rect x="253.4" y="2441" width="3.3" height="19.0" fill="rgb(247,197,47)" rx="2" ry="2" />
+<text  x="256.42" y="2453.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (688,777,208 samples, 0.11%)</title><rect x="268.8" y="2141" width="4.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="271.77" y="2153.5" ></text>
+</g>
+<g >
+<title>[bash] (194,148,063 samples, 0.03%)</title><rect x="837.5" y="1481" width="1.3" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="840.54" y="1493.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (193,848,893 samples, 0.03%)</title><rect x="2611.7" y="2461" width="1.3" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="2614.71" y="2473.5" ></text>
+</g>
+<g >
+<title>vfs_fstat (275,621,951 samples, 0.04%)</title><rect x="3942.2" y="2341" width="1.8" height="19.0" fill="rgb(215,46,11)" rx="2" ry="2" />
+<text  x="3945.24" y="2353.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (164,808,262 samples, 0.03%)</title><rect x="870.8" y="1381" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="873.81" y="1393.5" ></text>
+</g>
+<g >
+<title>redirection_expand (383,077,638 samples, 0.06%)</title><rect x="277.5" y="381" width="2.5" height="19.0" fill="rgb(218,63,15)" rx="2" ry="2" />
+<text  x="280.53" y="393.5" ></text>
+</g>
+<g >
+<title>[bash] (279,026,271 samples, 0.04%)</title><rect x="275.1" y="341" width="1.8" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="278.06" y="353.5" ></text>
+</g>
+<g >
+<title>execute_command (195,916,485 samples, 0.03%)</title><rect x="835.2" y="1601" width="1.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="838.17" y="1613.5" ></text>
+</g>
+<g >
+<title>[bash] (201,027,753 samples, 0.03%)</title><rect x="827.7" y="141" width="1.3" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="830.67" y="153.5" ></text>
+</g>
+<g >
+<title>[cat] (413,970,628 samples, 0.06%)</title><rect x="900.9" y="2521" width="2.7" height="19.0" fill="rgb(209,20,4)" rx="2" ry="2" />
+<text  x="903.92" y="2533.5" ></text>
+</g>
+<g >
+<title>__printf_buffer_to_file_done (797,018,641 samples, 0.12%)</title><rect x="3409.6" y="2461" width="5.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="3412.64" y="2473.5" ></text>
+</g>
+<g >
+<title>_copy_to_iter (3,301,822,627 samples, 0.52%)</title><rect x="4078.3" y="2301" width="21.6" height="19.0" fill="rgb(234,134,32)" rx="2" ry="2" />
+<text  x="4081.25" y="2313.5" >_..</text>
+</g>
+<g >
+<title>__fread_chk (4,350,793,089 samples, 0.68%)</title><rect x="194.6" y="2461" width="28.5" height="19.0" fill="rgb(249,204,48)" rx="2" ry="2" />
+<text  x="197.65" y="2473.5" >__..</text>
+</g>
+<g >
+<title>[md5sum] (11,165,378,769 samples, 1.75%)</title><rect x="1589.6" y="2521" width="73.1" height="19.0" fill="rgb(229,113,27)" rx="2" ry="2" />
+<text  x="1592.57" y="2533.5" >[md5sum]</text>
+</g>
+<g >
+<title>execute_command (371,816,855 samples, 0.06%)</title><rect x="401.0" y="981" width="2.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="403.98" y="993.5" ></text>
+</g>
+<g >
+<title>exc_page_fault (169,050,517 samples, 0.03%)</title><rect x="779.6" y="1261" width="1.1" height="19.0" fill="rgb(219,65,15)" rx="2" ry="2" />
+<text  x="782.58" y="1273.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (713,521,499 samples, 0.11%)</title><rect x="296.5" y="2501" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.45" y="2513.5" ></text>
+</g>
+<g >
+<title>execute_command (713,521,499 samples, 0.11%)</title><rect x="296.5" y="2061" width="4.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="299.45" y="2073.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (662,289,592 samples, 0.10%)</title><rect x="4151.0" y="2441" width="4.3" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="4154.00" y="2453.5" ></text>
+</g>
+<g >
+<title>fclose@@GLIBC_2.2.5 (720,035,118 samples, 0.11%)</title><rect x="224.5" y="2481" width="4.7" height="19.0" fill="rgb(251,213,51)" rx="2" ry="2" />
+<text  x="227.50" y="2493.5" ></text>
+</g>
+<g >
+<title>__printf_buffer_to_file_done (393,610,020 samples, 0.06%)</title><rect x="1543.7" y="2441" width="2.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="1546.70" y="2453.5" ></text>
+</g>
+<g >
+<title>execute_command (959,050,067 samples, 0.15%)</title><rect x="309.9" y="681" width="6.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="312.94" y="693.5" ></text>
+</g>
+<g >
+<title>execute_command (175,601,700 samples, 0.03%)</title><rect x="860.3" y="341" width="1.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="863.32" y="353.5" ></text>
+</g>
+<g >
+<title>_dl_map_object_deps (199,539,301 samples, 0.03%)</title><rect x="2117.9" y="2501" width="1.3" height="19.0" fill="rgb(219,68,16)" rx="2" ry="2" />
+<text  x="2120.88" y="2513.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (713,462,810 samples, 0.11%)</title><rect x="280.1" y="881" width="4.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.11" y="893.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (2,973,517,551 samples, 0.47%)</title><rect x="2152.9" y="2421" width="19.5" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="2155.91" y="2433.5" ></text>
+</g>
+<g >
+<title>[bash] (171,796,738 samples, 0.03%)</title><rect x="385.1" y="261" width="1.1" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="388.06" y="273.5" ></text>
+</g>
+<g >
+<title>__printf_chk (2,798,236,337 samples, 0.44%)</title><rect x="3084.5" y="2501" width="18.3" height="19.0" fill="rgb(212,36,8)" rx="2" ry="2" />
+<text  x="3087.49" y="2513.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (195,916,485 samples, 0.03%)</title><rect x="835.2" y="1361" width="1.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="838.17" y="1373.5" ></text>
+</g>
+<g >
+<title>execute_command (574,909,828 samples, 0.09%)</title><rect x="884.6" y="701" width="3.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="887.64" y="713.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (717,313,739 samples, 0.11%)</title><rect x="280.1" y="1561" width="4.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.09" y="1573.5" ></text>
+</g>
+<g >
+<title>link_path_walk.part.0.constprop.0 (814,010,618 samples, 0.13%)</title><rect x="2128.6" y="2261" width="5.3" height="19.0" fill="rgb(254,229,54)" rx="2" ry="2" />
+<text  x="2131.56" y="2273.5" ></text>
+</g>
+<g >
+<title>[bash] (400,615,449 samples, 0.06%)</title><rect x="282.0" y="281" width="2.6" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="284.97" y="293.5" ></text>
+</g>
+<g >
+<title>execute_command (550,598,300 samples, 0.09%)</title><rect x="273.3" y="1101" width="3.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="276.32" y="1113.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (598,514,664 samples, 0.09%)</title><rect x="891.4" y="1621" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.40" y="1633.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (554,006,342 samples, 0.09%)</title><rect x="273.3" y="1921" width="3.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="276.29" y="1933.5" ></text>
+</g>
+<g >
+<title>[bash] (393,430,335 samples, 0.06%)</title><rect x="298.3" y="201" width="2.6" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="301.31" y="213.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (373,582,417 samples, 0.06%)</title><rect x="835.1" y="1681" width="2.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="838.10" y="1693.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,150,422,968 samples, 0.18%)</title><rect x="827.6" y="1901" width="7.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.57" y="1913.5" ></text>
+</g>
+<g >
+<title>[bash] (862,395,726 samples, 0.14%)</title><rect x="301.2" y="1101" width="5.6" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="304.15" y="1113.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (13,306,686,716 samples, 2.08%)</title><rect x="307.9" y="1721" width="87.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="310.94" y="1733.5" >execute_co..</text>
+</g>
+<g >
+<title>[bash] (578,992,244 samples, 0.09%)</title><rect x="884.6" y="2541" width="3.8" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="887.62" y="2553.5" ></text>
+</g>
+<g >
+<title>[bash] (210,970,187 samples, 0.03%)</title><rect x="385.0" y="321" width="1.4" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="387.98" y="333.5" ></text>
+</g>
+<g >
+<title>read (7,297,034,837 samples, 1.14%)</title><rect x="3948.5" y="2461" width="47.8" height="19.0" fill="rgb(252,216,51)" rx="2" ry="2" />
+<text  x="3951.51" y="2473.5" >read</text>
+</g>
+<g >
+<title>execute_command (1,350,734,241 samples, 0.21%)</title><rect x="316.4" y="621" width="8.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="319.38" y="633.5" ></text>
+</g>
+<g >
+<title>ima_file_check (162,356,042 samples, 0.03%)</title><rect x="4135.7" y="2261" width="1.1" height="19.0" fill="rgb(251,215,51)" rx="2" ry="2" />
+<text  x="4138.70" y="2273.5" ></text>
+</g>
+<g >
+<title>_IO_do_write@@GLIBC_2.2.5 (713,783,482 samples, 0.11%)</title><rect x="3384.2" y="2481" width="4.7" height="19.0" fill="rgb(238,155,37)" rx="2" ry="2" />
+<text  x="3387.25" y="2493.5" ></text>
+</g>
+<g >
+<title>execute_command (688,777,208 samples, 0.11%)</title><rect x="268.8" y="1881" width="4.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="271.77" y="1893.5" ></text>
+</g>
+<g >
+<title>execute_command (849,509,116 samples, 0.13%)</title><rect x="895.3" y="1761" width="5.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="898.35" y="1773.5" ></text>
+</g>
+<g >
+<title>execute_command (436,055,112 samples, 0.07%)</title><rect x="888.5" y="2481" width="2.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="891.55" y="2493.5" ></text>
+</g>
+<g >
+<title>execute_command (550,598,300 samples, 0.09%)</title><rect x="273.3" y="981" width="3.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="276.32" y="993.5" ></text>
+</g>
+<g >
+<title>_IO_file_fopen@@GLIBC_2.2.5 (4,488,148,915 samples, 0.70%)</title><rect x="4119.6" y="2461" width="29.4" height="19.0" fill="rgb(237,148,35)" rx="2" ry="2" />
+<text  x="4122.63" y="2473.5" >_I..</text>
+</g>
+<g >
+<title>execute_command_internal (195,267,188 samples, 0.03%)</title><rect x="835.2" y="1001" width="1.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="838.18" y="1013.5" ></text>
+</g>
+<g >
+<title>__vfprintf_internal (3,276,926,194 samples, 0.51%)</title><rect x="239.4" y="2481" width="21.5" height="19.0" fill="rgb(232,125,30)" rx="2" ry="2" />
+<text  x="242.43" y="2493.5" >_..</text>
+</g>
+<g >
+<title>execute_command (432,726,851 samples, 0.07%)</title><rect x="888.6" y="641" width="2.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="891.57" y="653.5" ></text>
+</g>
+<g >
+<title>__strchrnul_evex (333,618,140 samples, 0.05%)</title><rect x="257.7" y="2461" width="2.2" height="19.0" fill="rgb(239,159,38)" rx="2" ry="2" />
+<text  x="260.73" y="2473.5" ></text>
+</g>
+<g >
+<title>syscall_return_via_sysret (207,156,833 samples, 0.03%)</title><rect x="2042.0" y="2381" width="1.4" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="2045.03" y="2393.5" ></text>
+</g>
+<g >
+<title>execute_command (158,599,791 samples, 0.02%)</title><rect x="875.9" y="1081" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="878.93" y="1093.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (866,614,713 samples, 0.14%)</title><rect x="301.1" y="2141" width="5.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.12" y="2153.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,261,568,072 samples, 0.20%)</title><rect x="860.3" y="1381" width="8.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.31" y="1393.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (169,623,683 samples, 0.03%)</title><rect x="871.9" y="741" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="874.90" y="753.5" ></text>
+</g>
+<g >
+<title>vfs_fstatat (2,878,440,695 samples, 0.45%)</title><rect x="4162.4" y="2421" width="18.8" height="19.0" fill="rgb(239,157,37)" rx="2" ry="2" />
+<text  x="4165.39" y="2433.5" ></text>
+</g>
+<g >
+<title>execute_command (862,395,726 samples, 0.14%)</title><rect x="301.2" y="1041" width="5.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="304.15" y="1053.5" ></text>
+</g>
+<g >
+<title>execute_command (713,521,499 samples, 0.11%)</title><rect x="296.5" y="1661" width="4.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="299.45" y="1673.5" ></text>
+</g>
+<g >
+<title>[bash] (843,061,254 samples, 0.13%)</title><rect x="895.4" y="1201" width="5.5" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="898.39" y="1213.5" ></text>
+</g>
+<g >
+<title>execute_command (548,788,616 samples, 0.09%)</title><rect x="273.3" y="581" width="3.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="276.32" y="593.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (483,985,097 samples, 0.08%)</title><rect x="276.9" y="2201" width="3.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="279.92" y="2213.5" ></text>
+</g>
+<g >
+<title>execute_command (2,632,644,403 samples, 0.41%)</title><rect x="309.9" y="721" width="17.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="312.89" y="733.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (17,508,517,118 samples, 2.74%)</title><rect x="398.1" y="1401" width="114.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="401.14" y="1413.5" >execute_comman..</text>
+</g>
+<g >
+<title>execute_command (713,987,302 samples, 0.11%)</title><rect x="280.1" y="1261" width="4.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="283.11" y="1273.5" ></text>
+</g>
+<g >
+<title>__libc_fork (261,876,686 samples, 0.04%)</title><rect x="270.0" y="261" width="1.7" height="19.0" fill="rgb(220,70,16)" rx="2" ry="2" />
+<text  x="272.97" y="273.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (354,938,381 samples, 0.06%)</title><rect x="840.5" y="1001" width="2.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="843.48" y="1013.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (578,068,287 samples, 0.09%)</title><rect x="884.6" y="2321" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="887.62" y="2333.5" ></text>
+</g>
+<g >
+<title>ksys_read (2,369,285,248 samples, 0.37%)</title><rect x="1509.7" y="2381" width="15.5" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="1512.65" y="2393.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (717,313,739 samples, 0.11%)</title><rect x="280.1" y="1881" width="4.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.09" y="1893.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (413,260,615 samples, 0.06%)</title><rect x="400.7" y="1001" width="2.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="403.71" y="1013.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (666,234,521 samples, 0.10%)</title><rect x="835.1" y="1761" width="4.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="838.10" y="1773.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (159,710,185 samples, 0.03%)</title><rect x="875.9" y="1741" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="878.92" y="1753.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (195,267,188 samples, 0.03%)</title><rect x="835.2" y="881" width="1.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="838.18" y="893.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (158,599,791 samples, 0.02%)</title><rect x="875.9" y="981" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="878.93" y="993.5" ></text>
+</g>
+<g >
+<title>[bash] (264,483,298 samples, 0.04%)</title><rect x="898.4" y="161" width="1.7" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="901.39" y="173.5" ></text>
+</g>
+<g >
+<title>[bash] (204,516,794 samples, 0.03%)</title><rect x="390.9" y="421" width="1.4" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="393.94" y="433.5" ></text>
+</g>
+<g >
+<title>__libc_start_main@@GLIBC_2.34 (38,976,403,114 samples, 6.10%)</title><rect x="10.0" y="2561" width="255.2" height="19.0" fill="rgb(229,113,27)" rx="2" ry="2" />
+<text  x="13.00" y="2573.5" >__libc_start_main@@GLIBC_2.34</text>
+</g>
+<g >
+<title>execute_command_internal (215,132,849 samples, 0.03%)</title><rect x="842.8" y="1001" width="1.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="845.81" y="1013.5" ></text>
+</g>
+<g >
+<title>vfs_open (457,907,984 samples, 0.07%)</title><rect x="2556.8" y="2261" width="3.0" height="19.0" fill="rgb(238,154,37)" rx="2" ry="2" />
+<text  x="2559.79" y="2273.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (704,492,242 samples, 0.11%)</title><rect x="296.5" y="641" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.51" y="653.5" ></text>
+</g>
+<g >
+<title>execute_command (516,725,798 samples, 0.08%)</title><rect x="856.9" y="2241" width="3.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="859.92" y="2253.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (575,800,354 samples, 0.09%)</title><rect x="884.6" y="1401" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="887.64" y="1413.5" ></text>
+</g>
+<g >
+<title>execute_command (717,313,739 samples, 0.11%)</title><rect x="280.1" y="2061" width="4.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="283.09" y="2073.5" ></text>
+</g>
+<g >
+<title>do_redirections (644,619,334 samples, 0.10%)</title><rect x="344.8" y="681" width="4.2" height="19.0" fill="rgb(247,193,46)" rx="2" ry="2" />
+<text  x="347.82" y="693.5" ></text>
+</g>
+<g >
+<title>exc_page_fault (582,210,388 samples, 0.09%)</title><rect x="454.2" y="1001" width="3.8" height="19.0" fill="rgb(219,65,15)" rx="2" ry="2" />
+<text  x="457.21" y="1013.5" ></text>
+</g>
+<g >
+<title>execute_command (842,511,421 samples, 0.13%)</title><rect x="895.4" y="881" width="5.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="898.39" y="893.5" ></text>
+</g>
+<g >
+<title>execute_command (699,290,297 samples, 0.11%)</title><rect x="296.5" y="501" width="4.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="299.51" y="513.5" ></text>
+</g>
+<g >
+<title>__strchrnul_evex (245,537,280 samples, 0.04%)</title><rect x="3100.5" y="2461" width="1.6" height="19.0" fill="rgb(239,159,38)" rx="2" ry="2" />
+<text  x="3103.47" y="2473.5" ></text>
+</g>
+<g >
+<title>__libc_start_call_main (866,614,713 samples, 0.14%)</title><rect x="301.1" y="2561" width="5.7" height="19.0" fill="rgb(210,26,6)" rx="2" ry="2" />
+<text  x="304.12" y="2573.5" ></text>
+</g>
+<g >
+<title>execute_command (578,068,287 samples, 0.09%)</title><rect x="884.6" y="1821" width="3.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="887.62" y="1833.5" ></text>
+</g>
+<g >
+<title>shmem_file_read_iter (2,154,497,151 samples, 0.34%)</title><rect x="1511.1" y="2341" width="14.1" height="19.0" fill="rgb(238,152,36)" rx="2" ry="2" />
+<text  x="1514.06" y="2353.5" ></text>
+</g>
+<g >
+<title>fclose@@GLIBC_2.2.5 (1,435,214,228 samples, 0.22%)</title><rect x="1548.8" y="2481" width="9.4" height="19.0" fill="rgb(251,213,51)" rx="2" ry="2" />
+<text  x="1551.81" y="2493.5" ></text>
+</g>
+<g >
+<title>__GI___libc_open (3,353,331,076 samples, 0.53%)</title><rect x="2543.0" y="2401" width="21.9" height="19.0" fill="rgb(249,202,48)" rx="2" ry="2" />
+<text  x="2545.96" y="2413.5" >_..</text>
+</g>
+<g >
+<title>[bash] (62,819,725,715 samples, 9.84%)</title><rect x="395.1" y="1761" width="411.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="398.09" y="1773.5" >[bash]</text>
+</g>
+<g >
+<title>execute_command_internal (481,813,209 samples, 0.08%)</title><rect x="276.9" y="1161" width="3.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="279.93" y="1173.5" ></text>
+</g>
+<g >
+<title>core_sys_select (191,110,363 samples, 0.03%)</title><rect x="313.1" y="361" width="1.3" height="19.0" fill="rgb(245,186,44)" rx="2" ry="2" />
+<text  x="316.11" y="373.5" ></text>
+</g>
+<g >
+<title>lookup_fast (211,746,817 samples, 0.03%)</title><rect x="2031.6" y="2261" width="1.4" height="19.0" fill="rgb(226,97,23)" rx="2" ry="2" />
+<text  x="2034.63" y="2273.5" ></text>
+</g>
+<g >
+<title>__close_nocancel (831,718,881 samples, 0.13%)</title><rect x="2605.5" y="2461" width="5.5" height="19.0" fill="rgb(228,109,26)" rx="2" ry="2" />
+<text  x="2608.54" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (314,630,647 samples, 0.05%)</title><rect x="351.7" y="641" width="2.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="354.65" y="653.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (353,505,141 samples, 0.06%)</title><rect x="2606.3" y="2421" width="2.3" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="2609.30" y="2433.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (163,954,022 samples, 0.03%)</title><rect x="870.8" y="1141" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="873.82" y="1153.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (551,359,579 samples, 0.09%)</title><rect x="273.3" y="1321" width="3.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="276.31" y="1333.5" ></text>
+</g>
+<g >
+<title>execute_command (695,772,580 samples, 0.11%)</title><rect x="296.5" y="421" width="4.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="299.51" y="433.5" ></text>
+</g>
+<g >
+<title>[sha512sum] (11,041,376,614 samples, 1.73%)</title><rect x="3311.1" y="2501" width="72.3" height="19.0" fill="rgb(248,201,48)" rx="2" ry="2" />
+<text  x="3314.15" y="2513.5" >[sha512s..</text>
+</g>
+<g >
+<title>execute_command_internal (13,307,154,980 samples, 2.08%)</title><rect x="307.9" y="1801" width="87.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="310.94" y="1813.5" >execute_co..</text>
+</g>
+<g >
+<title>execute_command_internal (432,872,015 samples, 0.07%)</title><rect x="888.6" y="1101" width="2.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="891.57" y="1113.5" ></text>
+</g>
+<g >
+<title>getname_flags.part.0 (402,581,514 samples, 0.06%)</title><rect x="4141.8" y="2321" width="2.6" height="19.0" fill="rgb(213,39,9)" rx="2" ry="2" />
+<text  x="4144.77" y="2333.5" ></text>
+</g>
+<g >
+<title>[bash] (558,478,669 samples, 0.09%)</title><rect x="319.3" y="541" width="3.6" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="322.29" y="553.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (432,872,015 samples, 0.07%)</title><rect x="888.6" y="941" width="2.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="891.57" y="953.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (705,583,873 samples, 0.11%)</title><rect x="296.5" y="1181" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.50" y="1193.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (890,006,400 samples, 0.14%)</title><rect x="851.1" y="1301" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.09" y="1313.5" ></text>
+</g>
+<g >
+<title>__printf_buffer_flush_to_file (376,188,256 samples, 0.06%)</title><rect x="3097.2" y="2441" width="2.5" height="19.0" fill="rgb(247,197,47)" rx="2" ry="2" />
+<text  x="3100.20" y="2453.5" ></text>
+</g>
+<g >
+<title>_IO_do_write@@GLIBC_2.2.5 (1,019,822,850 samples, 0.16%)</title><rect x="3895.9" y="2461" width="6.7" height="19.0" fill="rgb(238,155,37)" rx="2" ry="2" />
+<text  x="3898.88" y="2473.5" ></text>
+</g>
+<g >
+<title>lookup_fast (227,115,274 samples, 0.04%)</title><rect x="3322.1" y="2221" width="1.4" height="19.0" fill="rgb(226,97,23)" rx="2" ry="2" />
+<text  x="3325.06" y="2233.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (823,963,614 samples, 0.13%)</title><rect x="895.4" y="421" width="5.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.39" y="433.5" ></text>
+</g>
+<g >
+<title>execute_command (158,744,410 samples, 0.02%)</title><rect x="875.9" y="1281" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="878.93" y="1293.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (241,866,356 samples, 0.04%)</title><rect x="196.6" y="2361" width="1.6" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="199.62" y="2373.5" ></text>
+</g>
+<g >
+<title>execute_command (516,725,798 samples, 0.08%)</title><rect x="856.9" y="2521" width="3.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="859.92" y="2533.5" ></text>
+</g>
+<g >
+<title>execute_command (861,612,432 samples, 0.13%)</title><rect x="301.2" y="761" width="5.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="304.16" y="773.5" ></text>
+</g>
+<g >
+<title>execute_command (576,411,126 samples, 0.09%)</title><rect x="891.4" y="361" width="3.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="894.42" y="373.5" ></text>
+</g>
+<g >
+<title>__fread_unlocked_chk (4,471,868,195 samples, 0.70%)</title><rect x="1609.2" y="2481" width="29.3" height="19.0" fill="rgb(225,94,22)" rx="2" ry="2" />
+<text  x="1612.19" y="2493.5" >__..</text>
+</g>
+<g >
+<title>execute_command_internal (356,134,455 samples, 0.06%)</title><rect x="840.5" y="1521" width="2.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="843.47" y="1533.5" ></text>
+</g>
+<g >
+<title>execute_command (13,256,971,382 samples, 2.08%)</title><rect x="307.9" y="1341" width="86.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="310.95" y="1353.5" >execute_co..</text>
+</g>
+<g >
+<title>execute_command_internal (512,251,839 samples, 0.08%)</title><rect x="856.9" y="701" width="3.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="859.94" y="713.5" ></text>
+</g>
+<g >
+<title>[bash] (62,845,347,232 samples, 9.84%)</title><rect x="395.1" y="1781" width="411.4" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="398.09" y="1793.5" >[bash]</text>
+</g>
+<g >
+<title>execute_command_internal (157,733,729 samples, 0.02%)</title><rect x="296.5" y="281" width="1.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.51" y="293.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,066,371,179 samples, 0.17%)</title><rect x="861.5" y="381" width="7.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="864.52" y="393.5" ></text>
+</g>
+<g >
+<title>[bash] (598,514,664 samples, 0.09%)</title><rect x="891.4" y="2561" width="3.9" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="894.40" y="2573.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (436,055,112 samples, 0.07%)</title><rect x="888.5" y="2101" width="2.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="891.55" y="2113.5" ></text>
+</g>
+<g >
+<title>execute_command (844,832,793 samples, 0.13%)</title><rect x="301.2" y="361" width="5.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="304.16" y="373.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (4,258,113,902 samples, 0.67%)</title><rect x="3905.6" y="2381" width="27.9" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="3908.59" y="2393.5" >d..</text>
+</g>
+<g >
+<title>execute_command_internal (163,954,022 samples, 0.03%)</title><rect x="870.8" y="861" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="873.82" y="873.5" ></text>
+</g>
+<g >
+<title>__GI___libc_open (2,811,936,883 samples, 0.44%)</title><rect x="2125.7" y="2401" width="18.4" height="19.0" fill="rgb(249,202,48)" rx="2" ry="2" />
+<text  x="2128.73" y="2413.5" ></text>
+</g>
+<g >
+<title>syscall_return_via_sysret (207,309,532 samples, 0.03%)</title><rect x="2641.7" y="2481" width="1.4" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="2644.74" y="2493.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (341,764,870 samples, 0.05%)</title><rect x="868.6" y="1621" width="2.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="871.57" y="1633.5" ></text>
+</g>
+<g >
+<title>[bash] (3,027,377,465 samples, 0.47%)</title><rect x="615.1" y="1301" width="19.8" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="618.10" y="1313.5" ></text>
+</g>
+<g >
+<title>__GI___libc_open (3,481,811,100 samples, 0.55%)</title><rect x="3313.3" y="2401" width="22.8" height="19.0" fill="rgb(249,202,48)" rx="2" ry="2" />
+<text  x="3316.30" y="2413.5" >_..</text>
+</g>
+<g >
+<title>_int_malloc (193,123,621 samples, 0.03%)</title><rect x="582.6" y="1241" width="1.2" height="19.0" fill="rgb(215,47,11)" rx="2" ry="2" />
+<text  x="585.57" y="1253.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (516,725,798 samples, 0.08%)</title><rect x="856.9" y="1621" width="3.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="859.92" y="1633.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (159,710,185 samples, 0.03%)</title><rect x="875.9" y="1701" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="878.92" y="1713.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (13,306,226,362 samples, 2.08%)</title><rect x="307.9" y="1681" width="87.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="310.94" y="1693.5" >execute_co..</text>
+</g>
+<g >
+<title>execute_command (483,985,097 samples, 0.08%)</title><rect x="276.9" y="2021" width="3.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="279.92" y="2033.5" ></text>
+</g>
+<g >
+<title>execute_command (354,998,378 samples, 0.06%)</title><rect x="840.5" y="1181" width="2.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="843.48" y="1193.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (218,392,535 samples, 0.03%)</title><rect x="280.1" y="321" width="1.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.11" y="333.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (321,429,063 samples, 0.05%)</title><rect x="410.3" y="1101" width="2.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="413.31" y="1113.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (169,651,850 samples, 0.03%)</title><rect x="871.9" y="821" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="874.90" y="833.5" ></text>
+</g>
+<g >
+<title>redirection_expand (158,599,791 samples, 0.02%)</title><rect x="875.9" y="761" width="1.1" height="19.0" fill="rgb(218,63,15)" rx="2" ry="2" />
+<text  x="878.93" y="773.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (688,777,208 samples, 0.11%)</title><rect x="268.8" y="1941" width="4.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="271.77" y="1953.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (843,061,254 samples, 0.13%)</title><rect x="895.4" y="1221" width="5.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.39" y="1233.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,263,560,140 samples, 0.20%)</title><rect x="860.3" y="1881" width="8.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.30" y="1893.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (436,518,985 samples, 0.07%)</title><rect x="888.5" y="2541" width="2.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="891.54" y="2553.5" ></text>
+</g>
+<g >
+<title>execute_command (13,307,198,782 samples, 2.08%)</title><rect x="307.9" y="1821" width="87.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="310.94" y="1833.5" >execute_co..</text>
+</g>
+<g >
+<title>execute_command (16,896,043,062 samples, 2.65%)</title><rect x="398.9" y="1261" width="110.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="401.91" y="1273.5" >execute_command</text>
+</g>
+<g >
+<title>[bash] (667,759,614 samples, 0.10%)</title><rect x="310.3" y="541" width="4.4" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="313.29" y="553.5" ></text>
+</g>
+<g >
+<title>fclose@@GLIBC_2.2.5 (1,029,235,930 samples, 0.16%)</title><rect x="3372.3" y="2481" width="6.7" height="19.0" fill="rgb(251,213,51)" rx="2" ry="2" />
+<text  x="3375.28" y="2493.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (511,757,677 samples, 0.08%)</title><rect x="885.0" y="501" width="3.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="888.05" y="513.5" ></text>
+</g>
+<g >
+<title>entry_SYSRETQ_unsafe_stack (436,997,419 samples, 0.07%)</title><rect x="2075.7" y="2441" width="2.8" height="19.0" fill="rgb(213,37,8)" rx="2" ry="2" />
+<text  x="2078.68" y="2453.5" ></text>
+</g>
+<g >
+<title>lookup_fast (160,866,575 samples, 0.03%)</title><rect x="1597.8" y="2221" width="1.1" height="19.0" fill="rgb(226,97,23)" rx="2" ry="2" />
+<text  x="1600.84" y="2233.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (872,429,608 samples, 0.14%)</title><rect x="328.8" y="561" width="5.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="331.75" y="573.5" ></text>
+</g>
+<g >
+<title>__printf_buffer (2,168,112,378 samples, 0.34%)</title><rect x="3395.1" y="2461" width="14.2" height="19.0" fill="rgb(219,68,16)" rx="2" ry="2" />
+<text  x="3398.08" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (180,216,075 samples, 0.03%)</title><rect x="878.5" y="1861" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="881.48" y="1873.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (686,486,049 samples, 0.11%)</title><rect x="268.8" y="1181" width="4.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="271.78" y="1193.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (432,872,015 samples, 0.07%)</title><rect x="888.6" y="821" width="2.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="891.57" y="833.5" ></text>
+</g>
+<g >
+<title>perf_try_init_event (260,266,049 samples, 0.04%)</title><rect x="704.7" y="1101" width="1.7" height="19.0" fill="rgb(246,191,45)" rx="2" ry="2" />
+<text  x="707.72" y="1113.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,793,310,882 samples, 0.28%)</title><rect x="835.1" y="2041" width="11.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="838.10" y="2053.5" ></text>
+</g>
+<g >
+<title>[bash] (417,109,693 samples, 0.07%)</title><rect x="298.2" y="241" width="2.7" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="301.19" y="253.5" ></text>
+</g>
+<g >
+<title>[bash] (717,313,739 samples, 0.11%)</title><rect x="280.1" y="2481" width="4.7" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="283.09" y="2493.5" ></text>
+</g>
+<g >
+<title>[bash] (179,777,548 samples, 0.03%)</title><rect x="878.5" y="861" width="1.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="881.48" y="873.5" ></text>
+</g>
+<g >
+<title>[bash] (659,372,368 samples, 0.10%)</title><rect x="852.5" y="301" width="4.3" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="855.47" y="313.5" ></text>
+</g>
+<g >
+<title>_IO_file_xsgetn (768,035,017 samples, 0.12%)</title><rect x="1437.9" y="2421" width="5.1" height="19.0" fill="rgb(207,11,2)" rx="2" ry="2" />
+<text  x="1440.92" y="2433.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (481,813,209 samples, 0.08%)</title><rect x="276.9" y="1261" width="3.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="279.93" y="1273.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (323,026,366 samples, 0.05%)</title><rect x="868.7" y="1301" width="2.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="871.70" y="1313.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (575,800,354 samples, 0.09%)</title><rect x="884.6" y="1501" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="887.64" y="1513.5" ></text>
+</g>
+<g >
+<title>redirection_expand (179,777,548 samples, 0.03%)</title><rect x="878.5" y="881" width="1.2" height="19.0" fill="rgb(218,63,15)" rx="2" ry="2" />
+<text  x="881.48" y="893.5" ></text>
+</g>
+<g >
+<title>execute_command (436,055,112 samples, 0.07%)</title><rect x="888.5" y="1641" width="2.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="891.55" y="1653.5" ></text>
+</g>
+<g >
+<title>realloc (345,890,766 samples, 0.05%)</title><rect x="647.9" y="1321" width="2.2" height="19.0" fill="rgb(246,189,45)" rx="2" ry="2" />
+<text  x="650.88" y="1333.5" ></text>
+</g>
+<g >
+<title>execute_command (592,880,892 samples, 0.09%)</title><rect x="891.4" y="561" width="3.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="894.42" y="573.5" ></text>
+</g>
+<g >
+<title>[bash] (354,911,948 samples, 0.06%)</title><rect x="840.5" y="761" width="2.3" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="843.48" y="773.5" ></text>
+</g>
+<g >
+<title>filemap_get_entry (269,001,110 samples, 0.04%)</title><rect x="2169.9" y="2321" width="1.8" height="19.0" fill="rgb(253,222,53)" rx="2" ry="2" />
+<text  x="2172.93" y="2333.5" ></text>
+</g>
+<g >
+<title>bpf_lsm_file_open (165,541,287 samples, 0.03%)</title><rect x="2558.3" y="2201" width="1.1" height="19.0" fill="rgb(227,105,25)" rx="2" ry="2" />
+<text  x="2561.32" y="2213.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (713,987,302 samples, 0.11%)</title><rect x="280.1" y="1121" width="4.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.11" y="1133.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (516,725,798 samples, 0.08%)</title><rect x="856.9" y="2141" width="3.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="859.92" y="2153.5" ></text>
+</g>
+<g >
+<title>new_do_write (512,140,133 samples, 0.08%)</title><rect x="1565.0" y="2461" width="3.4" height="19.0" fill="rgb(206,5,1)" rx="2" ry="2" />
+<text  x="1568.04" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command (890,006,400 samples, 0.14%)</title><rect x="851.1" y="1381" width="5.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="854.09" y="1393.5" ></text>
+</g>
+<g >
+<title>[bash] (354,911,948 samples, 0.06%)</title><rect x="840.5" y="721" width="2.3" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="843.48" y="733.5" ></text>
+</g>
+<g >
+<title>execute_command (679,254,761 samples, 0.11%)</title><rect x="268.8" y="521" width="4.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="271.79" y="533.5" ></text>
+</g>
+<g >
+<title>__x64_sys_execve (1,260,500,822 samples, 0.20%)</title><rect x="288.1" y="2521" width="8.2" height="19.0" fill="rgb(253,223,53)" rx="2" ry="2" />
+<text  x="291.10" y="2533.5" ></text>
+</g>
+<g >
+<title>fclose@@GLIBC_2.2.5 (951,739,830 samples, 0.15%)</title><rect x="2604.8" y="2481" width="6.3" height="19.0" fill="rgb(251,213,51)" rx="2" ry="2" />
+<text  x="2607.82" y="2493.5" ></text>
+</g>
+<g >
+<title>execute_command (322,256,264 samples, 0.05%)</title><rect x="868.7" y="1081" width="2.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="871.70" y="1093.5" ></text>
+</g>
+<g >
+<title>read (3,525,934,186 samples, 0.55%)</title><rect x="3047.7" y="2461" width="23.1" height="19.0" fill="rgb(252,216,51)" rx="2" ry="2" />
+<text  x="3050.73" y="2473.5" >r..</text>
+</g>
+<g >
+<title>[bash] (174,879,678 samples, 0.03%)</title><rect x="271.8" y="241" width="1.1" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="274.76" y="253.5" ></text>
+</g>
+<g >
+<title>execute_command (840,181,758 samples, 0.13%)</title><rect x="895.4" y="601" width="5.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="898.39" y="613.5" ></text>
+</g>
+<g >
+<title>execute_command (849,509,116 samples, 0.13%)</title><rect x="895.3" y="1961" width="5.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="898.35" y="1973.5" ></text>
+</g>
+<g >
+<title>__x64_sys_openat (2,911,208,650 samples, 0.46%)</title><rect x="3314.3" y="2341" width="19.1" height="19.0" fill="rgb(208,15,3)" rx="2" ry="2" />
+<text  x="3317.33" y="2353.5" ></text>
+</g>
+<g >
+<title>lookup_fast (235,283,352 samples, 0.04%)</title><rect x="4132.6" y="2241" width="1.6" height="19.0" fill="rgb(226,97,23)" rx="2" ry="2" />
+<text  x="4135.63" y="2253.5" ></text>
+</g>
+<g >
+<title>free_pages_and_swap_cache (675,196,587 samples, 0.11%)</title><rect x="812.8" y="2381" width="4.4" height="19.0" fill="rgb(229,112,26)" rx="2" ry="2" />
+<text  x="815.79" y="2393.5" ></text>
+</g>
+<g >
+<title>bpf_lsm_file_open (251,728,390 samples, 0.04%)</title><rect x="3927.4" y="2221" width="1.6" height="19.0" fill="rgb(227,105,25)" rx="2" ry="2" />
+<text  x="3930.39" y="2233.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (215,132,849 samples, 0.03%)</title><rect x="842.8" y="1201" width="1.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="845.81" y="1213.5" ></text>
+</g>
+<g >
+<title>ksys_read (2,441,436,782 samples, 0.38%)</title><rect x="3049.9" y="2401" width="16.0" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="3052.92" y="2413.5" ></text>
+</g>
+<g >
+<title>_dl_catch_exception (285,620,843 samples, 0.04%)</title><rect x="1579.5" y="2481" width="1.9" height="19.0" fill="rgb(253,223,53)" rx="2" ry="2" />
+<text  x="1582.52" y="2493.5" ></text>
+</g>
+<g >
+<title>execute_command (474,271,348 samples, 0.07%)</title><rect x="276.9" y="501" width="3.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="279.94" y="513.5" ></text>
+</g>
+<g >
+<title>execute_command (169,590,710 samples, 0.03%)</title><rect x="280.1" y="261" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="283.11" y="273.5" ></text>
+</g>
+<g >
+<title>execute_command (1,963,824,397 samples, 0.31%)</title><rect x="835.1" y="2221" width="12.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="838.10" y="2233.5" ></text>
+</g>
+<g >
+<title>execute_command (195,267,188 samples, 0.03%)</title><rect x="835.2" y="1021" width="1.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="838.18" y="1033.5" ></text>
+</g>
+<g >
+<title>execute_command (554,006,342 samples, 0.09%)</title><rect x="273.3" y="1861" width="3.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="276.29" y="1873.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (576,411,126 samples, 0.09%)</title><rect x="891.4" y="341" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.42" y="353.5" ></text>
+</g>
+<g >
+<title>execute_command (516,725,798 samples, 0.08%)</title><rect x="856.9" y="2481" width="3.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="859.92" y="2493.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,263,560,140 samples, 0.20%)</title><rect x="860.3" y="1801" width="8.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.30" y="1813.5" ></text>
+</g>
+<g >
+<title>execute_command (193,994,695 samples, 0.03%)</title><rect x="835.2" y="781" width="1.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="838.18" y="793.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (322,121,136 samples, 0.05%)</title><rect x="196.1" y="2381" width="2.1" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="199.09" y="2393.5" ></text>
+</g>
+<g >
+<title>_dl_start (1,065,482,964 samples, 0.17%)</title><rect x="1578.8" y="2561" width="7.0" height="19.0" fill="rgb(237,151,36)" rx="2" ry="2" />
+<text  x="1581.80" y="2573.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (554,006,342 samples, 0.09%)</title><rect x="273.3" y="2081" width="3.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="276.29" y="2093.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (575,800,354 samples, 0.09%)</title><rect x="884.6" y="1441" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="887.64" y="1453.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (3,235,381,632 samples, 0.51%)</title><rect x="4160.3" y="2481" width="21.2" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="4163.28" y="2493.5" ></text>
+</g>
+<g >
+<title>__do_sys_clone (442,577,833 samples, 0.07%)</title><rect x="862.9" y="121" width="2.9" height="19.0" fill="rgb(217,57,13)" rx="2" ry="2" />
+<text  x="865.91" y="133.5" ></text>
+</g>
+<g >
+<title>[unknown] (202,217,548 samples, 0.03%)</title><rect x="4034.0" y="2481" width="1.3" height="19.0" fill="rgb(210,24,5)" rx="2" ry="2" />
+<text  x="4037.01" y="2493.5" ></text>
+</g>
+<g >
+<title>execute_command (832,026,624 samples, 0.13%)</title><rect x="895.4" y="481" width="5.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="898.39" y="493.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,263,560,140 samples, 0.20%)</title><rect x="860.3" y="2281" width="8.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.30" y="2293.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (195,267,188 samples, 0.03%)</title><rect x="835.2" y="1041" width="1.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="838.18" y="1053.5" ></text>
+</g>
+<g >
+<title>ksys_read (2,904,849,047 samples, 0.45%)</title><rect x="3346.9" y="2401" width="19.0" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="3349.93" y="2413.5" ></text>
+</g>
+<g >
+<title>execute_command (688,777,208 samples, 0.11%)</title><rect x="268.8" y="1841" width="4.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="271.77" y="1853.5" ></text>
+</g>
+<g >
+<title>link_path_walk.part.0.constprop.0 (739,981,517 samples, 0.12%)</title><rect x="1594.0" y="2261" width="4.9" height="19.0" fill="rgb(254,229,54)" rx="2" ry="2" />
+<text  x="1597.05" y="2273.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (179,777,548 samples, 0.03%)</title><rect x="878.5" y="1301" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="881.48" y="1313.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (717,313,739 samples, 0.11%)</title><rect x="280.1" y="1921" width="4.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.09" y="1933.5" ></text>
+</g>
+<g >
+<title>[bash] (316,791,988 samples, 0.05%)</title><rect x="337.0" y="581" width="2.0" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="339.95" y="593.5" ></text>
+</g>
+<g >
+<title>execute_command (436,055,112 samples, 0.07%)</title><rect x="888.5" y="2001" width="2.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="891.55" y="2013.5" ></text>
+</g>
+<g >
+<title>[xxhsum] (19,179,633,295 samples, 3.00%)</title><rect x="4033.8" y="2501" width="125.5" height="19.0" fill="rgb(249,206,49)" rx="2" ry="2" />
+<text  x="4036.78" y="2513.5" >[xxhsum]</text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (284,304,276 samples, 0.04%)</title><rect x="4020.0" y="2501" width="1.9" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="4023.00" y="2513.5" ></text>
+</g>
+<g >
+<title>execute_command (279,063,315 samples, 0.04%)</title><rect x="351.7" y="581" width="1.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="354.69" y="593.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (550,598,300 samples, 0.09%)</title><rect x="273.3" y="1041" width="3.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="276.32" y="1053.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (158,744,410 samples, 0.02%)</title><rect x="875.9" y="1341" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="878.93" y="1353.5" ></text>
+</g>
+<g >
+<title>execute_command (866,614,713 samples, 0.14%)</title><rect x="301.1" y="2241" width="5.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="304.12" y="2253.5" ></text>
+</g>
+<g >
+<title>[unknown] (167,658,109 samples, 0.03%)</title><rect x="3903.0" y="2441" width="1.1" height="19.0" fill="rgb(210,24,5)" rx="2" ry="2" />
+<text  x="3905.96" y="2453.5" ></text>
+</g>
+<g >
+<title>execute_command (320,467,680 samples, 0.05%)</title><rect x="868.7" y="681" width="2.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="871.70" y="693.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (189,339,619 samples, 0.03%)</title><rect x="2639.2" y="2481" width="1.2" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="2642.21" y="2493.5" ></text>
+</g>
+<g >
+<title>expand_arith_string (264,044,592 samples, 0.04%)</title><rect x="390.9" y="441" width="1.7" height="19.0" fill="rgb(206,6,1)" rx="2" ry="2" />
+<text  x="393.90" y="453.5" ></text>
+</g>
+<g >
+<title>[bash] (467,551,161 samples, 0.07%)</title><rect x="857.2" y="381" width="3.1" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="860.22" y="393.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (5,698,523,301 samples, 0.89%)</title><rect x="4068.9" y="2421" width="37.3" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="4071.93" y="2433.5" >ent..</text>
+</g>
+<g >
+<title>execute_command (551,359,579 samples, 0.09%)</title><rect x="273.3" y="1501" width="3.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="276.31" y="1513.5" ></text>
+</g>
+<g >
+<title>execute_command (481,191,724 samples, 0.08%)</title><rect x="276.9" y="741" width="3.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="279.94" y="753.5" ></text>
+</g>
+<g >
+<title>getname_flags.part.0 (245,088,525 samples, 0.04%)</title><rect x="1604.4" y="2301" width="1.6" height="19.0" fill="rgb(213,39,9)" rx="2" ry="2" />
+<text  x="1607.38" y="2313.5" ></text>
+</g>
+<g >
+<title>[bash] (308,285,225 samples, 0.05%)</title><rect x="298.3" y="161" width="2.0" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="301.31" y="173.5" ></text>
+</g>
+<g >
+<title>execute_command (322,256,264 samples, 0.05%)</title><rect x="868.7" y="1121" width="2.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="871.70" y="1133.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (866,614,713 samples, 0.14%)</title><rect x="301.1" y="2361" width="5.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.12" y="2373.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (5,906,425,332 samples, 0.93%)</title><rect x="356.1" y="1261" width="38.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="359.06" y="1273.5" >exe..</text>
+</g>
+<g >
+<title>execute_command_internal (700,045,805 samples, 0.11%)</title><rect x="280.1" y="441" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.11" y="453.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (554,006,342 samples, 0.09%)</title><rect x="273.3" y="2201" width="3.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="276.29" y="2213.5" ></text>
+</g>
+<g >
+<title>alloc_empty_file (262,218,072 samples, 0.04%)</title><rect x="4123.1" y="2281" width="1.8" height="19.0" fill="rgb(215,49,11)" rx="2" ry="2" />
+<text  x="4126.15" y="2293.5" ></text>
+</g>
+<g >
+<title>lookup_fast (178,537,814 samples, 0.03%)</title><rect x="3030.4" y="2221" width="1.2" height="19.0" fill="rgb(226,97,23)" rx="2" ry="2" />
+<text  x="3033.42" y="2233.5" ></text>
+</g>
+<g >
+<title>[bash] (674,758,973 samples, 0.11%)</title><rect x="852.4" y="361" width="4.5" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="855.44" y="373.5" ></text>
+</g>
+<g >
+<title>shmem_file_read_iter (2,138,561,816 samples, 0.33%)</title><rect x="1446.7" y="2321" width="14.0" height="19.0" fill="rgb(238,152,36)" rx="2" ry="2" />
+<text  x="1449.67" y="2333.5" ></text>
+</g>
+<g >
+<title>do_dentry_open (580,387,981 samples, 0.09%)</title><rect x="1490.1" y="2241" width="3.8" height="19.0" fill="rgb(249,205,49)" rx="2" ry="2" />
+<text  x="1493.11" y="2253.5" ></text>
+</g>
+<g >
+<title>execute_command (578,068,287 samples, 0.09%)</title><rect x="884.6" y="1781" width="3.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="887.62" y="1793.5" ></text>
+</g>
+<g >
+<title>__fread_unlocked_chk (5,280,864,174 samples, 0.83%)</title><rect x="3337.4" y="2481" width="34.6" height="19.0" fill="rgb(225,94,22)" rx="2" ry="2" />
+<text  x="3340.43" y="2493.5" >__..</text>
+</g>
+<g >
+<title>[bash] (807,151,470 samples, 0.13%)</title><rect x="829.8" y="341" width="5.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="832.76" y="353.5" ></text>
+</g>
+<g >
+<title>perf_event_alloc (356,313,858 samples, 0.06%)</title><rect x="704.2" y="1121" width="2.3" height="19.0" fill="rgb(215,49,11)" rx="2" ry="2" />
+<text  x="707.20" y="1133.5" ></text>
+</g>
+<g >
+<title>parse_and_execute (284,005,982 samples, 0.04%)</title><rect x="832.8" y="241" width="1.9" height="19.0" fill="rgb(243,178,42)" rx="2" ry="2" />
+<text  x="835.81" y="253.5" ></text>
+</g>
+<g >
+<title>[bash] (76,555,707,463 samples, 11.99%)</title><rect x="306.9" y="2381" width="501.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="309.94" y="2393.5" >[bash]</text>
+</g>
+<g >
+<title>[bash] (165,105,872 samples, 0.03%)</title><rect x="871.9" y="421" width="1.1" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="874.92" y="433.5" ></text>
+</g>
+<g >
+<title>execute_command (866,614,713 samples, 0.14%)</title><rect x="301.1" y="2081" width="5.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="304.12" y="2093.5" ></text>
+</g>
+<g >
+<title>filemap_get_entry (211,529,536 samples, 0.03%)</title><rect x="1459.0" y="2281" width="1.4" height="19.0" fill="rgb(253,222,53)" rx="2" ry="2" />
+<text  x="1461.97" y="2293.5" ></text>
+</g>
+<g >
+<title>execute_command (516,725,798 samples, 0.08%)</title><rect x="856.9" y="2201" width="3.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="859.92" y="2213.5" ></text>
+</g>
+<g >
+<title>execute_command (713,521,499 samples, 0.11%)</title><rect x="296.5" y="1941" width="4.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="299.45" y="1953.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (686,486,049 samples, 0.11%)</title><rect x="268.8" y="1301" width="4.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="271.78" y="1313.5" ></text>
+</g>
+<g >
+<title>[bash] (481,813,209 samples, 0.08%)</title><rect x="276.9" y="1281" width="3.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="279.93" y="1293.5" ></text>
+</g>
+<g >
+<title>syscall_return_via_sysret (315,160,435 samples, 0.05%)</title><rect x="3935.1" y="2401" width="2.1" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="3938.14" y="2413.5" ></text>
+</g>
+<g >
+<title>copy_process (179,813,516 samples, 0.03%)</title><rect x="273.8" y="241" width="1.2" height="19.0" fill="rgb(239,160,38)" rx="2" ry="2" />
+<text  x="276.84" y="253.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (158,741,628 samples, 0.02%)</title><rect x="836.5" y="621" width="1.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="839.50" y="633.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (166,042,857 samples, 0.03%)</title><rect x="836.5" y="1521" width="1.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="839.46" y="1533.5" ></text>
+</g>
+<g >
+<title>read (3,489,271,332 samples, 0.55%)</title><rect x="200.3" y="2441" width="22.8" height="19.0" fill="rgb(252,216,51)" rx="2" ry="2" />
+<text  x="203.29" y="2453.5" >r..</text>
+</g>
+<g >
+<title>execute_command (2,156,220,174 samples, 0.34%)</title><rect x="835.1" y="2341" width="14.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="838.10" y="2353.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (866,614,713 samples, 0.14%)</title><rect x="301.1" y="1541" width="5.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.12" y="1553.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (513,954,307 samples, 0.08%)</title><rect x="856.9" y="1521" width="3.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="859.94" y="1533.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (713,521,499 samples, 0.11%)</title><rect x="296.5" y="1601" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.45" y="1613.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (596,118,643 samples, 0.09%)</title><rect x="891.4" y="1121" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.42" y="1133.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,146,830,397 samples, 0.18%)</title><rect x="827.6" y="901" width="7.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.59" y="913.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (866,614,713 samples, 0.14%)</title><rect x="301.1" y="1781" width="5.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.12" y="1793.5" ></text>
+</g>
+<g >
+<title>[bash] (1,263,560,140 samples, 0.20%)</title><rect x="860.3" y="2501" width="8.3" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="863.30" y="2513.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (332,204,411 samples, 0.05%)</title><rect x="1610.4" y="2401" width="2.1" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="1613.36" y="2413.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (432,872,015 samples, 0.07%)</title><rect x="888.6" y="861" width="2.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="891.57" y="873.5" ></text>
+</g>
+<g >
+<title>fclose@@GLIBC_2.2.5 (1,375,258,204 samples, 0.22%)</title><rect x="4150.0" y="2481" width="9.0" height="19.0" fill="rgb(251,213,51)" rx="2" ry="2" />
+<text  x="4152.97" y="2493.5" ></text>
+</g>
+<g >
+<title>execute_command (550,598,300 samples, 0.09%)</title><rect x="273.3" y="1181" width="3.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="276.32" y="1193.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,263,560,140 samples, 0.20%)</title><rect x="860.3" y="2121" width="8.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.30" y="2133.5" ></text>
+</g>
+<g >
+<title>entry_SYSRETQ_unsafe_stack (259,941,400 samples, 0.04%)</title><rect x="4008.0" y="2461" width="1.7" height="19.0" fill="rgb(213,37,8)" rx="2" ry="2" />
+<text  x="4010.96" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command (322,256,264 samples, 0.05%)</title><rect x="868.7" y="1201" width="2.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="871.70" y="1213.5" ></text>
+</g>
+<g >
+<title>selinux_inode_permission (554,042,762 samples, 0.09%)</title><rect x="1477.0" y="2221" width="3.6" height="19.0" fill="rgb(238,156,37)" rx="2" ry="2" />
+<text  x="1480.01" y="2233.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (705,583,873 samples, 0.11%)</title><rect x="296.5" y="1241" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.50" y="1253.5" ></text>
+</g>
+<g >
+<title>execute_command (1,146,830,397 samples, 0.18%)</title><rect x="827.6" y="721" width="7.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="830.59" y="733.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (574,909,828 samples, 0.09%)</title><rect x="884.6" y="681" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="887.64" y="693.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (194,148,063 samples, 0.03%)</title><rect x="837.5" y="1601" width="1.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="840.54" y="1613.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (7,228,971,938 samples, 1.13%)</title><rect x="308.5" y="1081" width="47.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="311.54" y="1093.5" >exec..</text>
+</g>
+<g >
+<title>execute_command (433,500,595 samples, 0.07%)</title><rect x="888.6" y="1401" width="2.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="891.56" y="1413.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (686,486,049 samples, 0.11%)</title><rect x="268.8" y="1381" width="4.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="271.78" y="1393.5" ></text>
+</g>
+<g >
+<title>__libc_start_main@@GLIBC_2.34 (17,640,558,494 samples, 2.76%)</title><rect x="3310.0" y="2561" width="115.5" height="19.0" fill="rgb(229,113,27)" rx="2" ry="2" />
+<text  x="3313.02" y="2573.5" >__libc_start_m..</text>
+</g>
+<g >
+<title>execute_command_internal (166,042,857 samples, 0.03%)</title><rect x="836.5" y="1321" width="1.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="839.46" y="1333.5" ></text>
+</g>
+<g >
+<title>execute_command (550,598,300 samples, 0.09%)</title><rect x="273.3" y="901" width="3.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="276.32" y="913.5" ></text>
+</g>
+<g >
+<title>execute_command (179,777,548 samples, 0.03%)</title><rect x="878.5" y="1521" width="1.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="881.48" y="1533.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (2,276,144,711 samples, 0.36%)</title><rect x="868.6" y="2381" width="14.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="871.57" y="2393.5" ></text>
+</g>
+<g >
+<title>execute_command (717,313,739 samples, 0.11%)</title><rect x="280.1" y="2021" width="4.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="283.09" y="2033.5" ></text>
+</g>
+<g >
+<title>__handle_mm_fault (448,060,808 samples, 0.07%)</title><rect x="724.8" y="1181" width="2.9" height="19.0" fill="rgb(213,39,9)" rx="2" ry="2" />
+<text  x="727.78" y="1193.5" ></text>
+</g>
+<g >
+<title>_copy_to_iter (1,684,640,767 samples, 0.26%)</title><rect x="1619.4" y="2321" width="11.0" height="19.0" fill="rgb(234,134,32)" rx="2" ry="2" />
+<text  x="1622.38" y="2333.5" ></text>
+</g>
+<g >
+<title>execute_command (164,731,865 samples, 0.03%)</title><rect x="836.5" y="1181" width="1.0" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="839.46" y="1193.5" ></text>
+</g>
+<g >
+<title>execute_command (575,055,300 samples, 0.09%)</title><rect x="884.6" y="821" width="3.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="887.64" y="833.5" ></text>
+</g>
+<g >
+<title>[bash] (40,934,425,281 samples, 6.41%)</title><rect x="514.8" y="1381" width="268.0" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="517.80" y="1393.5" >[bash]</text>
+</g>
+<g >
+<title>kmem_cache_alloc_noprof (323,449,358 samples, 0.05%)</title><rect x="1494.2" y="2281" width="2.1" height="19.0" fill="rgb(205,0,0)" rx="2" ry="2" />
+<text  x="1497.22" y="2293.5" ></text>
+</g>
+<g >
+<title>alloc_word_desc (260,592,759 samples, 0.04%)</title><rect x="580.2" y="1281" width="1.7" height="19.0" fill="rgb(208,16,3)" rx="2" ry="2" />
+<text  x="583.18" y="1293.5" ></text>
+</g>
+<g >
+<title>[bash] (713,987,302 samples, 0.11%)</title><rect x="280.1" y="1161" width="4.7" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="283.11" y="1173.5" ></text>
+</g>
+<g >
+<title>[bash] (171,847,094 samples, 0.03%)</title><rect x="871.9" y="1481" width="1.1" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="874.89" y="1493.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (891,895,571 samples, 0.14%)</title><rect x="851.1" y="1481" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.08" y="1493.5" ></text>
+</g>
+<g >
+<title>execute_command (341,764,870 samples, 0.05%)</title><rect x="868.6" y="1641" width="2.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="871.57" y="1653.5" ></text>
+</g>
+<g >
+<title>execute_command (866,614,713 samples, 0.14%)</title><rect x="301.1" y="2281" width="5.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="304.12" y="2293.5" ></text>
+</g>
+<g >
+<title>execute_command (713,987,302 samples, 0.11%)</title><rect x="280.1" y="1061" width="4.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="283.11" y="1073.5" ></text>
+</g>
+<g >
+<title>__tlb_batch_free_encoded_pages (399,330,573 samples, 0.06%)</title><rect x="290.2" y="2361" width="2.6" height="19.0" fill="rgb(212,33,8)" rx="2" ry="2" />
+<text  x="293.17" y="2373.5" ></text>
+</g>
+<g >
+<title>selinux_inode_permission (342,006,911 samples, 0.05%)</title><rect x="2027.6" y="2221" width="2.2" height="19.0" fill="rgb(238,156,37)" rx="2" ry="2" />
+<text  x="2030.60" y="2233.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (164,072,262 samples, 0.03%)</title><rect x="836.5" y="641" width="1.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="839.46" y="653.5" ></text>
+</g>
+<g >
+<title>execute_command (548,788,616 samples, 0.09%)</title><rect x="273.3" y="621" width="3.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="276.32" y="633.5" ></text>
+</g>
+<g >
+<title>execute_command (193,792,882 samples, 0.03%)</title><rect x="835.2" y="621" width="1.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="838.18" y="633.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (215,132,849 samples, 0.03%)</title><rect x="842.8" y="921" width="1.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="845.81" y="933.5" ></text>
+</g>
+<g >
+<title>[bash] (436,518,985 samples, 0.07%)</title><rect x="888.5" y="2521" width="2.9" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="891.54" y="2533.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (862,395,726 samples, 0.14%)</title><rect x="301.2" y="981" width="5.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.15" y="993.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (891,895,571 samples, 0.14%)</title><rect x="851.1" y="1601" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.08" y="1613.5" ></text>
+</g>
+<g >
+<title>_IO_file_xsputn@@GLIBC_2.2.5 (171,029,348 samples, 0.03%)</title><rect x="3097.9" y="2421" width="1.2" height="19.0" fill="rgb(242,171,41)" rx="2" ry="2" />
+<text  x="3100.94" y="2433.5" ></text>
+</g>
+<g >
+<title>execute_command (717,313,739 samples, 0.11%)</title><rect x="280.1" y="2101" width="4.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="283.09" y="2113.5" ></text>
+</g>
+<g >
+<title>execute_command (862,395,726 samples, 0.14%)</title><rect x="301.2" y="1001" width="5.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="304.15" y="1013.5" ></text>
+</g>
+<g >
+<title>do_redirections (343,594,175 samples, 0.05%)</title><rect x="889.1" y="441" width="2.3" height="19.0" fill="rgb(247,193,46)" rx="2" ry="2" />
+<text  x="892.10" y="453.5" ></text>
+</g>
+<g >
+<title>execute_command (713,462,810 samples, 0.11%)</title><rect x="280.1" y="941" width="4.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="283.11" y="953.5" ></text>
+</g>
+<g >
+<title>_Fork (460,799,632 samples, 0.07%)</title><rect x="862.9" y="181" width="3.0" height="19.0" fill="rgb(252,220,52)" rx="2" ry="2" />
+<text  x="865.89" y="193.5" ></text>
+</g>
+<g >
+<title>execute_command (688,777,208 samples, 0.11%)</title><rect x="268.8" y="1721" width="4.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="271.77" y="1733.5" ></text>
+</g>
+<g >
+<title>[bash] (860,104,616 samples, 0.13%)</title><rect x="829.4" y="381" width="5.7" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="832.44" y="393.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (323,026,366 samples, 0.05%)</title><rect x="868.7" y="1601" width="2.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="871.70" y="1613.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (195,916,485 samples, 0.03%)</title><rect x="835.2" y="1481" width="1.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="838.17" y="1493.5" ></text>
+</g>
+<g >
+<title>execute_command (436,055,112 samples, 0.07%)</title><rect x="888.5" y="2081" width="2.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="891.55" y="2093.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (278,095,596 samples, 0.04%)</title><rect x="383.1" y="301" width="1.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="386.10" y="313.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (689,552,686 samples, 0.11%)</title><rect x="296.5" y="361" width="4.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.51" y="373.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (343,144,668 samples, 0.05%)</title><rect x="1639.4" y="2441" width="2.2" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="1642.37" y="2453.5" ></text>
+</g>
+<g >
+<title>execute_command (861,612,432 samples, 0.13%)</title><rect x="301.2" y="641" width="5.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="304.16" y="653.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (595,672,870 samples, 0.09%)</title><rect x="891.4" y="821" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.42" y="833.5" ></text>
+</g>
+<g >
+<title>execute_command (215,132,849 samples, 0.03%)</title><rect x="842.8" y="1221" width="1.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="845.81" y="1233.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (2,129,461,443 samples, 0.33%)</title><rect x="694.2" y="1281" width="14.0" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="697.23" y="1293.5" ></text>
+</g>
+<g >
+<title>execute_command (432,726,851 samples, 0.07%)</title><rect x="888.6" y="681" width="2.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="891.57" y="693.5" ></text>
+</g>
+<g >
+<title>execute_command (849,509,116 samples, 0.13%)</title><rect x="895.3" y="1601" width="5.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="898.35" y="1613.5" ></text>
+</g>
+<g >
+<title>execute_command (436,055,112 samples, 0.07%)</title><rect x="888.5" y="2401" width="2.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="891.55" y="2413.5" ></text>
+</g>
+<g >
+<title>execute_command (322,256,264 samples, 0.05%)</title><rect x="868.7" y="841" width="2.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="871.70" y="853.5" ></text>
+</g>
+<g >
+<title>execute_command (554,006,342 samples, 0.09%)</title><rect x="273.3" y="1701" width="3.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="276.29" y="1713.5" ></text>
+</g>
+<g >
+<title>__libc_start_call_main (14,646,479,590 samples, 2.29%)</title><rect x="2019.4" y="2541" width="95.9" height="19.0" fill="rgb(210,26,6)" rx="2" ry="2" />
+<text  x="2022.39" y="2553.5" >__libc_star..</text>
+</g>
+<g >
+<title>__d_lookup_rcu (339,417,754 samples, 0.05%)</title><rect x="1483.4" y="2241" width="2.3" height="19.0" fill="rgb(235,139,33)" rx="2" ry="2" />
+<text  x="1486.44" y="2253.5" ></text>
+</g>
+<g >
+<title>evalexp (163,428,151 samples, 0.03%)</title><rect x="389.3" y="441" width="1.1" height="19.0" fill="rgb(223,84,20)" rx="2" ry="2" />
+<text  x="392.28" y="453.5" ></text>
+</g>
+<g >
+<title>execute_command (157,733,729 samples, 0.02%)</title><rect x="296.5" y="301" width="1.0" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="299.51" y="313.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,147,316,451 samples, 0.18%)</title><rect x="827.6" y="1401" width="7.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.59" y="1413.5" ></text>
+</g>
+<g >
+<title>execute_command (76,163,354,412 samples, 11.93%)</title><rect x="307.9" y="2101" width="498.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="310.93" y="2113.5" >execute_command</text>
+</g>
+<g >
+<title>execute_command_internal (76,204,635,631 samples, 11.93%)</title><rect x="307.9" y="2201" width="498.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="310.93" y="2213.5" >execute_command_internal</text>
+</g>
+<g >
+<title>__strchrnul_evex (225,283,168 samples, 0.04%)</title><rect x="2636.1" y="2461" width="1.5" height="19.0" fill="rgb(239,159,38)" rx="2" ry="2" />
+<text  x="2639.13" y="2473.5" ></text>
+</g>
+<g >
+<title>[md5sum] (2,841,595,972 samples, 0.45%)</title><rect x="1590.4" y="2481" width="18.6" height="19.0" fill="rgb(229,113,27)" rx="2" ry="2" />
+<text  x="1593.40" y="2493.5" ></text>
+</g>
+<g >
+<title>__strlen_evex (279,344,981 samples, 0.04%)</title><rect x="659.5" y="1301" width="1.8" height="19.0" fill="rgb(240,164,39)" rx="2" ry="2" />
+<text  x="662.46" y="1313.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (598,514,664 samples, 0.09%)</title><rect x="891.4" y="1501" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.40" y="1513.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (193,792,882 samples, 0.03%)</title><rect x="835.2" y="601" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="838.18" y="613.5" ></text>
+</g>
+<g >
+<title>execute_command (897,666,085 samples, 0.14%)</title><rect x="868.6" y="1801" width="5.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="871.57" y="1813.5" ></text>
+</g>
+<g >
+<title>__GI___libc_open (156,249,627 samples, 0.02%)</title><rect x="1467.4" y="2401" width="1.0" height="19.0" fill="rgb(249,202,48)" rx="2" ry="2" />
+<text  x="1470.41" y="2413.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (323,026,366 samples, 0.05%)</title><rect x="868.7" y="1421" width="2.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="871.70" y="1433.5" ></text>
+</g>
+<g >
+<title>execute_command (264,069,883 samples, 0.04%)</title><rect x="827.6" y="281" width="1.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="830.59" y="293.5" ></text>
+</g>
+<g >
+<title>_int_malloc (241,276,185 samples, 0.04%)</title><rect x="630.2" y="1261" width="1.6" height="19.0" fill="rgb(215,47,11)" rx="2" ry="2" />
+<text  x="633.18" y="1273.5" ></text>
+</g>
+<g >
+<title>execute_command (595,672,870 samples, 0.09%)</title><rect x="891.4" y="761" width="3.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="894.42" y="773.5" ></text>
+</g>
+<g >
+<title>_int_free (2,919,421,757 samples, 0.46%)</title><rect x="758.4" y="1321" width="19.1" height="19.0" fill="rgb(247,196,46)" rx="2" ry="2" />
+<text  x="761.43" y="1333.5" ></text>
+</g>
+<g >
+<title>execute_command (76,556,548,766 samples, 11.99%)</title><rect x="306.9" y="2441" width="501.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="309.94" y="2453.5" >execute_command</text>
+</g>
+<g >
+<title>[bash] (218,110,314 samples, 0.03%)</title><rect x="325.3" y="521" width="1.5" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="328.33" y="533.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (694,326,527 samples, 0.11%)</title><rect x="280.1" y="361" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.11" y="373.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (170,489,782 samples, 0.03%)</title><rect x="871.9" y="1221" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="874.90" y="1233.5" ></text>
+</g>
+<g >
+<title>[bash] (861,612,432 samples, 0.13%)</title><rect x="301.2" y="941" width="5.6" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="304.16" y="953.5" ></text>
+</g>
+<g >
+<title>[sha224sum] (12,990,573,871 samples, 2.03%)</title><rect x="2123.3" y="2581" width="85.0" height="19.0" fill="rgb(248,201,48)" rx="2" ry="2" />
+<text  x="2126.27" y="2593.5" >[sha224sum]</text>
+</g>
+<g >
+<title>__GI___execve (1,618,869,264 samples, 0.25%)</title><rect x="662.1" y="1341" width="10.6" height="19.0" fill="rgb(230,117,28)" rx="2" ry="2" />
+<text  x="665.07" y="1353.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (215,132,849 samples, 0.03%)</title><rect x="842.8" y="1241" width="1.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="845.81" y="1253.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (158,744,410 samples, 0.02%)</title><rect x="875.9" y="1381" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="878.93" y="1393.5" ></text>
+</g>
+<g >
+<title>execute_command (183,798,433 samples, 0.03%)</title><rect x="860.3" y="381" width="1.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="863.32" y="393.5" ></text>
+</g>
+<g >
+<title>malloc (508,187,326 samples, 0.08%)</title><rect x="643.1" y="1281" width="3.3" height="19.0" fill="rgb(230,119,28)" rx="2" ry="2" />
+<text  x="646.06" y="1293.5" ></text>
+</g>
+<g >
+<title>execute_command (717,313,739 samples, 0.11%)</title><rect x="280.1" y="1981" width="4.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="283.09" y="1993.5" ></text>
+</g>
+<g >
+<title>execute_command (1,143,630,623 samples, 0.18%)</title><rect x="827.6" y="481" width="7.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="830.59" y="493.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,150,422,968 samples, 0.18%)</title><rect x="827.6" y="1541" width="7.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.57" y="1553.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,662,235,493 samples, 0.26%)</title><rect x="316.2" y="681" width="10.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="319.22" y="693.5" ></text>
+</g>
+<g >
+<title>[bash] (2,455,040,554 samples, 0.38%)</title><rect x="268.7" y="2581" width="16.1" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="271.73" y="2593.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (575,055,300 samples, 0.09%)</title><rect x="884.6" y="1081" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="887.64" y="1093.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (588,487,519 samples, 0.09%)</title><rect x="388.8" y="461" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="391.83" y="473.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (685,976,378 samples, 0.11%)</title><rect x="268.8" y="701" width="4.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="271.79" y="713.5" ></text>
+</g>
+<g >
+<title>execute_command (481,191,724 samples, 0.08%)</title><rect x="276.9" y="981" width="3.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="279.94" y="993.5" ></text>
+</g>
+<g >
+<title>execute_command (180,216,075 samples, 0.03%)</title><rect x="878.5" y="1981" width="1.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="881.48" y="1993.5" ></text>
+</g>
+<g >
+<title>do_sys_openat2 (2,217,092,716 samples, 0.35%)</title><rect x="3024.6" y="2321" width="14.5" height="19.0" fill="rgb(209,21,5)" rx="2" ry="2" />
+<text  x="3027.56" y="2333.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (321,220,297 samples, 0.05%)</title><rect x="1438.9" y="2361" width="2.1" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="1441.88" y="2373.5" ></text>
+</g>
+<g >
+<title>execute_command (163,563,240 samples, 0.03%)</title><rect x="870.8" y="841" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="873.82" y="853.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (308,775,933 samples, 0.05%)</title><rect x="3339.5" y="2381" width="2.0" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="3342.51" y="2393.5" ></text>
+</g>
+<g >
+<title>walk_component (196,580,416 samples, 0.03%)</title><rect x="2132.6" y="2241" width="1.3" height="19.0" fill="rgb(247,197,47)" rx="2" ry="2" />
+<text  x="2135.60" y="2253.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (159,710,185 samples, 0.03%)</title><rect x="875.9" y="1781" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="878.92" y="1793.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (843,061,254 samples, 0.13%)</title><rect x="895.4" y="1361" width="5.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.39" y="1373.5" ></text>
+</g>
+<g >
+<title>[bash] (192,670,319 samples, 0.03%)</title><rect x="837.6" y="1321" width="1.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="840.55" y="1333.5" ></text>
+</g>
+<g >
+<title>__mmput (194,719,319 samples, 0.03%)</title><rect x="1585.8" y="2461" width="1.3" height="19.0" fill="rgb(205,3,0)" rx="2" ry="2" />
+<text  x="1588.83" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (685,976,378 samples, 0.11%)</title><rect x="268.8" y="741" width="4.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="271.79" y="753.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (551,359,579 samples, 0.09%)</title><rect x="273.3" y="1541" width="3.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="276.31" y="1553.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (156,502,882 samples, 0.02%)</title><rect x="392.7" y="541" width="1.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="395.72" y="553.5" ></text>
+</g>
+<g >
+<title>[bash] (183,863,901 samples, 0.03%)</title><rect x="890.0" y="261" width="1.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="892.97" y="273.5" ></text>
+</g>
+<g >
+<title>redirection_expand (525,556,686 samples, 0.08%)</title><rect x="897.3" y="281" width="3.4" height="19.0" fill="rgb(218,63,15)" rx="2" ry="2" />
+<text  x="900.29" y="293.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (516,725,798 samples, 0.08%)</title><rect x="856.9" y="1661" width="3.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="859.92" y="1673.5" ></text>
+</g>
+<g >
+<title>_dl_map_object (195,917,389 samples, 0.03%)</title><rect x="3015.9" y="2441" width="1.3" height="19.0" fill="rgb(248,199,47)" rx="2" ry="2" />
+<text  x="3018.87" y="2453.5" ></text>
+</g>
+<g >
+<title>__fopen_internal (5,369,105,666 samples, 0.84%)</title><rect x="3902.7" y="2481" width="35.2" height="19.0" fill="rgb(248,197,47)" rx="2" ry="2" />
+<text  x="3905.72" y="2493.5" >__..</text>
+</g>
+<g >
+<title>execute_command (713,521,499 samples, 0.11%)</title><rect x="296.5" y="1741" width="4.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="299.45" y="1753.5" ></text>
+</g>
+<g >
+<title>read (154,329,410 samples, 0.02%)</title><rect x="828.0" y="81" width="1.0" height="19.0" fill="rgb(252,216,51)" rx="2" ry="2" />
+<text  x="830.95" y="93.5" ></text>
+</g>
+<g >
+<title>execute_command (822,625,656 samples, 0.13%)</title><rect x="895.4" y="401" width="5.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="898.39" y="413.5" ></text>
+</g>
+<g >
+<title>_IO_file_fopen@@GLIBC_2.2.5 (5,283,594,672 samples, 0.83%)</title><rect x="3902.8" y="2461" width="34.6" height="19.0" fill="rgb(237,148,35)" rx="2" ry="2" />
+<text  x="3905.82" y="2473.5" >_I..</text>
+</g>
+<g >
+<title>[bash] (198,222,753 samples, 0.03%)</title><rect x="827.7" y="121" width="1.3" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="830.67" y="133.5" ></text>
+</g>
+<g >
+<title>ima_file_check (182,991,697 samples, 0.03%)</title><rect x="1487.9" y="2241" width="1.2" height="19.0" fill="rgb(251,215,51)" rx="2" ry="2" />
+<text  x="1490.89" y="2253.5" ></text>
+</g>
+<g >
+<title>execute_command (163,954,022 samples, 0.03%)</title><rect x="870.8" y="1081" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="873.82" y="1093.5" ></text>
+</g>
+<g >
+<title>__fput (181,104,193 samples, 0.03%)</title><rect x="2083.9" y="2381" width="1.2" height="19.0" fill="rgb(205,0,0)" rx="2" ry="2" />
+<text  x="2086.91" y="2393.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (192,670,319 samples, 0.03%)</title><rect x="837.6" y="1121" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="840.55" y="1133.5" ></text>
+</g>
+<g >
+<title>execute_command (713,521,499 samples, 0.11%)</title><rect x="296.5" y="2221" width="4.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="299.45" y="2233.5" ></text>
+</g>
+<g >
+<title>exc_page_fault (857,734,810 samples, 0.13%)</title><rect x="734.7" y="1221" width="5.6" height="19.0" fill="rgb(219,65,15)" rx="2" ry="2" />
+<text  x="737.69" y="1233.5" ></text>
+</g>
+<g >
+<title>exc_page_fault (527,505,154 samples, 0.08%)</title><rect x="724.6" y="1241" width="3.4" height="19.0" fill="rgb(219,65,15)" rx="2" ry="2" />
+<text  x="727.58" y="1253.5" ></text>
+</g>
+<g >
+<title>__do_sys_newfstat (268,380,361 samples, 0.04%)</title><rect x="3339.6" y="2361" width="1.8" height="19.0" fill="rgb(225,96,23)" rx="2" ry="2" />
+<text  x="3342.62" y="2373.5" ></text>
+</g>
+<g >
+<title>security_file_open (231,659,840 samples, 0.04%)</title><rect x="2036.8" y="2221" width="1.6" height="19.0" fill="rgb(215,47,11)" rx="2" ry="2" />
+<text  x="2039.84" y="2233.5" ></text>
+</g>
+<g >
+<title>execute_command (889,542,281 samples, 0.14%)</title><rect x="851.1" y="781" width="5.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="854.09" y="793.5" ></text>
+</g>
+<g >
+<title>execute_command (737,490,267 samples, 0.12%)</title><rect x="835.1" y="1821" width="4.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="838.10" y="1833.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (3,816,229,178 samples, 0.60%)</title><rect x="361.4" y="361" width="25.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="364.41" y="373.5" >e..</text>
+</g>
+<g >
+<title>_dl_sysdep_start (384,629,895 samples, 0.06%)</title><rect x="4028.8" y="2541" width="2.5" height="19.0" fill="rgb(234,137,32)" rx="2" ry="2" />
+<text  x="4031.77" y="2553.5" ></text>
+</g>
+<g >
+<title>execute_command (76,163,081,250 samples, 11.93%)</title><rect x="307.9" y="2061" width="498.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="310.94" y="2073.5" >execute_command</text>
+</g>
+<g >
+<title>execute_command (433,500,595 samples, 0.07%)</title><rect x="888.6" y="1241" width="2.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="891.56" y="1253.5" ></text>
+</g>
+<g >
+<title>execute_command (59,877,485,415 samples, 9.38%)</title><rect x="397.5" y="1461" width="392.0" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="400.48" y="1473.5" >execute_command</text>
+</g>
+<g >
+<title>syscall_return_via_sysret (153,838,939 samples, 0.02%)</title><rect x="3105.5" y="2481" width="1.0" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="3108.51" y="2493.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,147,316,451 samples, 0.18%)</title><rect x="827.6" y="1281" width="7.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.59" y="1293.5" ></text>
+</g>
+<g >
+<title>execute_command (890,006,400 samples, 0.14%)</title><rect x="851.1" y="1141" width="5.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="854.09" y="1153.5" ></text>
+</g>
+<g >
+<title>folio_remove_rmap_ptes (548,005,146 samples, 0.09%)</title><rect x="822.5" y="2381" width="3.6" height="19.0" fill="rgb(226,98,23)" rx="2" ry="2" />
+<text  x="825.49" y="2393.5" ></text>
+</g>
+<g >
+<title>execute_command (481,191,724 samples, 0.08%)</title><rect x="276.9" y="901" width="3.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="279.94" y="913.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (548,788,616 samples, 0.09%)</title><rect x="273.3" y="601" width="3.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="276.32" y="613.5" ></text>
+</g>
+<g >
+<title>fclose@@GLIBC_2.2.5 (726,880,648 samples, 0.11%)</title><rect x="1638.8" y="2481" width="4.7" height="19.0" fill="rgb(251,213,51)" rx="2" ry="2" />
+<text  x="1641.76" y="2493.5" ></text>
+</g>
+<g >
+<title>do_filp_open (2,339,676,144 samples, 0.37%)</title><rect x="2544.5" y="2301" width="15.3" height="19.0" fill="rgb(217,58,13)" rx="2" ry="2" />
+<text  x="2547.47" y="2313.5" ></text>
+</g>
+<g >
+<title>execute_command (513,428,353 samples, 0.08%)</title><rect x="856.9" y="881" width="3.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="859.94" y="893.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (264,069,883 samples, 0.04%)</title><rect x="827.6" y="261" width="1.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.59" y="273.5" ></text>
+</g>
+<g >
+<title>syscall_return_via_sysret (172,775,625 samples, 0.03%)</title><rect x="3040.1" y="2381" width="1.2" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="3043.12" y="2393.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (169,651,850 samples, 0.03%)</title><rect x="871.9" y="861" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="874.90" y="873.5" ></text>
+</g>
+<g >
+<title>make_bare_word (1,003,660,674 samples, 0.16%)</title><rect x="520.9" y="1201" width="6.6" height="19.0" fill="rgb(245,184,44)" rx="2" ry="2" />
+<text  x="523.94" y="1213.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (2,271,035,529 samples, 0.36%)</title><rect x="3024.3" y="2361" width="14.9" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="3027.34" y="2373.5" ></text>
+</g>
+<g >
+<title>lookup_fast (179,012,760 samples, 0.03%)</title><rect x="2132.7" y="2221" width="1.2" height="19.0" fill="rgb(226,97,23)" rx="2" ry="2" />
+<text  x="2135.71" y="2233.5" ></text>
+</g>
+<g >
+<title>[bash] (354,998,378 samples, 0.06%)</title><rect x="840.5" y="1481" width="2.3" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="843.48" y="1493.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (891,895,571 samples, 0.14%)</title><rect x="851.1" y="1721" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.08" y="1733.5" ></text>
+</g>
+<g >
+<title>[bash] (950,670,386 samples, 0.15%)</title><rect x="862.0" y="241" width="6.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="864.98" y="253.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (713,521,499 samples, 0.11%)</title><rect x="296.5" y="2081" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.45" y="2093.5" ></text>
+</g>
+<g >
+<title>execute_command (578,444,541 samples, 0.09%)</title><rect x="891.4" y="401" width="3.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="894.42" y="413.5" ></text>
+</g>
+<g >
+<title>[bash] (534,241,545 samples, 0.08%)</title><rect x="344.8" y="661" width="3.5" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="347.83" y="673.5" ></text>
+</g>
+<g >
+<title>[bash] (2,616,463,076 samples, 0.41%)</title><rect x="561.0" y="1281" width="17.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="564.03" y="1293.5" ></text>
+</g>
+<g >
+<title>entry_SYSRETQ_unsafe_stack (168,140,352 samples, 0.03%)</title><rect x="3422.3" y="2481" width="1.1" height="19.0" fill="rgb(213,37,8)" rx="2" ry="2" />
+<text  x="3425.32" y="2493.5" ></text>
+</g>
+<g >
+<title>__GI___libc_write (278,613,697 samples, 0.04%)</title><rect x="900.9" y="2501" width="1.9" height="19.0" fill="rgb(217,57,13)" rx="2" ry="2" />
+<text  x="903.94" y="2513.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (281,045,858 samples, 0.04%)</title><rect x="401.5" y="921" width="1.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="404.50" y="933.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,261,220,789 samples, 0.20%)</title><rect x="860.3" y="1001" width="8.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.32" y="1013.5" ></text>
+</g>
+<g >
+<title>dispose_words (153,239,696 samples, 0.02%)</title><rect x="841.2" y="81" width="1.1" height="19.0" fill="rgb(235,141,33)" rx="2" ry="2" />
+<text  x="844.25" y="93.5" ></text>
+</g>
+<g >
+<title>_dl_map_object (196,628,374 samples, 0.03%)</title><rect x="2117.9" y="2441" width="1.3" height="19.0" fill="rgb(248,199,47)" rx="2" ry="2" />
+<text  x="2120.89" y="2453.5" ></text>
+</g>
+<g >
+<title>__libc_start_main@@GLIBC_2.34 (14,646,791,621 samples, 2.29%)</title><rect x="2019.4" y="2561" width="95.9" height="19.0" fill="rgb(229,113,27)" rx="2" ry="2" />
+<text  x="2022.39" y="2573.5" >__libc_star..</text>
+</g>
+<g >
+<title>inherit_task_group.isra.0 (476,579,321 samples, 0.07%)</title><rect x="703.4" y="1161" width="3.1" height="19.0" fill="rgb(218,62,14)" rx="2" ry="2" />
+<text  x="706.42" y="1173.5" ></text>
+</g>
+<g >
+<title>execute_command (688,777,208 samples, 0.11%)</title><rect x="268.8" y="2041" width="4.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="271.77" y="2053.5" ></text>
+</g>
+<g >
+<title>execute_command (833,088,691 samples, 0.13%)</title><rect x="301.2" y="321" width="5.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="304.16" y="333.5" ></text>
+</g>
+<g >
+<title>redirection_expand (190,014,181 samples, 0.03%)</title><rect x="837.6" y="581" width="1.2" height="19.0" fill="rgb(218,63,15)" rx="2" ry="2" />
+<text  x="840.56" y="593.5" ></text>
+</g>
+<g >
+<title>[b2sum] (25,164,019,252 samples, 3.94%)</title><rect x="11.1" y="2461" width="164.8" height="19.0" fill="rgb(216,50,12)" rx="2" ry="2" />
+<text  x="14.13" y="2473.5" >[b2sum]</text>
+</g>
+<g >
+<title>execute_command_internal (215,132,849 samples, 0.03%)</title><rect x="842.8" y="1441" width="1.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="845.81" y="1453.5" ></text>
+</g>
+<g >
+<title>__printf_chk (1,751,852,780 samples, 0.27%)</title><rect x="2098.6" y="2501" width="11.5" height="19.0" fill="rgb(212,36,8)" rx="2" ry="2" />
+<text  x="2101.62" y="2513.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (432,726,851 samples, 0.07%)</title><rect x="888.6" y="661" width="2.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="891.57" y="673.5" ></text>
+</g>
+<g >
+<title>execute_command (1,263,560,140 samples, 0.20%)</title><rect x="860.3" y="2381" width="8.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="863.30" y="2393.5" ></text>
+</g>
+<g >
+<title>execute_command (842,511,421 samples, 0.13%)</title><rect x="895.4" y="641" width="5.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="898.39" y="653.5" ></text>
+</g>
+<g >
+<title>_copy_from_user (167,759,513 samples, 0.03%)</title><rect x="666.3" y="1221" width="1.1" height="19.0" fill="rgb(213,37,8)" rx="2" ry="2" />
+<text  x="669.30" y="1233.5" ></text>
+</g>
+<g >
+<title>_dl_start_user (407,776,280 samples, 0.06%)</title><rect x="4186.4" y="2581" width="2.7" height="19.0" fill="rgb(236,145,34)" rx="2" ry="2" />
+<text  x="4189.40" y="2593.5" ></text>
+</g>
+<g >
+<title>do_redirections (305,580,020 samples, 0.05%)</title><rect x="868.8" y="521" width="2.0" height="19.0" fill="rgb(247,193,46)" rx="2" ry="2" />
+<text  x="871.80" y="533.5" ></text>
+</g>
+<g >
+<title>execute_command (432,872,015 samples, 0.07%)</title><rect x="888.6" y="1081" width="2.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="891.57" y="1093.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (1,617,682,384 samples, 0.25%)</title><rect x="662.1" y="1321" width="10.6" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="665.07" y="1333.5" ></text>
+</g>
+<g >
+<title>__fread_unlocked_chk (8,923,779,316 samples, 1.40%)</title><rect x="3937.9" y="2481" width="58.4" height="19.0" fill="rgb(225,94,22)" rx="2" ry="2" />
+<text  x="3940.86" y="2493.5" >__frea..</text>
+</g>
+<g >
+<title>__fstat64 (686,704,487 samples, 0.11%)</title><rect x="1438.4" y="2381" width="4.5" height="19.0" fill="rgb(224,88,21)" rx="2" ry="2" />
+<text  x="1441.40" y="2393.5" ></text>
+</g>
+<g >
+<title>__GI___libc_write (694,893,338 samples, 0.11%)</title><rect x="3384.4" y="2441" width="4.5" height="19.0" fill="rgb(217,57,13)" rx="2" ry="2" />
+<text  x="3387.37" y="2453.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (352,638,539 samples, 0.06%)</title><rect x="401.1" y="961" width="2.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="404.11" y="973.5" ></text>
+</g>
+<g >
+<title>dispose_words (593,841,570 samples, 0.09%)</title><rect x="608.3" y="1321" width="3.9" height="19.0" fill="rgb(235,141,33)" rx="2" ry="2" />
+<text  x="611.27" y="1333.5" ></text>
+</g>
+<g >
+<title>execute_command (195,916,485 samples, 0.03%)</title><rect x="835.2" y="1501" width="1.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="838.17" y="1513.5" ></text>
+</g>
+<g >
+<title>execute_command (713,987,302 samples, 0.11%)</title><rect x="280.1" y="1301" width="4.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="283.11" y="1313.5" ></text>
+</g>
+<g >
+<title>wait_for (906,383,038 samples, 0.14%)</title><rect x="783.5" y="1381" width="5.9" height="19.0" fill="rgb(214,43,10)" rx="2" ry="2" />
+<text  x="786.48" y="1393.5" ></text>
+</g>
+<g >
+<title>execute_command (713,521,499 samples, 0.11%)</title><rect x="296.5" y="2021" width="4.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="299.45" y="2033.5" ></text>
+</g>
+<g >
+<title>unquoted_glob_pattern_p (1,981,207,687 samples, 0.31%)</title><rect x="742.1" y="1341" width="13.0" height="19.0" fill="rgb(220,71,17)" rx="2" ry="2" />
+<text  x="745.11" y="1353.5" ></text>
+</g>
+<g >
+<title>[libcrypto.so.3.2.2] (205,820,545 samples, 0.03%)</title><rect x="2531.7" y="2541" width="1.3" height="19.0" fill="rgb(244,181,43)" rx="2" ry="2" />
+<text  x="2534.67" y="2553.5" ></text>
+</g>
+<g >
+<title>[bash] (164,731,865 samples, 0.03%)</title><rect x="836.5" y="1281" width="1.0" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="839.46" y="1293.5" ></text>
+</g>
+<g >
+<title>do_redirections (426,885,954 samples, 0.07%)</title><rect x="298.2" y="261" width="2.8" height="19.0" fill="rgb(247,193,46)" rx="2" ry="2" />
+<text  x="301.19" y="273.5" ></text>
+</g>
+<g >
+<title>execute_command (849,509,116 samples, 0.13%)</title><rect x="895.3" y="2081" width="5.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="898.35" y="2093.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (286,192,596 samples, 0.04%)</title><rect x="1559.4" y="2461" width="1.9" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="1562.38" y="2473.5" ></text>
+</g>
+<g >
+<title>free_pgtables (443,368,714 samples, 0.07%)</title><rect x="808.8" y="2421" width="2.9" height="19.0" fill="rgb(215,46,11)" rx="2" ry="2" />
+<text  x="811.83" y="2433.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (2,383,635,423 samples, 0.37%)</title><rect x="868.6" y="2461" width="15.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="871.57" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command (598,514,664 samples, 0.09%)</title><rect x="891.4" y="2321" width="3.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="894.40" y="2333.5" ></text>
+</g>
+<g >
+<title>do_redirections (212,285,054 samples, 0.03%)</title><rect x="800.4" y="1421" width="1.4" height="19.0" fill="rgb(247,193,46)" rx="2" ry="2" />
+<text  x="803.44" y="1433.5" ></text>
+</g>
+<g >
+<title>shmem_get_folio_gfp (665,940,664 samples, 0.10%)</title><rect x="3981.1" y="2341" width="4.3" height="19.0" fill="rgb(219,67,16)" rx="2" ry="2" />
+<text  x="3984.06" y="2353.5" ></text>
+</g>
+<g >
+<title>execute_command (688,777,208 samples, 0.11%)</title><rect x="268.8" y="1601" width="4.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="271.77" y="1613.5" ></text>
+</g>
+<g >
+<title>kmem_cache_alloc_noprof (158,342,982 samples, 0.02%)</title><rect x="1604.4" y="2281" width="1.0" height="19.0" fill="rgb(205,0,0)" rx="2" ry="2" />
+<text  x="1607.41" y="2293.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (436,055,112 samples, 0.07%)</title><rect x="888.5" y="2221" width="2.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="891.55" y="2233.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (688,777,208 samples, 0.11%)</title><rect x="268.8" y="2301" width="4.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="271.77" y="2313.5" ></text>
+</g>
+<g >
+<title>_IO_file_open (2,828,144,439 samples, 0.44%)</title><rect x="2125.6" y="2421" width="18.5" height="19.0" fill="rgb(249,205,49)" rx="2" ry="2" />
+<text  x="2128.63" y="2433.5" ></text>
+</g>
+<g >
+<title>[bash] (1,799,456,206 samples, 0.28%)</title><rect x="533.9" y="1201" width="11.7" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="536.86" y="1213.5" ></text>
+</g>
+<g >
+<title>execute_command (1,251,500,515 samples, 0.20%)</title><rect x="860.3" y="461" width="8.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="863.32" y="473.5" ></text>
+</g>
+<g >
+<title>execute_command (164,731,865 samples, 0.03%)</title><rect x="836.5" y="1021" width="1.0" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="839.46" y="1033.5" ></text>
+</g>
+<g >
+<title>do_sys_openat2 (156,430,154 samples, 0.02%)</title><rect x="331.5" y="401" width="1.0" height="19.0" fill="rgb(209,21,5)" rx="2" ry="2" />
+<text  x="334.49" y="413.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (349,185,086 samples, 0.05%)</title><rect x="225.1" y="2441" width="2.3" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="228.10" y="2453.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (861,612,432 samples, 0.13%)</title><rect x="301.2" y="581" width="5.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.16" y="593.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,146,830,397 samples, 0.18%)</title><rect x="827.6" y="661" width="7.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.59" y="673.5" ></text>
+</g>
+<g >
+<title>execute_command (513,428,353 samples, 0.08%)</title><rect x="856.9" y="921" width="3.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="859.94" y="933.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (163,954,022 samples, 0.03%)</title><rect x="870.8" y="1021" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="873.82" y="1033.5" ></text>
+</g>
+<g >
+<title>llseek@GLIBC_2.2.5 (508,591,618 samples, 0.08%)</title><rect x="229.2" y="2481" width="3.4" height="19.0" fill="rgb(239,156,37)" rx="2" ry="2" />
+<text  x="232.23" y="2493.5" ></text>
+</g>
+<g >
+<title>syscall_return_via_sysret (309,384,145 samples, 0.05%)</title><rect x="4064.0" y="2381" width="2.0" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="4066.96" y="2393.5" ></text>
+</g>
+<g >
+<title>execute_command (842,511,421 samples, 0.13%)</title><rect x="895.4" y="921" width="5.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="898.39" y="933.5" ></text>
+</g>
+<g >
+<title>do_wait (202,166,383 samples, 0.03%)</title><rect x="786.0" y="1261" width="1.3" height="19.0" fill="rgb(220,70,16)" rx="2" ry="2" />
+<text  x="788.98" y="1273.5" ></text>
+</g>
+<g >
+<title>alloc_pages_mpol_noprof (319,483,986 samples, 0.05%)</title><rect x="772.6" y="1141" width="2.1" height="19.0" fill="rgb(233,132,31)" rx="2" ry="2" />
+<text  x="775.56" y="1153.5" ></text>
+</g>
+<g >
+<title>entry_SYSRETQ_unsafe_stack (247,103,190 samples, 0.04%)</title><rect x="4062.3" y="2381" width="1.7" height="19.0" fill="rgb(213,37,8)" rx="2" ry="2" />
+<text  x="4065.34" y="2393.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (13,307,904,157 samples, 2.08%)</title><rect x="307.9" y="1841" width="87.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="310.94" y="1853.5" >execute_co..</text>
+</g>
+<g >
+<title>[bash] (866,614,713 samples, 0.14%)</title><rect x="301.1" y="2521" width="5.7" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="304.12" y="2533.5" ></text>
+</g>
+<g >
+<title>execute_command (323,026,366 samples, 0.05%)</title><rect x="868.7" y="1581" width="2.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="871.70" y="1593.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (436,055,112 samples, 0.07%)</title><rect x="888.5" y="2301" width="2.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="891.55" y="2313.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,263,560,140 samples, 0.20%)</title><rect x="860.3" y="1961" width="8.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.30" y="1973.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (170,489,782 samples, 0.03%)</title><rect x="871.9" y="1181" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="874.90" y="1193.5" ></text>
+</g>
+<g >
+<title>execute_command (1,861,037,088 samples, 0.29%)</title><rect x="835.1" y="2101" width="12.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="838.10" y="2113.5" ></text>
+</g>
+<g >
+<title>asm_exc_page_fault (1,932,044,225 samples, 0.30%)</title><rect x="763.6" y="1301" width="12.6" height="19.0" fill="rgb(231,123,29)" rx="2" ry="2" />
+<text  x="766.56" y="1313.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (483,985,097 samples, 0.08%)</title><rect x="276.9" y="2241" width="3.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="279.92" y="2253.5" ></text>
+</g>
+<g >
+<title>cksum (104,391,090,080 samples, 16.35%)</title><rect x="903.8" y="2601" width="683.4" height="19.0" fill="rgb(229,114,27)" rx="2" ry="2" />
+<text  x="906.82" y="2613.5" >cksum</text>
+</g>
+<g >
+<title>execute_command (699,290,297 samples, 0.11%)</title><rect x="296.5" y="541" width="4.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="299.51" y="553.5" ></text>
+</g>
+<g >
+<title>[bash] (343,414,451 samples, 0.05%)</title><rect x="889.1" y="381" width="2.3" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="892.10" y="393.5" ></text>
+</g>
+<g >
+<title>execute_command (666,234,521 samples, 0.10%)</title><rect x="835.1" y="1781" width="4.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="838.10" y="1793.5" ></text>
+</g>
+<g >
+<title>execute_command (695,079,167 samples, 0.11%)</title><rect x="280.1" y="421" width="4.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="283.11" y="433.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (163,954,022 samples, 0.03%)</title><rect x="870.8" y="901" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="873.82" y="913.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (578,068,287 samples, 0.09%)</title><rect x="884.6" y="2121" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="887.62" y="2133.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (713,987,302 samples, 0.11%)</title><rect x="280.1" y="1041" width="4.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.11" y="1053.5" ></text>
+</g>
+<g >
+<title>execute_command (688,777,208 samples, 0.11%)</title><rect x="268.8" y="1681" width="4.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="271.77" y="1693.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (41,963,808,470 samples, 6.57%)</title><rect x="514.7" y="1401" width="274.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="517.71" y="1413.5" >execute_command_internal</text>
+</g>
+<g >
+<title>execute_command_internal (194,148,063 samples, 0.03%)</title><rect x="837.5" y="1561" width="1.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="840.54" y="1573.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (596,118,643 samples, 0.09%)</title><rect x="891.4" y="1221" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.42" y="1233.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (194,148,063 samples, 0.03%)</title><rect x="837.5" y="1541" width="1.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="840.54" y="1553.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (432,872,015 samples, 0.07%)</title><rect x="888.6" y="741" width="2.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="891.57" y="753.5" ></text>
+</g>
+<g >
+<title>asm_exc_page_fault (268,347,535 samples, 0.04%)</title><rect x="547.4" y="1181" width="1.8" height="19.0" fill="rgb(231,123,29)" rx="2" ry="2" />
+<text  x="550.40" y="1193.5" ></text>
+</g>
+<g >
+<title>__do_sys_clone (2,122,330,120 samples, 0.33%)</title><rect x="694.3" y="1241" width="13.8" height="19.0" fill="rgb(217,57,13)" rx="2" ry="2" />
+<text  x="697.25" y="1253.5" ></text>
+</g>
+<g >
+<title>[bash] (705,583,873 samples, 0.11%)</title><rect x="296.5" y="1121" width="4.6" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="299.50" y="1133.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (516,725,798 samples, 0.08%)</title><rect x="856.9" y="2101" width="3.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="859.92" y="2113.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (322,256,264 samples, 0.05%)</title><rect x="868.7" y="861" width="2.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="871.70" y="873.5" ></text>
+</g>
+<g >
+<title>execute_command (516,725,798 samples, 0.08%)</title><rect x="856.9" y="1961" width="3.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="859.92" y="1973.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (554,006,342 samples, 0.09%)</title><rect x="273.3" y="2161" width="3.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="276.29" y="2173.5" ></text>
+</g>
+<g >
+<title>execute_command (1,146,830,397 samples, 0.18%)</title><rect x="827.6" y="681" width="7.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="830.59" y="693.5" ></text>
+</g>
+<g >
+<title>do_pselect.constprop.0 (206,196,290 samples, 0.03%)</title><rect x="313.1" y="381" width="1.3" height="19.0" fill="rgb(221,74,17)" rx="2" ry="2" />
+<text  x="316.09" y="393.5" ></text>
+</g>
+<g >
+<title>[bash] (631,292,609 samples, 0.10%)</title><rect x="375.4" y="121" width="4.1" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="378.37" y="133.5" ></text>
+</g>
+<g >
+<title>execute_command (1,263,560,140 samples, 0.20%)</title><rect x="860.3" y="1581" width="8.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="863.30" y="1593.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,146,830,397 samples, 0.18%)</title><rect x="827.6" y="701" width="7.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.59" y="713.5" ></text>
+</g>
+<g >
+<title>syscall_return_via_sysret (292,787,432 samples, 0.05%)</title><rect x="4023.7" y="2501" width="1.9" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="4026.72" y="2513.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (554,006,342 samples, 0.09%)</title><rect x="273.3" y="2481" width="3.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="276.29" y="2493.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (685,976,378 samples, 0.11%)</title><rect x="268.8" y="901" width="4.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="271.79" y="913.5" ></text>
+</g>
+<g >
+<title>_IO_file_fopen@@GLIBC_2.2.5 (2,689,496,942 samples, 0.42%)</title><rect x="1590.7" y="2441" width="17.6" height="19.0" fill="rgb(237,148,35)" rx="2" ry="2" />
+<text  x="1593.70" y="2453.5" ></text>
+</g>
+<g >
+<title>getname_flags.part.0 (272,029,434 samples, 0.04%)</title><rect x="190.3" y="2301" width="1.8" height="19.0" fill="rgb(213,39,9)" rx="2" ry="2" />
+<text  x="193.31" y="2313.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (554,006,342 samples, 0.09%)</title><rect x="273.3" y="1881" width="3.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="276.29" y="1893.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (170,489,782 samples, 0.03%)</title><rect x="871.9" y="1261" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="874.90" y="1273.5" ></text>
+</g>
+<g >
+<title>execute_command (215,132,849 samples, 0.03%)</title><rect x="842.8" y="981" width="1.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="845.81" y="993.5" ></text>
+</g>
+<g >
+<title>execute_command (192,670,319 samples, 0.03%)</title><rect x="837.6" y="1061" width="1.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="840.55" y="1073.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (283,001,373 samples, 0.04%)</title><rect x="1570.1" y="2481" width="1.8" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="1573.06" y="2493.5" ></text>
+</g>
+<g >
+<title>vfs_open (675,546,939 samples, 0.11%)</title><rect x="3925.1" y="2281" width="4.4" height="19.0" fill="rgb(238,154,37)" rx="2" ry="2" />
+<text  x="3928.11" y="2293.5" ></text>
+</g>
+<g >
+<title>_dl_map_object_from_fd (159,865,999 samples, 0.03%)</title><rect x="1579.9" y="2421" width="1.0" height="19.0" fill="rgb(249,205,49)" rx="2" ry="2" />
+<text  x="1582.86" y="2433.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (891,895,571 samples, 0.14%)</title><rect x="851.1" y="1881" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.08" y="1893.5" ></text>
+</g>
+<g >
+<title>[bash] (319,374,708 samples, 0.05%)</title><rect x="336.9" y="601" width="2.1" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="339.95" y="613.5" ></text>
+</g>
+<g >
+<title>execute_command (717,313,739 samples, 0.11%)</title><rect x="280.1" y="2341" width="4.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="283.09" y="2353.5" ></text>
+</g>
+<g >
+<title>ima_file_check (187,817,229 samples, 0.03%)</title><rect x="3923.5" y="2261" width="1.3" height="19.0" fill="rgb(251,215,51)" rx="2" ry="2" />
+<text  x="3926.53" y="2273.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (179,777,548 samples, 0.03%)</title><rect x="878.5" y="1221" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="881.48" y="1233.5" ></text>
+</g>
+<g >
+<title>ksys_read (2,895,332,471 samples, 0.45%)</title><rect x="2153.2" y="2401" width="18.9" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="2156.17" y="2413.5" ></text>
+</g>
+<g >
+<title>execute_command (436,055,112 samples, 0.07%)</title><rect x="888.5" y="2241" width="2.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="891.55" y="2253.5" ></text>
+</g>
+<g >
+<title>execute_command (821,054,811 samples, 0.13%)</title><rect x="835.1" y="1861" width="5.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="838.10" y="1873.5" ></text>
+</g>
+<g >
+<title>__libc_start_main@@GLIBC_2.34 (15,825,536,218 samples, 2.48%)</title><rect x="2540.1" y="2561" width="103.6" height="19.0" fill="rgb(229,113,27)" rx="2" ry="2" />
+<text  x="2543.07" y="2573.5" >__libc_start..</text>
+</g>
+<g >
+<title>execute_command (513,954,307 samples, 0.08%)</title><rect x="856.9" y="1481" width="3.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="859.94" y="1493.5" ></text>
+</g>
+<g >
+<title>[bash] (364,717,468 samples, 0.06%)</title><rect x="339.8" y="621" width="2.4" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="342.84" y="633.5" ></text>
+</g>
+<g >
+<title>execute_command (578,068,287 samples, 0.09%)</title><rect x="884.6" y="2341" width="3.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="887.62" y="2353.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (483,985,097 samples, 0.08%)</title><rect x="276.9" y="1601" width="3.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="279.92" y="1613.5" ></text>
+</g>
+<g >
+<title>[bash] (158,599,791 samples, 0.02%)</title><rect x="875.9" y="721" width="1.1" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="878.93" y="733.5" ></text>
+</g>
+<g >
+<title>execute_command (713,462,810 samples, 0.11%)</title><rect x="280.1" y="821" width="4.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="283.11" y="833.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (354,423,603 samples, 0.06%)</title><rect x="3072.0" y="2441" width="2.4" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="3075.04" y="2453.5" ></text>
+</g>
+<g >
+<title>do_filp_open (2,253,555,682 samples, 0.35%)</title><rect x="2023.7" y="2301" width="14.7" height="19.0" fill="rgb(217,58,13)" rx="2" ry="2" />
+<text  x="2026.68" y="2313.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (320,852,930 samples, 0.05%)</title><rect x="868.7" y="741" width="2.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="871.70" y="753.5" ></text>
+</g>
+<g >
+<title>__x64_sys_close (317,355,445 samples, 0.05%)</title><rect x="3374.4" y="2401" width="2.0" height="19.0" fill="rgb(238,153,36)" rx="2" ry="2" />
+<text  x="3377.37" y="2413.5" ></text>
+</g>
+<g >
+<title>execute_command (13,301,939,660 samples, 2.08%)</title><rect x="307.9" y="1461" width="87.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="310.94" y="1473.5" >execute_co..</text>
+</g>
+<g >
+<title>execute_command (554,006,342 samples, 0.09%)</title><rect x="273.3" y="2301" width="3.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="276.29" y="2313.5" ></text>
+</g>
+<g >
+<title>walk_component (195,811,594 samples, 0.03%)</title><rect x="3030.3" y="2241" width="1.3" height="19.0" fill="rgb(247,197,47)" rx="2" ry="2" />
+<text  x="3033.31" y="2253.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,513,658,329 samples, 0.24%)</title><rect x="868.6" y="1981" width="9.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="871.57" y="1993.5" ></text>
+</g>
+<g >
+<title>[bash] (575,055,300 samples, 0.09%)</title><rect x="884.6" y="1161" width="3.8" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="887.64" y="1173.5" ></text>
+</g>
+<g >
+<title>execute_command (480,699,859 samples, 0.08%)</title><rect x="276.9" y="701" width="3.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="279.94" y="713.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (164,808,262 samples, 0.03%)</title><rect x="870.8" y="1581" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="873.81" y="1593.5" ></text>
+</g>
+<g >
+<title>rep_movs_alternative (1,870,992,662 samples, 0.29%)</title><rect x="2156.6" y="2301" width="12.2" height="19.0" fill="rgb(211,31,7)" rx="2" ry="2" />
+<text  x="2159.55" y="2313.5" ></text>
+</g>
+<g >
+<title>[bash] (1,129,648,781 samples, 0.18%)</title><rect x="363.8" y="221" width="7.4" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="366.82" y="233.5" ></text>
+</g>
+<g >
+<title>entry_SYSRETQ_unsafe_stack (254,541,637 samples, 0.04%)</title><rect x="1554.5" y="2441" width="1.6" height="19.0" fill="rgb(213,37,8)" rx="2" ry="2" />
+<text  x="1557.47" y="2453.5" ></text>
+</g>
+<g >
+<title>[xxhsum] (23,223,837,310 samples, 3.64%)</title><rect x="4033.5" y="2581" width="152.0" height="19.0" fill="rgb(249,206,49)" rx="2" ry="2" />
+<text  x="4036.48" y="2593.5" >[xxhsum]</text>
+</g>
+<g >
+<title>parse_and_execute (265,207,606 samples, 0.04%)</title><rect x="803.4" y="1561" width="1.7" height="19.0" fill="rgb(243,178,42)" rx="2" ry="2" />
+<text  x="806.36" y="1573.5" ></text>
+</g>
+<g >
+<title>_int_free_create_chunk (469,185,518 samples, 0.07%)</title><rect x="778.8" y="1301" width="3.1" height="19.0" fill="rgb(244,182,43)" rx="2" ry="2" />
+<text  x="781.78" y="1313.5" ></text>
+</g>
+<g >
+<title>execute_command (704,492,242 samples, 0.11%)</title><rect x="296.5" y="621" width="4.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="299.51" y="633.5" ></text>
+</g>
+<g >
+<title>[bash] (166,935,283 samples, 0.03%)</title><rect x="334.5" y="481" width="1.1" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="337.53" y="493.5" ></text>
+</g>
+<g >
+<title>array_flush (4,890,380,518 samples, 0.77%)</title><rect x="430.0" y="1081" width="32.0" height="19.0" fill="rgb(215,46,11)" rx="2" ry="2" />
+<text  x="433.03" y="1093.5" >ar..</text>
+</g>
+<g >
+<title>dispose_command (278,788,607 samples, 0.04%)</title><rect x="840.5" y="421" width="1.8" height="19.0" fill="rgb(248,201,48)" rx="2" ry="2" />
+<text  x="843.48" y="433.5" ></text>
+</g>
+<g >
+<title>[bash] (292,345,381 samples, 0.05%)</title><rect x="328.8" y="521" width="1.9" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="331.82" y="533.5" ></text>
+</g>
+<g >
+<title>folios_put_refs (545,501,691 samples, 0.09%)</title><rect x="813.4" y="2361" width="3.6" height="19.0" fill="rgb(211,29,7)" rx="2" ry="2" />
+<text  x="816.44" y="2373.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (215,132,849 samples, 0.03%)</title><rect x="842.8" y="1541" width="1.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="845.81" y="1553.5" ></text>
+</g>
+<g >
+<title>execute_command (215,132,849 samples, 0.03%)</title><rect x="842.8" y="1061" width="1.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="845.81" y="1073.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (432,872,015 samples, 0.07%)</title><rect x="888.6" y="901" width="2.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="891.57" y="913.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (866,614,713 samples, 0.14%)</title><rect x="301.1" y="2381" width="5.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.12" y="2393.5" ></text>
+</g>
+<g >
+<title>parse_and_execute (158,593,817 samples, 0.02%)</title><rect x="875.9" y="681" width="1.1" height="19.0" fill="rgb(243,178,42)" rx="2" ry="2" />
+<text  x="878.93" y="693.5" ></text>
+</g>
+<g >
+<title>execute_command (853,210,202 samples, 0.13%)</title><rect x="301.2" y="481" width="5.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="304.16" y="493.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (889,542,281 samples, 0.14%)</title><rect x="851.1" y="761" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.09" y="773.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,177,189,266 samples, 0.18%)</title><rect x="835.1" y="1881" width="7.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="838.10" y="1893.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (474,319,738 samples, 0.07%)</title><rect x="276.9" y="521" width="3.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="279.94" y="533.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (13,300,775,316 samples, 2.08%)</title><rect x="307.9" y="1401" width="87.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="310.94" y="1413.5" >execute_co..</text>
+</g>
+<g >
+<title>shmem_get_folio_gfp (327,639,043 samples, 0.05%)</title><rect x="1522.6" y="2321" width="2.2" height="19.0" fill="rgb(219,67,16)" rx="2" ry="2" />
+<text  x="1525.63" y="2333.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (164,808,262 samples, 0.03%)</title><rect x="870.8" y="1301" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="873.81" y="1313.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (512,251,839 samples, 0.08%)</title><rect x="856.9" y="741" width="3.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="859.94" y="753.5" ></text>
+</g>
+<g >
+<title>syscall_return_via_sysret (293,403,014 samples, 0.05%)</title><rect x="4156.9" y="2441" width="2.0" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="4159.95" y="2453.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (598,514,664 samples, 0.09%)</title><rect x="891.4" y="1461" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.40" y="1473.5" ></text>
+</g>
+<g >
+<title>[bash] (341,330,256 samples, 0.05%)</title><rect x="889.1" y="361" width="2.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="892.10" y="373.5" ></text>
+</g>
+<g >
+<title>execute_command (1,145,785,833 samples, 0.18%)</title><rect x="827.6" y="601" width="7.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="830.59" y="613.5" ></text>
+</g>
+<g >
+<title>execute_command (575,055,300 samples, 0.09%)</title><rect x="884.6" y="901" width="3.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="887.64" y="913.5" ></text>
+</g>
+<g >
+<title>execute_command (320,852,930 samples, 0.05%)</title><rect x="868.7" y="801" width="2.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="871.70" y="813.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (554,006,342 samples, 0.09%)</title><rect x="273.3" y="1681" width="3.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="276.29" y="1693.5" ></text>
+</g>
+<g >
+<title>[bash] (155,967,926 samples, 0.02%)</title><rect x="836.5" y="421" width="1.0" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="839.51" y="433.5" ></text>
+</g>
+<g >
+<title>__tlb_batch_free_encoded_pages (676,327,698 samples, 0.11%)</title><rect x="812.8" y="2401" width="4.4" height="19.0" fill="rgb(212,33,8)" rx="2" ry="2" />
+<text  x="815.78" y="2413.5" ></text>
+</g>
+<g >
+<title>redirection_expand (398,651,048 samples, 0.06%)</title><rect x="298.3" y="221" width="2.6" height="19.0" fill="rgb(218,63,15)" rx="2" ry="2" />
+<text  x="301.31" y="233.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (180,216,075 samples, 0.03%)</title><rect x="878.5" y="1701" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="881.48" y="1713.5" ></text>
+</g>
+<g >
+<title>execute_command (5,182,401,274 samples, 0.81%)</title><rect x="359.8" y="581" width="34.0" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="362.84" y="593.5" >ex..</text>
+</g>
+<g >
+<title>do_syscall_64 (275,359,670 samples, 0.04%)</title><rect x="3072.6" y="2421" width="1.8" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="3075.56" y="2433.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (598,514,664 samples, 0.09%)</title><rect x="891.4" y="1381" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.40" y="1393.5" ></text>
+</g>
+<g >
+<title>_IO_doallocbuf (712,488,823 samples, 0.11%)</title><rect x="1502.7" y="2421" width="4.7" height="19.0" fill="rgb(214,45,10)" rx="2" ry="2" />
+<text  x="1505.70" y="2433.5" ></text>
+</g>
+<g >
+<title>vfs_read (252,909,801 samples, 0.04%)</title><rect x="499.0" y="981" width="1.7" height="19.0" fill="rgb(230,118,28)" rx="2" ry="2" />
+<text  x="502.00" y="993.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (578,068,287 samples, 0.09%)</title><rect x="884.6" y="2001" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="887.62" y="2013.5" ></text>
+</g>
+<g >
+<title>expand_string_assignment (287,075,463 samples, 0.04%)</title><rect x="337.0" y="541" width="1.9" height="19.0" fill="rgb(235,141,33)" rx="2" ry="2" />
+<text  x="340.01" y="553.5" ></text>
+</g>
+<g >
+<title>execute_command (195,267,188 samples, 0.03%)</title><rect x="835.2" y="1181" width="1.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="838.18" y="1193.5" ></text>
+</g>
+<g >
+<title>_dl_start_user (732,003,738 samples, 0.11%)</title><rect x="3015.3" y="2581" width="4.7" height="19.0" fill="rgb(236,145,34)" rx="2" ry="2" />
+<text  x="3018.25" y="2593.5" ></text>
+</g>
+<g >
+<title>execute_command (592,793,695 samples, 0.09%)</title><rect x="891.4" y="481" width="3.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="894.42" y="493.5" ></text>
+</g>
+<g >
+<title>unlink_chunk.isra.0 (1,987,561,969 samples, 0.31%)</title><rect x="729.0" y="1261" width="13.0" height="19.0" fill="rgb(248,198,47)" rx="2" ry="2" />
+<text  x="732.00" y="1273.5" ></text>
+</g>
+<g >
+<title>do_redirections (389,130,011 samples, 0.06%)</title><rect x="892.6" y="281" width="2.6" height="19.0" fill="rgb(247,193,46)" rx="2" ry="2" />
+<text  x="895.64" y="293.5" ></text>
+</g>
+<g >
+<title>[unknown] (184,901,674 samples, 0.03%)</title><rect x="4032.3" y="2581" width="1.2" height="19.0" fill="rgb(210,24,5)" rx="2" ry="2" />
+<text  x="4035.27" y="2593.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (5,904,400,482 samples, 0.92%)</title><rect x="356.1" y="1161" width="38.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="359.07" y="1173.5" >exe..</text>
+</g>
+<g >
+<title>execute_command_internal (1,259,613,163 samples, 0.20%)</title><rect x="860.3" y="561" width="8.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.32" y="573.5" ></text>
+</g>
+<g >
+<title>copy_process (227,531,407 samples, 0.04%)</title><rect x="270.0" y="141" width="1.5" height="19.0" fill="rgb(239,160,38)" rx="2" ry="2" />
+<text  x="272.99" y="153.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (436,055,112 samples, 0.07%)</title><rect x="888.5" y="1581" width="2.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="891.55" y="1593.5" ></text>
+</g>
+<g >
+<title>__GI___libc_open (5,047,956,817 samples, 0.79%)</title><rect x="1468.6" y="2401" width="33.1" height="19.0" fill="rgb(249,202,48)" rx="2" ry="2" />
+<text  x="1471.65" y="2413.5" >__..</text>
+</g>
+<g >
+<title>execute_command (434,113,565 samples, 0.07%)</title><rect x="400.6" y="1021" width="2.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="403.58" y="1033.5" ></text>
+</g>
+<g >
+<title>execute_command (598,514,664 samples, 0.09%)</title><rect x="891.4" y="2081" width="3.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="894.40" y="2093.5" ></text>
+</g>
+<g >
+<title>getname_flags.part.0 (496,229,234 samples, 0.08%)</title><rect x="1494.2" y="2301" width="3.2" height="19.0" fill="rgb(213,39,9)" rx="2" ry="2" />
+<text  x="1497.16" y="2313.5" ></text>
+</g>
+<g >
+<title>execute_command (158,744,410 samples, 0.02%)</title><rect x="875.9" y="1121" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="878.93" y="1133.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (158,599,791 samples, 0.02%)</title><rect x="875.9" y="1021" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="878.93" y="1033.5" ></text>
+</g>
+<g >
+<title>_IO_file_fopen@@GLIBC_2.2.5 (2,797,302,953 samples, 0.44%)</title><rect x="176.0" y="2441" width="18.4" height="19.0" fill="rgb(237,148,35)" rx="2" ry="2" />
+<text  x="179.04" y="2453.5" ></text>
+</g>
+<g >
+<title>execute_command (164,731,865 samples, 0.03%)</title><rect x="836.5" y="941" width="1.0" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="839.46" y="953.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (76,537,461,807 samples, 11.99%)</title><rect x="307.1" y="2361" width="501.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="310.06" y="2373.5" >execute_command_internal</text>
+</g>
+<g >
+<title>execute_command (598,514,664 samples, 0.09%)</title><rect x="891.4" y="2201" width="3.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="894.40" y="2213.5" ></text>
+</g>
+<g >
+<title>execute_command (598,514,664 samples, 0.09%)</title><rect x="891.4" y="2001" width="3.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="894.40" y="2013.5" ></text>
+</g>
+<g >
+<title>[bash] (241,399,960 samples, 0.04%)</title><rect x="401.5" y="901" width="1.6" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="404.54" y="913.5" ></text>
+</g>
+<g >
+<title>execute_command (193,792,882 samples, 0.03%)</title><rect x="835.2" y="661" width="1.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="838.18" y="673.5" ></text>
+</g>
+<g >
+<title>execute_command (861,612,432 samples, 0.13%)</title><rect x="301.2" y="881" width="5.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="304.16" y="893.5" ></text>
+</g>
+<g >
+<title>execute_command (164,731,865 samples, 0.03%)</title><rect x="836.5" y="1261" width="1.0" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="839.46" y="1273.5" ></text>
+</g>
+<g >
+<title>native_flush_tlb_one_user (185,992,098 samples, 0.03%)</title><rect x="771.2" y="1121" width="1.2" height="19.0" fill="rgb(210,27,6)" rx="2" ry="2" />
+<text  x="774.22" y="1133.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (226,195,951 samples, 0.04%)</title><rect x="232.8" y="2421" width="1.5" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="235.82" y="2433.5" ></text>
+</g>
+<g >
+<title>run_exit_trap (162,312,751 samples, 0.03%)</title><rect x="806.9" y="2281" width="1.1" height="19.0" fill="rgb(242,171,40)" rx="2" ry="2" />
+<text  x="809.93" y="2293.5" ></text>
+</g>
+<g >
+<title>bpf_lsm_file_open (242,006,773 samples, 0.04%)</title><rect x="4139.4" y="2221" width="1.5" height="19.0" fill="rgb(227,105,25)" rx="2" ry="2" />
+<text  x="4142.37" y="2233.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (688,777,208 samples, 0.11%)</title><rect x="268.8" y="1781" width="4.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="271.77" y="1793.5" ></text>
+</g>
+<g >
+<title>parse_and_execute (277,961,909 samples, 0.04%)</title><rect x="866.2" y="221" width="1.8" height="19.0" fill="rgb(243,178,42)" rx="2" ry="2" />
+<text  x="869.16" y="233.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (849,509,116 samples, 0.13%)</title><rect x="895.3" y="2341" width="5.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.35" y="2353.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (549,214,247 samples, 0.09%)</title><rect x="273.3" y="721" width="3.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="276.32" y="733.5" ></text>
+</g>
+<g >
+<title>execute_command (192,670,319 samples, 0.03%)</title><rect x="837.6" y="1181" width="1.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="840.55" y="1193.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (163,954,022 samples, 0.03%)</title><rect x="870.8" y="1221" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="873.82" y="1233.5" ></text>
+</g>
+<g >
+<title>execute_command (554,006,342 samples, 0.09%)</title><rect x="273.3" y="2061" width="3.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="276.29" y="2073.5" ></text>
+</g>
+<g >
+<title>execute_command (578,068,287 samples, 0.09%)</title><rect x="884.6" y="1741" width="3.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="887.62" y="1753.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (717,313,739 samples, 0.11%)</title><rect x="280.1" y="1801" width="4.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.09" y="1813.5" ></text>
+</g>
+<g >
+<title>[bash] (279,356,654 samples, 0.04%)</title><rect x="858.4" y="321" width="1.8" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="861.37" y="333.5" ></text>
+</g>
+<g >
+<title>execute_command (1,263,560,140 samples, 0.20%)</title><rect x="860.3" y="1861" width="8.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="863.30" y="1873.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (716,095,135 samples, 0.11%)</title><rect x="852.2" y="421" width="4.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="855.18" y="433.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (684,675,720 samples, 0.11%)</title><rect x="296.5" y="321" width="4.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.51" y="333.5" ></text>
+</g>
+<g >
+<title>__x64_sys_close (476,606,407 samples, 0.07%)</title><rect x="4004.7" y="2421" width="3.1" height="19.0" fill="rgb(238,153,36)" rx="2" ry="2" />
+<text  x="4007.66" y="2433.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (338,048,422 samples, 0.05%)</title><rect x="2083.8" y="2421" width="2.2" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="2086.75" y="2433.5" ></text>
+</g>
+<g >
+<title>redirection_expand (158,643,683 samples, 0.02%)</title><rect x="836.5" y="541" width="1.0" height="19.0" fill="rgb(218,63,15)" rx="2" ry="2" />
+<text  x="839.50" y="553.5" ></text>
+</g>
+<g >
+<title>_dl_start_user (1,097,685,033 samples, 0.17%)</title><rect x="1578.6" y="2581" width="7.2" height="19.0" fill="rgb(236,145,34)" rx="2" ry="2" />
+<text  x="1581.59" y="2593.5" ></text>
+</g>
+<g >
+<title>new_do_write (560,621,658 samples, 0.09%)</title><rect x="2187.6" y="2461" width="3.6" height="19.0" fill="rgb(206,5,1)" rx="2" ry="2" />
+<text  x="2190.56" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command (194,148,063 samples, 0.03%)</title><rect x="837.5" y="1681" width="1.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="840.54" y="1693.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (516,725,798 samples, 0.08%)</title><rect x="856.9" y="2301" width="3.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="859.92" y="2313.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (481,813,209 samples, 0.08%)</title><rect x="276.9" y="1341" width="3.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="279.93" y="1353.5" ></text>
+</g>
+<g >
+<title>execute_command (598,514,664 samples, 0.09%)</title><rect x="891.4" y="1561" width="3.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="894.40" y="1573.5" ></text>
+</g>
+<g >
+<title>execute_command (578,068,287 samples, 0.09%)</title><rect x="884.6" y="1861" width="3.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="887.62" y="1873.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (194,148,063 samples, 0.03%)</title><rect x="837.5" y="1661" width="1.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="840.54" y="1673.5" ></text>
+</g>
+<g >
+<title>execute_command (1,263,560,140 samples, 0.20%)</title><rect x="860.3" y="2341" width="8.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="863.30" y="2353.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (688,777,208 samples, 0.11%)</title><rect x="268.8" y="2421" width="4.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="271.77" y="2433.5" ></text>
+</g>
+<g >
+<title>kmem_cache_alloc_noprof (171,027,449 samples, 0.03%)</title><rect x="3037.3" y="2281" width="1.1" height="19.0" fill="rgb(205,0,0)" rx="2" ry="2" />
+<text  x="3040.31" y="2293.5" ></text>
+</g>
+<g >
+<title>redirection_expand (881,467,052 samples, 0.14%)</title><rect x="375.3" y="181" width="5.8" height="19.0" fill="rgb(218,63,15)" rx="2" ry="2" />
+<text  x="378.31" y="193.5" ></text>
+</g>
+<g >
+<title>execute_command (513,954,307 samples, 0.08%)</title><rect x="856.9" y="1541" width="3.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="859.94" y="1553.5" ></text>
+</g>
+<g >
+<title>link_path_walk.part.0.constprop.0 (935,728,818 samples, 0.15%)</title><rect x="2025.5" y="2261" width="6.1" height="19.0" fill="rgb(254,229,54)" rx="2" ry="2" />
+<text  x="2028.50" y="2273.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,150,422,968 samples, 0.18%)</title><rect x="827.6" y="2481" width="7.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.57" y="2493.5" ></text>
+</g>
+<g >
+<title>llseek@GLIBC_2.2.5 (661,023,166 samples, 0.10%)</title><rect x="2088.4" y="2481" width="4.3" height="19.0" fill="rgb(239,156,37)" rx="2" ry="2" />
+<text  x="2091.37" y="2493.5" ></text>
+</g>
+<g >
+<title>__fread_unlocked_chk (5,794,638,237 samples, 0.91%)</title><rect x="2044.1" y="2481" width="37.9" height="19.0" fill="rgb(225,94,22)" rx="2" ry="2" />
+<text  x="2047.10" y="2493.5" >__f..</text>
+</g>
+<g >
+<title>[bash] (185,467,659 samples, 0.03%)</title><rect x="835.2" y="481" width="1.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="838.23" y="493.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (193,846,806 samples, 0.03%)</title><rect x="835.2" y="681" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="838.18" y="693.5" ></text>
+</g>
+<g >
+<title>execute_command (891,895,571 samples, 0.14%)</title><rect x="851.1" y="1861" width="5.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="854.08" y="1873.5" ></text>
+</g>
+<g >
+<title>ksys_read (2,516,629,869 samples, 0.39%)</title><rect x="1616.9" y="2401" width="16.5" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="1619.89" y="2413.5" ></text>
+</g>
+<g >
+<title>execute_command (1,150,422,968 samples, 0.18%)</title><rect x="827.6" y="1521" width="7.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="830.57" y="1533.5" ></text>
+</g>
+<g >
+<title>sha384sum (44,111,630,763 samples, 6.91%)</title><rect x="3021.1" y="2601" width="288.8" height="19.0" fill="rgb(242,171,41)" rx="2" ry="2" />
+<text  x="3024.11" y="2613.5" >sha384sum</text>
+</g>
+<g >
+<title>execute_command (1,150,422,968 samples, 0.18%)</title><rect x="827.6" y="2241" width="7.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="830.57" y="2253.5" ></text>
+</g>
+<g >
+<title>execute_command (323,026,366 samples, 0.05%)</title><rect x="868.7" y="1481" width="2.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="871.70" y="1493.5" ></text>
+</g>
+<g >
+<title>__printf_buffer (564,470,149 samples, 0.09%)</title><rect x="4048.9" y="2401" width="3.6" height="19.0" fill="rgb(219,68,16)" rx="2" ry="2" />
+<text  x="4051.85" y="2413.5" ></text>
+</g>
+<g >
+<title>dispose_command (271,133,774 samples, 0.04%)</title><rect x="840.5" y="141" width="1.8" height="19.0" fill="rgb(248,201,48)" rx="2" ry="2" />
+<text  x="843.50" y="153.5" ></text>
+</g>
+<g >
+<title>execute_command (891,895,571 samples, 0.14%)</title><rect x="851.1" y="1821" width="5.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="854.08" y="1833.5" ></text>
+</g>
+<g >
+<title>tlb_finish_mmu (403,441,241 samples, 0.06%)</title><rect x="290.2" y="2381" width="2.6" height="19.0" fill="rgb(207,12,2)" rx="2" ry="2" />
+<text  x="293.16" y="2393.5" ></text>
+</g>
+<g >
+<title>copy_process (2,043,556,084 samples, 0.32%)</title><rect x="694.3" y="1201" width="13.4" height="19.0" fill="rgb(239,160,38)" rx="2" ry="2" />
+<text  x="697.27" y="1213.5" ></text>
+</g>
+<g >
+<title>execute_command (159,710,185 samples, 0.03%)</title><rect x="875.9" y="1861" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="878.92" y="1873.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,259,613,163 samples, 0.20%)</title><rect x="860.3" y="601" width="8.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.32" y="613.5" ></text>
+</g>
+<g >
+<title>syscall_return_via_sysret (191,932,676 samples, 0.03%)</title><rect x="2087.0" y="2441" width="1.3" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="2090.02" y="2453.5" ></text>
+</g>
+<g >
+<title>execute_command (713,521,499 samples, 0.11%)</title><rect x="296.5" y="1901" width="4.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="299.45" y="1913.5" ></text>
+</g>
+<g >
+<title>__printf_buffer (818,752,938 samples, 0.13%)</title><rect x="2100.6" y="2461" width="5.4" height="19.0" fill="rgb(219,68,16)" rx="2" ry="2" />
+<text  x="2103.63" y="2473.5" ></text>
+</g>
+<g >
+<title>all (638,531,124,932 samples, 100%)</title><rect x="10.0" y="2621" width="4180.0" height="19.0" fill="rgb(213,39,9)" rx="2" ry="2" />
+<text  x="13.00" y="2633.5" ></text>
+</g>
+<g >
+<title>__GI___libc_write (526,368,765 samples, 0.08%)</title><rect x="3080.5" y="2441" width="3.5" height="19.0" fill="rgb(217,57,13)" rx="2" ry="2" />
+<text  x="3083.54" y="2453.5" ></text>
+</g>
+<g >
+<title>syscall_return_via_sysret (157,881,409 samples, 0.02%)</title><rect x="1613.5" y="2401" width="1.1" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="1616.54" y="2413.5" ></text>
+</g>
+<g >
+<title>execute_command (688,777,208 samples, 0.11%)</title><rect x="268.8" y="1961" width="4.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="271.77" y="1973.5" ></text>
+</g>
+<g >
+<title>execute_command (516,725,798 samples, 0.08%)</title><rect x="856.9" y="1921" width="3.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="859.92" y="1933.5" ></text>
+</g>
+<g >
+<title>execute_command (713,521,499 samples, 0.11%)</title><rect x="296.5" y="1501" width="4.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="299.45" y="1513.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (686,486,049 samples, 0.11%)</title><rect x="268.8" y="1481" width="4.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="271.78" y="1493.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (513,428,353 samples, 0.08%)</title><rect x="856.9" y="1201" width="3.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="859.94" y="1213.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (598,514,664 samples, 0.09%)</title><rect x="891.4" y="2261" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.40" y="2273.5" ></text>
+</g>
+<g >
+<title>execute_command (1,263,560,140 samples, 0.20%)</title><rect x="860.3" y="2221" width="8.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="863.30" y="2233.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (891,895,571 samples, 0.14%)</title><rect x="851.1" y="2401" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.08" y="2413.5" ></text>
+</g>
+<g >
+<title>execute_command (595,672,870 samples, 0.09%)</title><rect x="891.4" y="801" width="3.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="894.42" y="813.5" ></text>
+</g>
+<g >
+<title>execute_command (5,326,349,599 samples, 0.83%)</title><rect x="359.1" y="821" width="34.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="362.06" y="833.5" >ex..</text>
+</g>
+<g >
+<title>execute_command (5,794,983,125 samples, 0.91%)</title><rect x="356.5" y="901" width="37.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="359.47" y="913.5" >exe..</text>
+</g>
+<g >
+<title>execute_command_internal (849,509,116 samples, 0.13%)</title><rect x="895.3" y="1421" width="5.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.35" y="1433.5" ></text>
+</g>
+<g >
+<title>[bash] (169,097,581 samples, 0.03%)</title><rect x="835.3" y="381" width="1.1" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="838.33" y="393.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (76,163,814,701 samples, 11.93%)</title><rect x="307.9" y="2161" width="498.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="310.93" y="2173.5" >execute_command_internal</text>
+</g>
+<g >
+<title>execute_command (890,006,400 samples, 0.14%)</title><rect x="851.1" y="1441" width="5.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="854.09" y="1453.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (481,813,209 samples, 0.08%)</title><rect x="276.9" y="1501" width="3.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="279.93" y="1513.5" ></text>
+</g>
+<g >
+<title>execute_command (1,261,220,789 samples, 0.20%)</title><rect x="860.3" y="1021" width="8.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="863.32" y="1033.5" ></text>
+</g>
+<g >
+<title>execute_command (595,672,870 samples, 0.09%)</title><rect x="891.4" y="961" width="3.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="894.42" y="973.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (889,542,281 samples, 0.14%)</title><rect x="851.1" y="801" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.09" y="813.5" ></text>
+</g>
+<g >
+<title>execute_command (13,257,342,939 samples, 2.08%)</title><rect x="307.9" y="1381" width="86.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="310.94" y="1393.5" >execute_co..</text>
+</g>
+<g >
+<title>execute_command (598,514,664 samples, 0.09%)</title><rect x="891.4" y="1961" width="3.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="894.40" y="1973.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (283,759,531 samples, 0.04%)</title><rect x="325.2" y="621" width="1.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="328.22" y="633.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (516,725,798 samples, 0.08%)</title><rect x="856.9" y="2221" width="3.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="859.92" y="2233.5" ></text>
+</g>
+<g >
+<title>lookup_fast (232,303,175 samples, 0.04%)</title><rect x="2552.7" y="2261" width="1.5" height="19.0" fill="rgb(226,97,23)" rx="2" ry="2" />
+<text  x="2555.67" y="2273.5" ></text>
+</g>
+<g >
+<title>[bash] (555,813,567 samples, 0.09%)</title><rect x="302.6" y="161" width="3.7" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="305.65" y="173.5" ></text>
+</g>
+<g >
+<title>__x64_sys_close (305,824,356 samples, 0.05%)</title><rect x="2083.9" y="2401" width="2.0" height="19.0" fill="rgb(238,153,36)" rx="2" ry="2" />
+<text  x="2086.85" y="2413.5" ></text>
+</g>
+<g >
+<title>unlink_anon_vmas (302,631,569 samples, 0.05%)</title><rect x="809.4" y="2401" width="2.0" height="19.0" fill="rgb(247,196,47)" rx="2" ry="2" />
+<text  x="812.38" y="2413.5" ></text>
+</g>
+<g >
+<title>execute_command (598,514,664 samples, 0.09%)</title><rect x="891.4" y="1681" width="3.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="894.40" y="1693.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (5,903,016,406 samples, 0.92%)</title><rect x="356.1" y="1121" width="38.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="359.07" y="1133.5" >exe..</text>
+</g>
+<g >
+<title>execute_command (694,354,648 samples, 0.11%)</title><rect x="280.1" y="381" width="4.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="283.11" y="393.5" ></text>
+</g>
+<g >
+<title>_IO_file_xsgetn (809,576,463 samples, 0.13%)</title><rect x="3042.4" y="2461" width="5.3" height="19.0" fill="rgb(207,11,2)" rx="2" ry="2" />
+<text  x="3045.39" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command (713,521,499 samples, 0.11%)</title><rect x="296.5" y="1861" width="4.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="299.45" y="1873.5" ></text>
+</g>
+<g >
+<title>[bash] (1,261,568,072 samples, 0.20%)</title><rect x="860.3" y="1201" width="8.3" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="863.31" y="1213.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (849,509,116 samples, 0.13%)</title><rect x="895.3" y="1501" width="5.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.35" y="1513.5" ></text>
+</g>
+<g >
+<title>ksys_write (157,244,467 samples, 0.02%)</title><rect x="3385.3" y="2381" width="1.0" height="19.0" fill="rgb(212,34,8)" rx="2" ry="2" />
+<text  x="3388.32" y="2393.5" ></text>
+</g>
+<g >
+<title>_Fork (172,399,812 samples, 0.03%)</title><rect x="886.7" y="181" width="1.1" height="19.0" fill="rgb(252,220,52)" rx="2" ry="2" />
+<text  x="889.70" y="193.5" ></text>
+</g>
+<g >
+<title>_dl_sysdep_start (700,148,259 samples, 0.11%)</title><rect x="3015.4" y="2541" width="4.6" height="19.0" fill="rgb(234,137,32)" rx="2" ry="2" />
+<text  x="3018.41" y="2553.5" ></text>
+</g>
+<g >
+<title>execute_command (717,313,739 samples, 0.11%)</title><rect x="280.1" y="1421" width="4.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="283.09" y="1433.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (685,976,378 samples, 0.11%)</title><rect x="268.8" y="1121" width="4.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="271.79" y="1133.5" ></text>
+</g>
+<g >
+<title>_IO_file_overflow@@GLIBC_2.2.5 (574,518,766 samples, 0.09%)</title><rect x="2187.5" y="2501" width="3.7" height="19.0" fill="rgb(239,157,37)" rx="2" ry="2" />
+<text  x="2190.48" y="2513.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,263,560,140 samples, 0.20%)</title><rect x="860.3" y="2361" width="8.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.30" y="2373.5" ></text>
+</g>
+<g >
+<title>entry_SYSRETQ_unsafe_stack (255,000,023 samples, 0.04%)</title><rect x="4022.1" y="2501" width="1.6" height="19.0" fill="rgb(213,37,8)" rx="2" ry="2" />
+<text  x="4025.05" y="2513.5" ></text>
+</g>
+<g >
+<title>execute_command (1,263,560,140 samples, 0.20%)</title><rect x="860.3" y="2301" width="8.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="863.30" y="2313.5" ></text>
+</g>
+<g >
+<title>entry_SYSRETQ_unsafe_stack (174,331,590 samples, 0.03%)</title><rect x="2040.9" y="2381" width="1.1" height="19.0" fill="rgb(213,37,8)" rx="2" ry="2" />
+<text  x="2043.89" y="2393.5" ></text>
+</g>
+<g >
+<title>execute_command (2,118,773,782 samples, 0.33%)</title><rect x="868.6" y="2321" width="13.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="871.57" y="2333.5" ></text>
+</g>
+<g >
+<title>execute_command (843,061,254 samples, 0.13%)</title><rect x="895.4" y="1281" width="5.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="898.39" y="1293.5" ></text>
+</g>
+<g >
+<title>execute_command (320,852,930 samples, 0.05%)</title><rect x="868.7" y="761" width="2.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="871.70" y="773.5" ></text>
+</g>
+<g >
+<title>new_do_write (1,014,325,971 samples, 0.16%)</title><rect x="3895.9" y="2441" width="6.7" height="19.0" fill="rgb(206,5,1)" rx="2" ry="2" />
+<text  x="3898.91" y="2453.5" ></text>
+</g>
+<g >
+<title>[sum] (50,633,176,716 samples, 7.93%)</title><rect x="3687.2" y="2521" width="331.5" height="19.0" fill="rgb(222,78,18)" rx="2" ry="2" />
+<text  x="3690.19" y="2533.5" >[sum]</text>
+</g>
+<g >
+<title>execute_command (598,514,664 samples, 0.09%)</title><rect x="891.4" y="2501" width="3.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="894.40" y="2513.5" ></text>
+</g>
+<g >
+<title>execute_command (1,146,830,397 samples, 0.18%)</title><rect x="827.6" y="921" width="7.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="830.59" y="933.5" ></text>
+</g>
+<g >
+<title>_copy_to_iter (2,265,705,908 samples, 0.35%)</title><rect x="2579.1" y="2321" width="14.8" height="19.0" fill="rgb(234,134,32)" rx="2" ry="2" />
+<text  x="2582.07" y="2333.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,263,560,140 samples, 0.20%)</title><rect x="860.3" y="1481" width="8.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.30" y="1493.5" ></text>
+</g>
+<g >
+<title>execute_command (861,612,432 samples, 0.13%)</title><rect x="301.2" y="801" width="5.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="304.16" y="813.5" ></text>
+</g>
+<g >
+<title>[bash] (305,263,719 samples, 0.05%)</title><rect x="868.8" y="421" width="2.0" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="871.80" y="433.5" ></text>
+</g>
+<g >
+<title>execute_command (685,976,378 samples, 0.11%)</title><rect x="268.8" y="841" width="4.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="271.79" y="853.5" ></text>
+</g>
+<g >
+<title>execute_command (550,598,300 samples, 0.09%)</title><rect x="273.3" y="1061" width="3.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="276.32" y="1073.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (323,026,366 samples, 0.05%)</title><rect x="868.7" y="1261" width="2.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="871.70" y="1273.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (166,042,857 samples, 0.03%)</title><rect x="836.5" y="1561" width="1.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="839.46" y="1573.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (2,386,219,976 samples, 0.37%)</title><rect x="1445.3" y="2381" width="15.6" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="1448.26" y="2393.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (578,068,287 samples, 0.09%)</title><rect x="884.6" y="2521" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="887.62" y="2533.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (322,256,264 samples, 0.05%)</title><rect x="868.7" y="981" width="2.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="871.70" y="993.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,150,422,968 samples, 0.18%)</title><rect x="827.6" y="2021" width="7.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.57" y="2033.5" ></text>
+</g>
+<g >
+<title>execute_command (589,030,705 samples, 0.09%)</title><rect x="350.3" y="821" width="3.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="353.26" y="833.5" ></text>
+</g>
+<g >
+<title>execute_command (573,803,867 samples, 0.09%)</title><rect x="884.6" y="541" width="3.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="887.64" y="553.5" ></text>
+</g>
+<g >
+<title>execute_command (354,998,378 samples, 0.06%)</title><rect x="840.5" y="1421" width="2.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="843.48" y="1433.5" ></text>
+</g>
+<g >
+<title>execute_command (1,150,422,968 samples, 0.18%)</title><rect x="827.6" y="2401" width="7.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="830.57" y="2413.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (866,614,713 samples, 0.14%)</title><rect x="301.1" y="2061" width="5.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.12" y="2073.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (890,006,400 samples, 0.14%)</title><rect x="851.1" y="1281" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.09" y="1293.5" ></text>
+</g>
+<g >
+<title>execute_command (550,598,300 samples, 0.09%)</title><rect x="273.3" y="1021" width="3.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="276.32" y="1033.5" ></text>
+</g>
+<g >
+<title>[bash] (506,678,626 samples, 0.08%)</title><rect x="897.3" y="241" width="3.3" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="900.29" y="253.5" ></text>
+</g>
+<g >
+<title>read (3,438,420,347 samples, 0.54%)</title><rect x="1507.5" y="2441" width="22.5" height="19.0" fill="rgb(252,216,51)" rx="2" ry="2" />
+<text  x="1510.50" y="2453.5" >r..</text>
+</g>
+<g >
+<title>execute_command_internal (575,055,300 samples, 0.09%)</title><rect x="884.6" y="881" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="887.64" y="893.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (436,055,112 samples, 0.07%)</title><rect x="888.5" y="1821" width="2.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="891.55" y="1833.5" ></text>
+</g>
+<g >
+<title>execute_command (551,359,579 samples, 0.09%)</title><rect x="273.3" y="1261" width="3.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="276.31" y="1273.5" ></text>
+</g>
+<g >
+<title>execute_command (717,313,739 samples, 0.11%)</title><rect x="280.1" y="2141" width="4.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="283.09" y="2153.5" ></text>
+</g>
+<g >
+<title>syscall_return_via_sysret (981,363,214 samples, 0.15%)</title><rect x="4112.1" y="2421" width="6.4" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="4115.09" y="2433.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (268,212,480 samples, 0.04%)</title><rect x="830.7" y="181" width="1.8" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="833.73" y="193.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,150,422,968 samples, 0.18%)</title><rect x="827.6" y="1821" width="7.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.57" y="1833.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (686,486,049 samples, 0.11%)</title><rect x="268.8" y="1441" width="4.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="271.78" y="1453.5" ></text>
+</g>
+<g >
+<title>execute_command (194,148,063 samples, 0.03%)</title><rect x="837.5" y="1421" width="1.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="840.54" y="1433.5" ></text>
+</g>
+<g >
+<title>__do_sys_newfstat (219,726,726 samples, 0.03%)</title><rect x="3044.0" y="2361" width="1.5" height="19.0" fill="rgb(225,96,23)" rx="2" ry="2" />
+<text  x="3047.04" y="2373.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,099,735,682 samples, 0.17%)</title><rect x="328.7" y="601" width="7.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="331.70" y="613.5" ></text>
+</g>
+<g >
+<title>rw_verify_area (161,350,426 samples, 0.03%)</title><rect x="3955.7" y="2361" width="1.1" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="3958.72" y="2373.5" ></text>
+</g>
+<g >
+<title>execute_command (866,614,713 samples, 0.14%)</title><rect x="301.1" y="1761" width="5.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="304.12" y="1773.5" ></text>
+</g>
+<g >
+<title>execute_command (215,132,849 samples, 0.03%)</title><rect x="842.8" y="1261" width="1.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="845.81" y="1273.5" ></text>
+</g>
+<g >
+<title>x64_sys_call (2,964,126,674 samples, 0.46%)</title><rect x="808.2" y="2541" width="19.4" height="19.0" fill="rgb(253,224,53)" rx="2" ry="2" />
+<text  x="811.16" y="2553.5" ></text>
+</g>
+<g >
+<title>do_redirections (676,530,787 samples, 0.11%)</title><rect x="852.4" y="381" width="4.5" height="19.0" fill="rgb(247,193,46)" rx="2" ry="2" />
+<text  x="855.44" y="393.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (822,597,060 samples, 0.13%)</title><rect x="895.4" y="381" width="5.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.39" y="393.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (513,954,307 samples, 0.08%)</title><rect x="856.9" y="1221" width="3.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="859.94" y="1233.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,261,220,789 samples, 0.20%)</title><rect x="860.3" y="1061" width="8.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.32" y="1073.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,250,169,612 samples, 0.20%)</title><rect x="860.3" y="401" width="8.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.32" y="413.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (2,625,407,795 samples, 0.41%)</title><rect x="309.9" y="701" width="17.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="312.92" y="713.5" ></text>
+</g>
+<g >
+<title>[sha256sum] (15,856,138,215 samples, 2.48%)</title><rect x="2539.9" y="2581" width="103.8" height="19.0" fill="rgb(216,53,12)" rx="2" ry="2" />
+<text  x="2542.87" y="2593.5" >[sha256sum]</text>
+</g>
+<g >
+<title>execute_command_internal (551,359,579 samples, 0.09%)</title><rect x="273.3" y="1241" width="3.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="276.31" y="1253.5" ></text>
+</g>
+<g >
+<title>execute_command (320,440,447 samples, 0.05%)</title><rect x="868.7" y="641" width="2.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="871.70" y="653.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (218,526,295 samples, 0.03%)</title><rect x="313.1" y="421" width="1.4" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="316.08" y="433.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (172,490,135 samples, 0.03%)</title><rect x="855.3" y="241" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="858.33" y="253.5" ></text>
+</g>
+<g >
+<title>do_redirections (614,957,335 samples, 0.10%)</title><rect x="302.6" y="241" width="4.0" height="19.0" fill="rgb(247,193,46)" rx="2" ry="2" />
+<text  x="305.57" y="253.5" ></text>
+</g>
+<g >
+<title>__d_lookup_rcu (273,929,693 samples, 0.04%)</title><rect x="4173.9" y="2281" width="1.8" height="19.0" fill="rgb(235,139,33)" rx="2" ry="2" />
+<text  x="4176.90" y="2293.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (169,596,485 samples, 0.03%)</title><rect x="871.9" y="661" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="874.90" y="673.5" ></text>
+</g>
+<g >
+<title>sha512sum (57,618,904,435 samples, 9.02%)</title><rect x="3309.9" y="2601" width="377.2" height="19.0" fill="rgb(237,149,35)" rx="2" ry="2" />
+<text  x="3312.88" y="2613.5" >sha512sum</text>
+</g>
+<g >
+<title>exc_page_fault (158,798,300 samples, 0.02%)</title><rect x="547.9" y="1161" width="1.0" height="19.0" fill="rgb(219,65,15)" rx="2" ry="2" />
+<text  x="550.90" y="1173.5" ></text>
+</g>
+<g >
+<title>[bash] (168,758,466 samples, 0.03%)</title><rect x="282.8" y="121" width="1.1" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="285.76" y="133.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (322,256,264 samples, 0.05%)</title><rect x="868.7" y="1141" width="2.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="871.70" y="1153.5" ></text>
+</g>
+<g >
+<title>execute_command (710,231,675 samples, 0.11%)</title><rect x="280.1" y="501" width="4.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="283.11" y="513.5" ></text>
+</g>
+<g >
+<title>execute_command (179,777,548 samples, 0.03%)</title><rect x="878.5" y="1001" width="1.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="881.48" y="1013.5" ></text>
+</g>
+<g >
+<title>[bash] (261,227,463 samples, 0.04%)</title><rect x="832.9" y="201" width="1.7" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="835.86" y="213.5" ></text>
+</g>
+<g >
+<title>syscall_return_via_sysret (158,840,703 samples, 0.02%)</title><rect x="3046.6" y="2401" width="1.0" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="3049.56" y="2413.5" ></text>
+</g>
+<g >
+<title>execute_command (704,492,242 samples, 0.11%)</title><rect x="296.5" y="581" width="4.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="299.51" y="593.5" ></text>
+</g>
+<g >
+<title>execute_command (76,204,885,733 samples, 11.93%)</title><rect x="307.9" y="2221" width="498.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="310.93" y="2233.5" >execute_command</text>
+</g>
+<g >
+<title>execute_command (4,493,671,589 samples, 0.70%)</title><rect x="309.8" y="761" width="29.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="312.84" y="773.5" >ex..</text>
+</g>
+<g >
+<title>execute_command_internal (481,191,724 samples, 0.08%)</title><rect x="276.9" y="961" width="3.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="279.94" y="973.5" ></text>
+</g>
+<g >
+<title>_dl_relocate_object (308,938,834 samples, 0.05%)</title><rect x="2536.3" y="2501" width="2.0" height="19.0" fill="rgb(231,120,28)" rx="2" ry="2" />
+<text  x="2539.29" y="2513.5" ></text>
+</g>
+<g >
+<title>execute_command (433,500,595 samples, 0.07%)</title><rect x="888.6" y="1201" width="2.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="891.56" y="1213.5" ></text>
+</g>
+<g >
+<title>execute_command (13,307,945,229 samples, 2.08%)</title><rect x="307.9" y="1861" width="87.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="310.94" y="1873.5" >execute_co..</text>
+</g>
+<g >
+<title>execute_command_internal (598,514,664 samples, 0.09%)</title><rect x="891.4" y="2061" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.40" y="2073.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (5,801,320,077 samples, 0.91%)</title><rect x="356.4" y="941" width="38.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="359.43" y="953.5" >exe..</text>
+</g>
+<g >
+<title>execute_command_internal (1,146,830,397 samples, 0.18%)</title><rect x="827.6" y="861" width="7.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.59" y="873.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (159,253,151 samples, 0.02%)</title><rect x="851.1" y="361" width="1.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.09" y="373.5" ></text>
+</g>
+<g >
+<title>__printf_chk (545,448,943 samples, 0.09%)</title><rect x="3996.3" y="2481" width="3.6" height="19.0" fill="rgb(212,36,8)" rx="2" ry="2" />
+<text  x="3999.31" y="2493.5" ></text>
+</g>
+<g >
+<title>dispose_command (275,125,986 samples, 0.04%)</title><rect x="840.5" y="201" width="1.8" height="19.0" fill="rgb(248,201,48)" rx="2" ry="2" />
+<text  x="843.49" y="213.5" ></text>
+</g>
+<g >
+<title>execute_command (170,489,782 samples, 0.03%)</title><rect x="871.9" y="1241" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="874.90" y="1253.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (717,313,739 samples, 0.11%)</title><rect x="280.1" y="1481" width="4.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.09" y="1493.5" ></text>
+</g>
+<g >
+<title>[bash] (171,847,094 samples, 0.03%)</title><rect x="871.9" y="1461" width="1.1" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="874.89" y="1473.5" ></text>
+</g>
+<g >
+<title>execute_command (1,142,026,027 samples, 0.18%)</title><rect x="827.6" y="441" width="7.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="830.59" y="453.5" ></text>
+</g>
+<g >
+<title>_int_free_merge_chunk (621,551,824 samples, 0.10%)</title><rect x="778.4" y="1321" width="4.1" height="19.0" fill="rgb(240,163,39)" rx="2" ry="2" />
+<text  x="781.38" y="1333.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,261,220,789 samples, 0.20%)</title><rect x="860.3" y="921" width="8.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.32" y="933.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (179,777,548 samples, 0.03%)</title><rect x="878.5" y="1141" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="881.48" y="1153.5" ></text>
+</g>
+<g >
+<title>execute_command (516,725,798 samples, 0.08%)</title><rect x="856.9" y="1761" width="3.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="859.92" y="1773.5" ></text>
+</g>
+<g >
+<title>__GI___libc_open (2,688,537,042 samples, 0.42%)</title><rect x="3023.7" y="2401" width="17.6" height="19.0" fill="rgb(249,202,48)" rx="2" ry="2" />
+<text  x="3026.65" y="2413.5" ></text>
+</g>
+<g >
+<title>__irqentry_text_end (499,593,812 samples, 0.08%)</title><rect x="449.3" y="1021" width="3.2" height="19.0" fill="rgb(254,228,54)" rx="2" ry="2" />
+<text  x="452.26" y="1033.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (164,731,865 samples, 0.03%)</title><rect x="836.5" y="1241" width="1.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="839.46" y="1253.5" ></text>
+</g>
+<g >
+<title>[bash] (356,134,455 samples, 0.06%)</title><rect x="840.5" y="1641" width="2.3" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="843.47" y="1653.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (890,006,400 samples, 0.14%)</title><rect x="851.1" y="1201" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.09" y="1213.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (713,521,499 samples, 0.11%)</title><rect x="296.5" y="1841" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.45" y="1853.5" ></text>
+</g>
+<g >
+<title>do_filp_open (227,656,164 samples, 0.04%)</title><rect x="320.0" y="421" width="1.5" height="19.0" fill="rgb(217,58,13)" rx="2" ry="2" />
+<text  x="323.02" y="433.5" ></text>
+</g>
+<g >
+<title>execute_command (688,777,208 samples, 0.11%)</title><rect x="268.8" y="2081" width="4.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="271.77" y="2093.5" ></text>
+</g>
+<g >
+<title>__libc_fork (473,792,159 samples, 0.07%)</title><rect x="862.9" y="201" width="3.1" height="19.0" fill="rgb(220,70,16)" rx="2" ry="2" />
+<text  x="865.89" y="213.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,036,429,910 samples, 0.16%)</title><rect x="884.6" y="2561" width="6.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="887.62" y="2573.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (190,019,711 samples, 0.03%)</title><rect x="837.6" y="661" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="840.56" y="673.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (575,800,354 samples, 0.09%)</title><rect x="884.6" y="1281" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="887.64" y="1293.5" ></text>
+</g>
+<g >
+<title>_IO_fread (9,577,641,959 samples, 1.50%)</title><rect x="4055.8" y="2461" width="62.7" height="19.0" fill="rgb(233,132,31)" rx="2" ry="2" />
+<text  x="4058.82" y="2473.5" >_IO_fr..</text>
+</g>
+<g >
+<title>execute_command_internal (356,134,455 samples, 0.06%)</title><rect x="840.5" y="1601" width="2.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="843.47" y="1613.5" ></text>
+</g>
+<g >
+<title>security_inode_permission (647,714,320 samples, 0.10%)</title><rect x="4127.7" y="2261" width="4.2" height="19.0" fill="rgb(215,47,11)" rx="2" ry="2" />
+<text  x="4130.69" y="2273.5" ></text>
+</g>
+<g >
+<title>execute_command (516,725,798 samples, 0.08%)</title><rect x="856.9" y="2161" width="3.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="859.92" y="2173.5" ></text>
+</g>
+<g >
+<title>execute_command (4,067,292,861 samples, 0.64%)</title><rect x="360.6" y="421" width="26.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="363.63" y="433.5" >e..</text>
+</g>
+<g >
+<title>execute_command (171,847,094 samples, 0.03%)</title><rect x="871.9" y="1561" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="874.89" y="1573.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (320,440,447 samples, 0.05%)</title><rect x="868.7" y="621" width="2.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="871.70" y="633.5" ></text>
+</g>
+<g >
+<title>redirection_expand (185,467,659 samples, 0.03%)</title><rect x="835.2" y="501" width="1.2" height="19.0" fill="rgb(218,63,15)" rx="2" ry="2" />
+<text  x="838.23" y="513.5" ></text>
+</g>
+<g >
+<title>execute_command (1,103,913,664 samples, 0.17%)</title><rect x="328.7" y="621" width="7.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="331.68" y="633.5" ></text>
+</g>
+<g >
+<title>sha1sum (41,968,644,349 samples, 6.57%)</title><rect x="1848.2" y="2601" width="274.7" height="19.0" fill="rgb(252,220,52)" rx="2" ry="2" />
+<text  x="1851.18" y="2613.5" >sha1sum</text>
+</g>
+<g >
+<title>execute_command_internal (170,489,782 samples, 0.03%)</title><rect x="871.9" y="1321" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="874.90" y="1333.5" ></text>
+</g>
+<g >
+<title>[bash] (598,514,664 samples, 0.09%)</title><rect x="891.4" y="2441" width="3.9" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="894.40" y="2453.5" ></text>
+</g>
+<g >
+<title>execute_command (891,895,571 samples, 0.14%)</title><rect x="851.1" y="2301" width="5.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="854.08" y="2313.5" ></text>
+</g>
+<g >
+<title>[bash] (156,895,695 samples, 0.02%)</title><rect x="870.9" y="501" width="1.0" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="873.86" y="513.5" ></text>
+</g>
+<g >
+<title>path_openat (2,218,121,946 samples, 0.35%)</title><rect x="2023.9" y="2281" width="14.5" height="19.0" fill="rgb(205,2,0)" rx="2" ry="2" />
+<text  x="2026.92" y="2293.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (713,462,810 samples, 0.11%)</title><rect x="280.1" y="961" width="4.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.11" y="973.5" ></text>
+</g>
+<g >
+<title>main (598,514,664 samples, 0.09%)</title><rect x="891.4" y="2581" width="3.9" height="19.0" fill="rgb(243,179,42)" rx="2" ry="2" />
+<text  x="894.40" y="2593.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (76,158,870,483 samples, 11.93%)</title><rect x="307.9" y="1881" width="498.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="310.94" y="1893.5" >execute_command_internal</text>
+</g>
+<g >
+<title>__fput (190,151,939 samples, 0.03%)</title><rect x="3374.4" y="2381" width="1.3" height="19.0" fill="rgb(205,0,0)" rx="2" ry="2" />
+<text  x="3377.43" y="2393.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (890,006,400 samples, 0.14%)</title><rect x="851.1" y="1161" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.09" y="1173.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (578,068,287 samples, 0.09%)</title><rect x="884.6" y="1601" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="887.62" y="1613.5" ></text>
+</g>
+<g >
+<title>do_select (180,536,913 samples, 0.03%)</title><rect x="313.2" y="341" width="1.1" height="19.0" fill="rgb(208,18,4)" rx="2" ry="2" />
+<text  x="316.16" y="353.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (483,985,097 samples, 0.08%)</title><rect x="276.9" y="2441" width="3.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="279.92" y="2453.5" ></text>
+</g>
+<g >
+<title>entry_SYSRETQ_unsafe_stack (246,284,292 samples, 0.04%)</title><rect x="4155.3" y="2441" width="1.6" height="19.0" fill="rgb(213,37,8)" rx="2" ry="2" />
+<text  x="4158.34" y="2453.5" ></text>
+</g>
+<g >
+<title>[bash] (323,026,366 samples, 0.05%)</title><rect x="868.7" y="1381" width="2.1" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="871.70" y="1393.5" ></text>
+</g>
+<g >
+<title>[bash] (166,943,806 samples, 0.03%)</title><rect x="871.9" y="541" width="1.1" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="874.92" y="553.5" ></text>
+</g>
+<g >
+<title>_IO_file_overflow@@GLIBC_2.2.5 (729,888,982 samples, 0.11%)</title><rect x="3384.2" y="2501" width="4.7" height="19.0" fill="rgb(239,157,37)" rx="2" ry="2" />
+<text  x="3387.16" y="2513.5" ></text>
+</g>
+<g >
+<title>execute_command (17,289,424,444 samples, 2.71%)</title><rect x="398.2" y="1381" width="113.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="401.24" y="1393.5" >execute_command</text>
+</g>
+<g >
+<title>syscall_return_via_sysret (302,638,289 samples, 0.05%)</title><rect x="3900.6" y="2401" width="2.0" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="3903.57" y="2413.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (436,055,112 samples, 0.07%)</title><rect x="888.5" y="1701" width="2.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="891.55" y="1713.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (598,514,664 samples, 0.09%)</title><rect x="891.4" y="2421" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.40" y="2433.5" ></text>
+</g>
+<g >
+<title>execute_command (843,061,254 samples, 0.13%)</title><rect x="895.4" y="1121" width="5.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="898.39" y="1133.5" ></text>
+</g>
+<g >
+<title>execute_command (7,151,129,018 samples, 1.12%)</title><rect x="308.9" y="921" width="46.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="311.88" y="933.5" >exec..</text>
+</g>
+<g >
+<title>execute_command_internal (265,116,794 samples, 0.04%)</title><rect x="898.4" y="181" width="1.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="901.39" y="193.5" ></text>
+</g>
+<g >
+<title>execute_command (163,954,022 samples, 0.03%)</title><rect x="870.8" y="1161" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="873.82" y="1173.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (575,055,300 samples, 0.09%)</title><rect x="884.6" y="1001" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="887.64" y="1013.5" ></text>
+</g>
+<g >
+<title>execute_command (1,513,658,329 samples, 0.24%)</title><rect x="868.6" y="2001" width="9.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="871.57" y="2013.5" ></text>
+</g>
+<g >
+<title>_IO_file_overflow@@GLIBC_2.2.5 (521,392,343 samples, 0.08%)</title><rect x="1565.0" y="2501" width="3.4" height="19.0" fill="rgb(239,157,37)" rx="2" ry="2" />
+<text  x="1567.99" y="2513.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (883,153,075 samples, 0.14%)</title><rect x="851.1" y="481" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.09" y="493.5" ></text>
+</g>
+<g >
+<title>vfs_open (469,167,753 samples, 0.07%)</title><rect x="3327.7" y="2261" width="3.0" height="19.0" fill="rgb(238,154,37)" rx="2" ry="2" />
+<text  x="3330.65" y="2273.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (866,614,713 samples, 0.14%)</title><rect x="301.1" y="1501" width="5.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.12" y="1513.5" ></text>
+</g>
+<g >
+<title>execute_command (164,209,678 samples, 0.03%)</title><rect x="836.5" y="821" width="1.0" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="839.46" y="833.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (598,514,664 samples, 0.09%)</title><rect x="891.4" y="1661" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.40" y="1673.5" ></text>
+</g>
+<g >
+<title>dispose_command (278,788,607 samples, 0.04%)</title><rect x="840.5" y="541" width="1.8" height="19.0" fill="rgb(248,201,48)" rx="2" ry="2" />
+<text  x="843.48" y="553.5" ></text>
+</g>
+<g >
+<title>dispose_command (278,788,607 samples, 0.04%)</title><rect x="840.5" y="441" width="1.8" height="19.0" fill="rgb(248,201,48)" rx="2" ry="2" />
+<text  x="843.48" y="453.5" ></text>
+</g>
+<g >
+<title>parse_and_execute (208,335,133 samples, 0.03%)</title><rect x="869.4" y="401" width="1.4" height="19.0" fill="rgb(243,178,42)" rx="2" ry="2" />
+<text  x="872.43" y="413.5" ></text>
+</g>
+<g >
+<title>execute_command (575,800,354 samples, 0.09%)</title><rect x="884.6" y="1221" width="3.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="887.64" y="1233.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (713,987,302 samples, 0.11%)</title><rect x="280.1" y="1281" width="4.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.11" y="1293.5" ></text>
+</g>
+<g >
+<title>kmem_cache_alloc_noprof (320,297,637 samples, 0.05%)</title><rect x="3929.8" y="2301" width="2.1" height="19.0" fill="rgb(205,0,0)" rx="2" ry="2" />
+<text  x="3932.85" y="2313.5" ></text>
+</g>
+<g >
+<title>security_file_open (347,157,355 samples, 0.05%)</title><rect x="3927.2" y="2241" width="2.2" height="19.0" fill="rgb(215,47,11)" rx="2" ry="2" />
+<text  x="3930.16" y="2253.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (717,313,739 samples, 0.11%)</title><rect x="280.1" y="1761" width="4.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.09" y="1773.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (59,818,658,640 samples, 9.37%)</title><rect x="397.8" y="1441" width="391.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="400.85" y="1453.5" >execute_command_internal</text>
+</g>
+<g >
+<title>execute_command_internal (201,027,753 samples, 0.03%)</title><rect x="827.7" y="161" width="1.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.67" y="173.5" ></text>
+</g>
+<g >
+<title>_int_malloc (3,509,096,737 samples, 0.55%)</title><rect x="719.1" y="1301" width="23.0" height="19.0" fill="rgb(215,47,11)" rx="2" ry="2" />
+<text  x="722.13" y="1313.5" >_..</text>
+</g>
+<g >
+<title>execute_command_internal (578,068,287 samples, 0.09%)</title><rect x="884.6" y="2081" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="887.62" y="2093.5" ></text>
+</g>
+<g >
+<title>execute_command (688,777,208 samples, 0.11%)</title><rect x="268.8" y="2201" width="4.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="271.77" y="2213.5" ></text>
+</g>
+<g >
+<title>execute_command (713,521,499 samples, 0.11%)</title><rect x="296.5" y="2181" width="4.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="299.45" y="2193.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (713,521,499 samples, 0.11%)</title><rect x="296.5" y="1721" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.45" y="1733.5" ></text>
+</g>
+<g >
+<title>execute_command (1,145,759,953 samples, 0.18%)</title><rect x="827.6" y="561" width="7.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="830.59" y="573.5" ></text>
+</g>
+<g >
+<title>xas_load (175,179,000 samples, 0.03%)</title><rect x="4103.6" y="2281" width="1.1" height="19.0" fill="rgb(224,88,21)" rx="2" ry="2" />
+<text  x="4106.60" y="2293.5" ></text>
+</g>
+<g >
+<title>__printf_buffer_flush_to_file (628,209,106 samples, 0.10%)</title><rect x="3410.7" y="2441" width="4.2" height="19.0" fill="rgb(247,197,47)" rx="2" ry="2" />
+<text  x="3413.74" y="2453.5" ></text>
+</g>
+<g >
+<title>security_file_open (186,827,256 samples, 0.03%)</title><rect x="188.9" y="2221" width="1.2" height="19.0" fill="rgb(215,47,11)" rx="2" ry="2" />
+<text  x="191.89" y="2233.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (164,731,865 samples, 0.03%)</title><rect x="836.5" y="1001" width="1.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="839.46" y="1013.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (866,614,713 samples, 0.14%)</title><rect x="301.1" y="1741" width="5.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.12" y="1753.5" ></text>
+</g>
+<g >
+<title>_IO_file_overflow@@GLIBC_2.2.5 (523,774,487 samples, 0.08%)</title><rect x="1530.5" y="2481" width="3.4" height="19.0" fill="rgb(239,157,37)" rx="2" ry="2" />
+<text  x="1533.52" y="2493.5" ></text>
+</g>
+<g >
+<title>execute_command (598,514,664 samples, 0.09%)</title><rect x="891.4" y="1881" width="3.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="894.40" y="1893.5" ></text>
+</g>
+<g >
+<title>entry_SYSRETQ_unsafe_stack (156,204,436 samples, 0.02%)</title><rect x="3376.7" y="2441" width="1.0" height="19.0" fill="rgb(213,37,8)" rx="2" ry="2" />
+<text  x="3379.67" y="2453.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (183,798,433 samples, 0.03%)</title><rect x="860.3" y="361" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.32" y="373.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (688,777,208 samples, 0.11%)</title><rect x="268.8" y="2101" width="4.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="271.77" y="2113.5" ></text>
+</g>
+<g >
+<title>execute_command (849,509,116 samples, 0.13%)</title><rect x="895.3" y="2361" width="5.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="898.35" y="2373.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (220,491,022 samples, 0.03%)</title><rect x="895.4" y="341" width="1.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.39" y="353.5" ></text>
+</g>
+<g >
+<title>execute_command (215,132,849 samples, 0.03%)</title><rect x="842.8" y="1421" width="1.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="845.81" y="1433.5" ></text>
+</g>
+<g >
+<title>[sha512sum] (3,845,664,734 samples, 0.60%)</title><rect x="3312.0" y="2481" width="25.2" height="19.0" fill="rgb(248,201,48)" rx="2" ry="2" />
+<text  x="3315.00" y="2493.5" >[..</text>
+</g>
+<g >
+<title>redirection_expand (363,965,128 samples, 0.06%)</title><rect x="892.8" y="241" width="2.4" height="19.0" fill="rgb(218,63,15)" rx="2" ry="2" />
+<text  x="895.77" y="253.5" ></text>
+</g>
+<g >
+<title>execute_command (567,730,480 samples, 0.09%)</title><rect x="835.1" y="1741" width="3.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="838.10" y="1753.5" ></text>
+</g>
+<g >
+<title>lookup_fast (169,995,206 samples, 0.03%)</title><rect x="183.5" y="2221" width="1.2" height="19.0" fill="rgb(226,97,23)" rx="2" ry="2" />
+<text  x="186.55" y="2233.5" ></text>
+</g>
+<g >
+<title>_dl_start_user (550,870,489 samples, 0.09%)</title><rect x="3305.5" y="2581" width="3.6" height="19.0" fill="rgb(236,145,34)" rx="2" ry="2" />
+<text  x="3308.53" y="2593.5" ></text>
+</g>
+<g >
+<title>[bash] (543,054,172 samples, 0.09%)</title><rect x="269.5" y="301" width="3.6" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="272.54" y="313.5" ></text>
+</g>
+<g >
+<title>execute_command (179,777,548 samples, 0.03%)</title><rect x="878.5" y="1481" width="1.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="881.48" y="1493.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (436,055,112 samples, 0.07%)</title><rect x="888.5" y="2061" width="2.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="891.55" y="2073.5" ></text>
+</g>
+<g >
+<title>[bash] (517,034,501 samples, 0.08%)</title><rect x="273.5" y="481" width="3.4" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="276.52" y="493.5" ></text>
+</g>
+<g >
+<title>execute_command (713,521,499 samples, 0.11%)</title><rect x="296.5" y="1621" width="4.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="299.45" y="1633.5" ></text>
+</g>
+<g >
+<title>execute_command (164,731,865 samples, 0.03%)</title><rect x="836.5" y="1061" width="1.0" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="839.46" y="1073.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (578,068,287 samples, 0.09%)</title><rect x="884.6" y="1561" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="887.62" y="1573.5" ></text>
+</g>
+<g >
+<title>[bash] (158,599,791 samples, 0.02%)</title><rect x="875.9" y="741" width="1.1" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="878.93" y="753.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (7,205,724,382 samples, 1.13%)</title><rect x="308.5" y="1001" width="47.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="311.54" y="1013.5" >exec..</text>
+</g>
+<g >
+<title>_int_free (229,872,200 samples, 0.04%)</title><rect x="609.9" y="1281" width="1.5" height="19.0" fill="rgb(247,196,46)" rx="2" ry="2" />
+<text  x="612.86" y="1293.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (62,297,094,765 samples, 9.76%)</title><rect x="395.5" y="1581" width="407.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="398.50" y="1593.5" >execute_command_internal</text>
+</g>
+<g >
+<title>execute_command_internal (1,150,422,968 samples, 0.18%)</title><rect x="827.6" y="2301" width="7.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.57" y="2313.5" ></text>
+</g>
+<g >
+<title>__printf_buffer_flush_to_file (311,225,482 samples, 0.05%)</title><rect x="1544.2" y="2421" width="2.1" height="19.0" fill="rgb(247,197,47)" rx="2" ry="2" />
+<text  x="1547.24" y="2433.5" ></text>
+</g>
+<g >
+<title>__close_nocancel (154,196,997 samples, 0.02%)</title><rect x="4034.3" y="2461" width="1.0" height="19.0" fill="rgb(228,109,26)" rx="2" ry="2" />
+<text  x="4037.32" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (179,777,548 samples, 0.03%)</title><rect x="878.5" y="1461" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="881.48" y="1473.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (598,514,664 samples, 0.09%)</title><rect x="891.4" y="2221" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.40" y="2233.5" ></text>
+</g>
+<g >
+<title>__d_lookup_rcu (162,686,674 samples, 0.03%)</title><rect x="3030.5" y="2201" width="1.1" height="19.0" fill="rgb(235,139,33)" rx="2" ry="2" />
+<text  x="3033.52" y="2213.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (192,670,319 samples, 0.03%)</title><rect x="837.6" y="961" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="840.55" y="973.5" ></text>
+</g>
+<g >
+<title>getname_flags.part.0 (318,756,223 samples, 0.05%)</title><rect x="2560.0" y="2301" width="2.0" height="19.0" fill="rgb(213,39,9)" rx="2" ry="2" />
+<text  x="2562.96" y="2313.5" ></text>
+</g>
+<g >
+<title>_IO_file_xsgetn (1,508,112,379 samples, 0.24%)</title><rect x="4056.2" y="2441" width="9.9" height="19.0" fill="rgb(207,11,2)" rx="2" ry="2" />
+<text  x="4059.24" y="2453.5" ></text>
+</g>
+<g >
+<title>do_wp_page (193,780,224 samples, 0.03%)</title><rect x="455.5" y="921" width="1.2" height="19.0" fill="rgb(219,66,15)" rx="2" ry="2" />
+<text  x="458.46" y="933.5" ></text>
+</g>
+<g >
+<title>entry_SYSRETQ_unsafe_stack (164,912,287 samples, 0.03%)</title><rect x="2090.3" y="2461" width="1.1" height="19.0" fill="rgb(213,37,8)" rx="2" ry="2" />
+<text  x="2093.35" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (215,132,849 samples, 0.03%)</title><rect x="842.8" y="1361" width="1.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="845.81" y="1373.5" ></text>
+</g>
+<g >
+<title>execute_command (549,214,247 samples, 0.09%)</title><rect x="273.3" y="701" width="3.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="276.32" y="713.5" ></text>
+</g>
+<g >
+<title>xxhsum (24,096,144,362 samples, 3.77%)</title><rect x="4032.3" y="2601" width="157.7" height="19.0" fill="rgb(238,154,36)" rx="2" ry="2" />
+<text  x="4035.26" y="2613.5" >xxhsum</text>
+</g>
+<g >
+<title>execute_command (5,905,381,433 samples, 0.92%)</title><rect x="356.1" y="1221" width="38.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="359.06" y="1233.5" >exe..</text>
+</g>
+<g >
+<title>malloc (243,795,128 samples, 0.04%)</title><rect x="580.3" y="1261" width="1.6" height="19.0" fill="rgb(230,119,28)" rx="2" ry="2" />
+<text  x="583.29" y="1273.5" ></text>
+</g>
+<g >
+<title>ksys_write (216,692,963 samples, 0.03%)</title><rect x="3897.4" y="2361" width="1.4" height="19.0" fill="rgb(212,34,8)" rx="2" ry="2" />
+<text  x="3900.39" y="2373.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (511,672,691 samples, 0.08%)</title><rect x="856.9" y="581" width="3.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="859.94" y="593.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (163,954,022 samples, 0.03%)</title><rect x="870.8" y="1101" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="873.82" y="1113.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (7,204,636,165 samples, 1.13%)</title><rect x="308.5" y="981" width="47.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="311.55" y="993.5" >exec..</text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (685,493,780 samples, 0.11%)</title><rect x="4003.5" y="2461" width="4.5" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="4006.47" y="2473.5" ></text>
+</g>
+<g >
+<title>[bash] (481,191,724 samples, 0.08%)</title><rect x="276.9" y="1121" width="3.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="279.94" y="1133.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (481,191,724 samples, 0.08%)</title><rect x="276.9" y="1041" width="3.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="279.94" y="1053.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,147,316,451 samples, 0.18%)</title><rect x="827.6" y="1181" width="7.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.59" y="1193.5" ></text>
+</g>
+<g >
+<title>shmem_get_folio_gfp (388,493,412 samples, 0.06%)</title><rect x="2169.2" y="2341" width="2.5" height="19.0" fill="rgb(219,67,16)" rx="2" ry="2" />
+<text  x="2172.15" y="2353.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (889,542,281 samples, 0.14%)</title><rect x="851.1" y="921" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.09" y="933.5" ></text>
+</g>
+<g >
+<title>[bash] (705,583,873 samples, 0.11%)</title><rect x="296.5" y="1141" width="4.6" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="299.50" y="1153.5" ></text>
+</g>
+<g >
+<title>execute_command (688,777,208 samples, 0.11%)</title><rect x="268.8" y="2321" width="4.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="271.77" y="2333.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (554,006,342 samples, 0.09%)</title><rect x="273.3" y="2041" width="3.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="276.29" y="2053.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (171,847,094 samples, 0.03%)</title><rect x="871.9" y="1521" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="874.89" y="1533.5" ></text>
+</g>
+<g >
+<title>execute_command (704,492,242 samples, 0.11%)</title><rect x="296.5" y="701" width="4.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="299.51" y="713.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (300,891,021 samples, 0.05%)</title><rect x="351.7" y="601" width="1.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="354.68" y="613.5" ></text>
+</g>
+<g >
+<title>execute_command (688,777,208 samples, 0.11%)</title><rect x="268.8" y="1921" width="4.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="271.77" y="1933.5" ></text>
+</g>
+<g >
+<title>syscall_return_via_sysret (160,311,375 samples, 0.03%)</title><rect x="2182.0" y="2441" width="1.0" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="2184.97" y="2453.5" ></text>
+</g>
+<g >
+<title>kmem_cache_alloc_noprof (175,185,071 samples, 0.03%)</title><rect x="2140.0" y="2281" width="1.2" height="19.0" fill="rgb(205,0,0)" rx="2" ry="2" />
+<text  x="2143.01" y="2293.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (717,313,739 samples, 0.11%)</title><rect x="280.1" y="2201" width="4.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.09" y="2213.5" ></text>
+</g>
+<g >
+<title>[bash] (5,801,136,955 samples, 0.91%)</title><rect x="356.4" y="921" width="38.0" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="359.43" y="933.5" >[ba..</text>
+</g>
+<g >
+<title>execute_command (76,163,586,815 samples, 11.93%)</title><rect x="307.9" y="2141" width="498.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="310.93" y="2153.5" >execute_command</text>
+</g>
+<g >
+<title>execute_command_internal (717,313,739 samples, 0.11%)</title><rect x="280.1" y="2421" width="4.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.09" y="2433.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (7,136,114,092 samples, 1.12%)</title><rect x="309.0" y="901" width="46.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="311.96" y="913.5" >exec..</text>
+</g>
+<g >
+<title>execute_command (179,777,548 samples, 0.03%)</title><rect x="878.5" y="1601" width="1.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="881.48" y="1613.5" ></text>
+</g>
+<g >
+<title>__close_nocancel (635,822,767 samples, 0.10%)</title><rect x="1639.3" y="2461" width="4.2" height="19.0" fill="rgb(228,109,26)" rx="2" ry="2" />
+<text  x="1642.29" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (516,725,798 samples, 0.08%)</title><rect x="856.9" y="1821" width="3.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="859.92" y="1833.5" ></text>
+</g>
+<g >
+<title>[bash] (182,615,086 samples, 0.03%)</title><rect x="325.4" y="441" width="1.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="328.41" y="453.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (891,895,571 samples, 0.14%)</title><rect x="851.1" y="1681" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.08" y="1693.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (516,725,798 samples, 0.08%)</title><rect x="856.9" y="2421" width="3.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="859.92" y="2433.5" ></text>
+</g>
+<g >
+<title>getname_flags.part.0 (266,456,849 samples, 0.04%)</title><rect x="2140.0" y="2301" width="1.7" height="19.0" fill="rgb(213,39,9)" rx="2" ry="2" />
+<text  x="2142.97" y="2313.5" ></text>
+</g>
+<g >
+<title>do_user_addr_fault (155,112,435 samples, 0.02%)</title><rect x="547.9" y="1141" width="1.0" height="19.0" fill="rgb(235,138,33)" rx="2" ry="2" />
+<text  x="550.92" y="1153.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (163,563,240 samples, 0.03%)</title><rect x="870.8" y="741" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="873.82" y="753.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (686,486,049 samples, 0.11%)</title><rect x="268.8" y="1421" width="4.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="271.78" y="1433.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (891,895,571 samples, 0.14%)</title><rect x="851.1" y="2121" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.08" y="2133.5" ></text>
+</g>
+<g >
+<title>execute_command (686,486,049 samples, 0.11%)</title><rect x="268.8" y="1361" width="4.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="271.78" y="1373.5" ></text>
+</g>
+<g >
+<title>execute_command (866,614,713 samples, 0.14%)</title><rect x="301.1" y="2161" width="5.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="304.12" y="2173.5" ></text>
+</g>
+<g >
+<title>[bash] (180,216,075 samples, 0.03%)</title><rect x="878.5" y="1801" width="1.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="881.48" y="1813.5" ></text>
+</g>
+<g >
+<title>[bash] (159,217,610 samples, 0.02%)</title><rect x="803.8" y="1461" width="1.0" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="806.80" y="1473.5" ></text>
+</g>
+<g >
+<title>copy_process (434,386,594 samples, 0.07%)</title><rect x="862.9" y="81" width="2.9" height="19.0" fill="rgb(239,160,38)" rx="2" ry="2" />
+<text  x="865.91" y="93.5" ></text>
+</g>
+<g >
+<title>execute_command (688,777,208 samples, 0.11%)</title><rect x="268.8" y="1521" width="4.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="271.77" y="1533.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (2,126,544,501 samples, 0.33%)</title><rect x="694.3" y="1261" width="13.9" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="697.25" y="1273.5" ></text>
+</g>
+<g >
+<title>execute_command (170,489,782 samples, 0.03%)</title><rect x="871.9" y="921" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="874.90" y="933.5" ></text>
+</g>
+<g >
+<title>execute_command (849,509,116 samples, 0.13%)</title><rect x="895.3" y="1681" width="5.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="898.35" y="1693.5" ></text>
+</g>
+<g >
+<title>make_word_list (568,990,976 samples, 0.09%)</title><rect x="642.7" y="1301" width="3.7" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="645.66" y="1313.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (207,707,782 samples, 0.03%)</title><rect x="1585.8" y="2581" width="1.4" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="1588.83" y="2593.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (2,336,163,397 samples, 0.37%)</title><rect x="835.1" y="2441" width="15.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="838.10" y="2453.5" ></text>
+</g>
+<g >
+<title>_IO_doallocbuf (942,310,251 samples, 0.15%)</title><rect x="3337.9" y="2441" width="6.2" height="19.0" fill="rgb(214,45,10)" rx="2" ry="2" />
+<text  x="3340.91" y="2453.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,645,947,880 samples, 0.26%)</title><rect x="835.1" y="2001" width="10.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="838.10" y="2013.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (2,701,883,820 samples, 0.42%)</title><rect x="200.8" y="2421" width="17.7" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="203.84" y="2433.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (483,985,097 samples, 0.08%)</title><rect x="276.9" y="2081" width="3.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="279.92" y="2093.5" ></text>
+</g>
+<g >
+<title>__printf_buffer_to_file_done (478,928,336 samples, 0.08%)</title><rect x="3096.5" y="2461" width="3.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="3099.53" y="2473.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (2,503,786,878 samples, 0.39%)</title><rect x="202.1" y="2401" width="16.4" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="205.14" y="2413.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (3,206,264,102 samples, 0.50%)</title><rect x="2151.4" y="2441" width="21.0" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="2154.38" y="2453.5" ></text>
+</g>
+<g >
+<title>_copy_to_iter (1,621,980,023 samples, 0.25%)</title><rect x="204.8" y="2301" width="10.6" height="19.0" fill="rgb(234,134,32)" rx="2" ry="2" />
+<text  x="207.83" y="2313.5" ></text>
+</g>
+<g >
+<title>[bash] (513,954,307 samples, 0.08%)</title><rect x="856.9" y="1341" width="3.4" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="859.94" y="1353.5" ></text>
+</g>
+<g >
+<title>_int_free_merge_chunk (166,153,940 samples, 0.03%)</title><rect x="532.5" y="1181" width="1.1" height="19.0" fill="rgb(240,163,39)" rx="2" ry="2" />
+<text  x="535.52" y="1193.5" ></text>
+</g>
+<g >
+<title>[bash] (158,744,410 samples, 0.02%)</title><rect x="875.9" y="1501" width="1.1" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="878.93" y="1513.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (889,118,394 samples, 0.14%)</title><rect x="851.1" y="561" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.09" y="573.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (866,614,713 samples, 0.14%)</title><rect x="301.1" y="2301" width="5.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.12" y="2313.5" ></text>
+</g>
+<g >
+<title>syscall_return_via_sysret (293,085,443 samples, 0.05%)</title><rect x="4183.3" y="2481" width="1.9" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="4186.26" y="2493.5" ></text>
+</g>
+<g >
+<title>syscall_return_via_sysret (203,883,997 samples, 0.03%)</title><rect x="2049.6" y="2401" width="1.4" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="2052.63" y="2413.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,261,568,072 samples, 0.20%)</title><rect x="860.3" y="1241" width="8.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.31" y="1253.5" ></text>
+</g>
+<g >
+<title>execute_command (481,191,724 samples, 0.08%)</title><rect x="276.9" y="1021" width="3.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="279.94" y="1033.5" ></text>
+</g>
+<g >
+<title>lookup_fast (313,502,817 samples, 0.05%)</title><rect x="1481.4" y="2221" width="2.0" height="19.0" fill="rgb(226,97,23)" rx="2" ry="2" />
+<text  x="1484.36" y="2233.5" ></text>
+</g>
+<g >
+<title>syscall_return_via_sysret (191,100,200 samples, 0.03%)</title><rect x="3382.0" y="2461" width="1.2" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="3384.96" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command (483,985,097 samples, 0.08%)</title><rect x="276.9" y="1941" width="3.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="279.92" y="1953.5" ></text>
+</g>
+<g >
+<title>_copy_to_iter (3,294,422,621 samples, 0.52%)</title><rect x="3958.9" y="2321" width="21.6" height="19.0" fill="rgb(234,134,32)" rx="2" ry="2" />
+<text  x="3961.92" y="2333.5" >_..</text>
+</g>
+<g >
+<title>execute_command (849,509,116 samples, 0.13%)</title><rect x="895.3" y="1481" width="5.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="898.35" y="1493.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (17,046,433,920 samples, 2.67%)</title><rect x="398.8" y="1281" width="111.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="401.83" y="1293.5" >execute_comma..</text>
+</g>
+<g >
+<title>execute_command_internal (215,748,926 samples, 0.03%)</title><rect x="842.8" y="1901" width="1.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="845.80" y="1913.5" ></text>
+</g>
+<g >
+<title>execute_command (866,614,713 samples, 0.14%)</title><rect x="301.1" y="1881" width="5.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="304.12" y="1893.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (248,586,733 samples, 0.04%)</title><rect x="1610.9" y="2381" width="1.6" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="1613.91" y="2393.5" ></text>
+</g>
+<g >
+<title>path_openat (1,748,722,057 samples, 0.27%)</title><rect x="1592.8" y="2281" width="11.5" height="19.0" fill="rgb(205,2,0)" rx="2" ry="2" />
+<text  x="1595.81" y="2293.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (713,521,499 samples, 0.11%)</title><rect x="296.5" y="2121" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.45" y="2133.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (436,055,112 samples, 0.07%)</title><rect x="888.5" y="2261" width="2.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="891.55" y="2273.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (159,556,533 samples, 0.02%)</title><rect x="331.5" y="441" width="1.0" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="334.48" y="453.5" ></text>
+</g>
+<g >
+<title>handle_mm_fault (165,733,694 samples, 0.03%)</title><rect x="1583.6" y="2421" width="1.1" height="19.0" fill="rgb(240,165,39)" rx="2" ry="2" />
+<text  x="1586.57" y="2433.5" ></text>
+</g>
+<g >
+<title>execute_command (578,068,287 samples, 0.09%)</title><rect x="884.6" y="1581" width="3.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="887.62" y="1593.5" ></text>
+</g>
+<g >
+<title>vfs_fstat (196,431,078 samples, 0.03%)</title><rect x="4060.7" y="2321" width="1.2" height="19.0" fill="rgb(215,46,11)" rx="2" ry="2" />
+<text  x="4063.66" y="2333.5" ></text>
+</g>
+<g >
+<title>ksys_write (276,196,231 samples, 0.04%)</title><rect x="900.9" y="2441" width="1.9" height="19.0" fill="rgb(212,34,8)" rx="2" ry="2" />
+<text  x="903.94" y="2453.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (849,509,116 samples, 0.13%)</title><rect x="895.3" y="1621" width="5.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.35" y="1633.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,144,745,070 samples, 0.18%)</title><rect x="827.6" y="501" width="7.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.59" y="513.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (179,777,548 samples, 0.03%)</title><rect x="878.5" y="1381" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="881.48" y="1393.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (832,026,624 samples, 0.13%)</title><rect x="895.4" y="461" width="5.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.39" y="473.5" ></text>
+</g>
+<g >
+<title>execute_command (554,006,342 samples, 0.09%)</title><rect x="273.3" y="2541" width="3.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="276.29" y="2553.5" ></text>
+</g>
+<g >
+<title>find_variable (196,631,016 samples, 0.03%)</title><rect x="792.7" y="1261" width="1.3" height="19.0" fill="rgb(242,173,41)" rx="2" ry="2" />
+<text  x="795.72" y="1273.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (182,499,389 samples, 0.03%)</title><rect x="803.8" y="1501" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="806.79" y="1513.5" ></text>
+</g>
+<g >
+<title>__x64_sys_exit_group (207,707,782 samples, 0.03%)</title><rect x="1585.8" y="2521" width="1.4" height="19.0" fill="rgb(220,72,17)" rx="2" ry="2" />
+<text  x="1588.83" y="2533.5" ></text>
+</g>
+<g >
+<title>__printf_buffer (1,306,921,898 samples, 0.20%)</title><rect x="3087.8" y="2461" width="8.5" height="19.0" fill="rgb(219,68,16)" rx="2" ry="2" />
+<text  x="3090.76" y="2473.5" ></text>
+</g>
+<g >
+<title>selinux_inode_permission (269,512,891 samples, 0.04%)</title><rect x="1595.7" y="2221" width="1.8" height="19.0" fill="rgb(238,156,37)" rx="2" ry="2" />
+<text  x="1598.72" y="2233.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (861,612,432 samples, 0.13%)</title><rect x="301.2" y="741" width="5.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.16" y="753.5" ></text>
+</g>
+<g >
+<title>__libc_start_call_main (13,123,945,975 samples, 2.06%)</title><rect x="3021.1" y="2541" width="85.9" height="19.0" fill="rgb(210,26,6)" rx="2" ry="2" />
+<text  x="3024.12" y="2553.5" >__libc_sta..</text>
+</g>
+<g >
+<title>execute_command_internal (194,148,063 samples, 0.03%)</title><rect x="837.5" y="1701" width="1.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="840.54" y="1713.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (264,100,248 samples, 0.04%)</title><rect x="827.6" y="301" width="1.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.59" y="313.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (217,258,247 samples, 0.03%)</title><rect x="1647.9" y="2421" width="1.4" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="1650.88" y="2433.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (596,118,643 samples, 0.09%)</title><rect x="891.4" y="1021" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.42" y="1033.5" ></text>
+</g>
+<g >
+<title>[bash] (7,220,008,010 samples, 1.13%)</title><rect x="308.5" y="1021" width="47.3" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="311.54" y="1033.5" >[bash]</text>
+</g>
+<g >
+<title>execute_command (481,813,209 samples, 0.08%)</title><rect x="276.9" y="1381" width="3.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="279.93" y="1393.5" ></text>
+</g>
+<g >
+<title>[bash] (14,555,006,876 samples, 2.28%)</title><rect x="412.5" y="1141" width="95.3" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="415.55" y="1153.5" >[bash]</text>
+</g>
+<g >
+<title>execute_command_internal (323,026,366 samples, 0.05%)</title><rect x="868.7" y="1541" width="2.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="871.70" y="1553.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (713,987,302 samples, 0.11%)</title><rect x="280.1" y="1221" width="4.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.11" y="1233.5" ></text>
+</g>
+<g >
+<title>_IO_file_xsgetn (878,724,882 samples, 0.14%)</title><rect x="2144.9" y="2461" width="5.8" height="19.0" fill="rgb(207,11,2)" rx="2" ry="2" />
+<text  x="2147.90" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command (215,748,926 samples, 0.03%)</title><rect x="842.8" y="1881" width="1.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="845.80" y="1893.5" ></text>
+</g>
+<g >
+<title>execute_command (1,261,568,072 samples, 0.20%)</title><rect x="860.3" y="1341" width="8.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="863.31" y="1353.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,963,824,397 samples, 0.31%)</title><rect x="835.1" y="2201" width="12.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="838.10" y="2213.5" ></text>
+</g>
+<g >
+<title>do_filp_open (1,774,111,934 samples, 0.28%)</title><rect x="1592.6" y="2301" width="11.7" height="19.0" fill="rgb(217,58,13)" rx="2" ry="2" />
+<text  x="1595.64" y="2313.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,261,568,072 samples, 0.20%)</title><rect x="860.3" y="1181" width="8.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.31" y="1193.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (359,523,613 samples, 0.06%)</title><rect x="410.1" y="1141" width="2.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="413.07" y="1153.5" ></text>
+</g>
+<g >
+<title>execute_command (6,890,822,685 samples, 1.08%)</title><rect x="309.0" y="881" width="45.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="312.03" y="893.5" >exec..</text>
+</g>
+<g >
+<title>[bash] (166,042,857 samples, 0.03%)</title><rect x="836.5" y="1461" width="1.0" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="839.46" y="1473.5" ></text>
+</g>
+<g >
+<title>[bash] (540,622,944 samples, 0.08%)</title><rect x="897.2" y="301" width="3.5" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="900.19" y="313.5" ></text>
+</g>
+<g >
+<title>execute_command (551,359,579 samples, 0.09%)</title><rect x="273.3" y="1301" width="3.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="276.31" y="1313.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (685,976,378 samples, 0.11%)</title><rect x="268.8" y="941" width="4.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="271.79" y="953.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (554,006,342 samples, 0.09%)</title><rect x="273.3" y="2441" width="3.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="276.29" y="2453.5" ></text>
+</g>
+<g >
+<title>filemap_get_entry (301,157,464 samples, 0.05%)</title><rect x="2072.8" y="2321" width="1.9" height="19.0" fill="rgb(253,222,53)" rx="2" ry="2" />
+<text  x="2075.76" y="2333.5" ></text>
+</g>
+<g >
+<title>do_sys_openat2 (261,160,382 samples, 0.04%)</title><rect x="320.0" y="441" width="1.7" height="19.0" fill="rgb(209,21,5)" rx="2" ry="2" />
+<text  x="322.98" y="453.5" ></text>
+</g>
+<g >
+<title>[unknown] (240,696,107 samples, 0.04%)</title><rect x="285.1" y="2561" width="1.5" height="19.0" fill="rgb(210,24,5)" rx="2" ry="2" />
+<text  x="288.07" y="2573.5" ></text>
+</g>
+<g >
+<title>vfs_fstat (176,432,898 samples, 0.03%)</title><rect x="3340.2" y="2341" width="1.2" height="19.0" fill="rgb(215,46,11)" rx="2" ry="2" />
+<text  x="3343.23" y="2353.5" ></text>
+</g>
+<g >
+<title>execute_command (717,313,739 samples, 0.11%)</title><rect x="280.1" y="2261" width="4.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="283.09" y="2273.5" ></text>
+</g>
+<g >
+<title>execute_command (158,744,410 samples, 0.02%)</title><rect x="875.9" y="1161" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="878.93" y="1173.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (842,511,421 samples, 0.13%)</title><rect x="895.4" y="781" width="5.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.39" y="793.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (516,725,798 samples, 0.08%)</title><rect x="856.9" y="2461" width="3.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="859.92" y="2473.5" ></text>
+</g>
+<g >
+<title>__d_lookup_rcu (184,647,720 samples, 0.03%)</title><rect x="2133.9" y="2241" width="1.2" height="19.0" fill="rgb(235,139,33)" rx="2" ry="2" />
+<text  x="2136.90" y="2253.5" ></text>
+</g>
+<g >
+<title>execute_command (13,306,993,942 samples, 2.08%)</title><rect x="307.9" y="1781" width="87.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="310.94" y="1793.5" >execute_co..</text>
+</g>
+<g >
+<title>syscall_return_via_sysret (197,867,552 samples, 0.03%)</title><rect x="3342.7" y="2401" width="1.3" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="3345.75" y="2413.5" ></text>
+</g>
+<g >
+<title>execute_command (170,489,782 samples, 0.03%)</title><rect x="871.9" y="1001" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="874.90" y="1013.5" ></text>
+</g>
+<g >
+<title>syscall_return_via_sysret (163,285,017 samples, 0.03%)</title><rect x="1607.1" y="2381" width="1.1" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="1610.11" y="2393.5" ></text>
+</g>
+<g >
+<title>do_dentry_open (575,481,276 samples, 0.09%)</title><rect x="3925.8" y="2261" width="3.7" height="19.0" fill="rgb(249,205,49)" rx="2" ry="2" />
+<text  x="3928.77" y="2273.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (705,583,873 samples, 0.11%)</title><rect x="296.5" y="1301" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.50" y="1313.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (354,938,381 samples, 0.06%)</title><rect x="840.5" y="1041" width="2.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="843.48" y="1053.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (717,313,739 samples, 0.11%)</title><rect x="280.1" y="2361" width="4.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.09" y="2373.5" ></text>
+</g>
+<g >
+<title>__fstat64 (700,547,480 samples, 0.11%)</title><rect x="195.6" y="2401" width="4.6" height="19.0" fill="rgb(224,88,21)" rx="2" ry="2" />
+<text  x="198.58" y="2413.5" ></text>
+</g>
+<g >
+<title>_int_malloc (343,462,120 samples, 0.05%)</title><rect x="647.9" y="1281" width="2.2" height="19.0" fill="rgb(215,47,11)" rx="2" ry="2" />
+<text  x="650.90" y="1293.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (76,163,512,233 samples, 11.93%)</title><rect x="307.9" y="2121" width="498.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="310.93" y="2133.5" >execute_command_internal</text>
+</g>
+<g >
+<title>dispose_command (268,007,342 samples, 0.04%)</title><rect x="840.5" y="121" width="1.8" height="19.0" fill="rgb(248,201,48)" rx="2" ry="2" />
+<text  x="843.51" y="133.5" ></text>
+</g>
+<g >
+<title>execute_command (861,612,432 samples, 0.13%)</title><rect x="301.2" y="601" width="5.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="304.16" y="613.5" ></text>
+</g>
+<g >
+<title>execute_command (17,068,301,261 samples, 2.67%)</title><rect x="398.7" y="1301" width="111.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="401.69" y="1313.5" >execute_command</text>
+</g>
+<g >
+<title>execute_command (717,313,739 samples, 0.11%)</title><rect x="280.1" y="1741" width="4.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="283.09" y="1753.5" ></text>
+</g>
+<g >
+<title>execute_command (1,263,560,140 samples, 0.20%)</title><rect x="860.3" y="2141" width="8.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="863.30" y="2153.5" ></text>
+</g>
+<g >
+<title>execute_command (977,768,443 samples, 0.15%)</title><rect x="868.6" y="1841" width="6.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="871.57" y="1853.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (713,521,499 samples, 0.11%)</title><rect x="296.5" y="2201" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.45" y="2213.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (279,780,297 samples, 0.04%)</title><rect x="858.4" y="341" width="1.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="861.37" y="353.5" ></text>
+</g>
+<g >
+<title>__close_nocancel (1,267,909,868 samples, 0.20%)</title><rect x="1549.8" y="2461" width="8.3" height="19.0" fill="rgb(228,109,26)" rx="2" ry="2" />
+<text  x="1552.79" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command (166,042,857 samples, 0.03%)</title><rect x="836.5" y="1541" width="1.0" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="839.46" y="1553.5" ></text>
+</g>
+<g >
+<title>[xxhsum] (1,008,942,779 samples, 0.16%)</title><rect x="4047.5" y="2441" width="6.6" height="19.0" fill="rgb(249,206,49)" rx="2" ry="2" />
+<text  x="4050.49" y="2453.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (842,511,421 samples, 0.13%)</title><rect x="895.4" y="741" width="5.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.39" y="753.5" ></text>
+</g>
+<g >
+<title>execute_command (598,514,664 samples, 0.09%)</title><rect x="891.4" y="2161" width="3.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="894.40" y="2173.5" ></text>
+</g>
+<g >
+<title>handle_mm_fault (416,892,531 samples, 0.07%)</title><rect x="454.6" y="961" width="2.7" height="19.0" fill="rgb(240,165,39)" rx="2" ry="2" />
+<text  x="457.58" y="973.5" ></text>
+</g>
+<g >
+<title>execute_command (481,813,209 samples, 0.08%)</title><rect x="276.9" y="1421" width="3.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="279.93" y="1433.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (573,803,867 samples, 0.09%)</title><rect x="884.6" y="521" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="887.64" y="533.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,147,316,451 samples, 0.18%)</title><rect x="827.6" y="1201" width="7.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.59" y="1213.5" ></text>
+</g>
+<g >
+<title>execute_command (516,725,798 samples, 0.08%)</title><rect x="856.9" y="1641" width="3.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="859.92" y="1653.5" ></text>
+</g>
+<g >
+<title>execute_command (516,725,798 samples, 0.08%)</title><rect x="856.9" y="2321" width="3.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="859.92" y="2333.5" ></text>
+</g>
+<g >
+<title>path_openat (1,831,734,151 samples, 0.29%)</title><rect x="178.2" y="2281" width="12.0" height="19.0" fill="rgb(205,2,0)" rx="2" ry="2" />
+<text  x="181.19" y="2293.5" ></text>
+</g>
+<g >
+<title>do_redirections (156,895,695 samples, 0.02%)</title><rect x="870.9" y="561" width="1.0" height="19.0" fill="rgb(247,193,46)" rx="2" ry="2" />
+<text  x="873.86" y="573.5" ></text>
+</g>
+<g >
+<title>execute_command (685,594,707 samples, 0.11%)</title><rect x="268.8" y="641" width="4.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="271.79" y="653.5" ></text>
+</g>
+<g >
+<title>execute_command (704,492,242 samples, 0.11%)</title><rect x="296.5" y="861" width="4.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="299.51" y="873.5" ></text>
+</g>
+<g >
+<title>[bash] (159,710,185 samples, 0.03%)</title><rect x="875.9" y="1661" width="1.1" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="878.92" y="1673.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (166,042,857 samples, 0.03%)</title><rect x="836.5" y="1501" width="1.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="839.46" y="1513.5" ></text>
+</g>
+<g >
+<title>execute_command (598,514,664 samples, 0.09%)</title><rect x="891.4" y="1761" width="3.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="894.40" y="1773.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,150,422,968 samples, 0.18%)</title><rect x="827.6" y="2381" width="7.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.57" y="2393.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (578,068,287 samples, 0.09%)</title><rect x="884.6" y="2401" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="887.62" y="2413.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (356,134,455 samples, 0.06%)</title><rect x="840.5" y="1701" width="2.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="843.47" y="1713.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,957,552,560 samples, 0.31%)</title><rect x="868.6" y="2181" width="12.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="871.57" y="2193.5" ></text>
+</g>
+<g >
+<title>_dl_start_user (179,675,228 samples, 0.03%)</title><rect x="266.6" y="2581" width="1.2" height="19.0" fill="rgb(236,145,34)" rx="2" ry="2" />
+<text  x="269.59" y="2593.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (688,777,208 samples, 0.11%)</title><rect x="268.8" y="1741" width="4.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="271.77" y="1753.5" ></text>
+</g>
+<g >
+<title>execute_command (1,150,422,968 samples, 0.18%)</title><rect x="827.6" y="2081" width="7.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="830.57" y="2093.5" ></text>
+</g>
+<g >
+<title>execute_command (511,991,718 samples, 0.08%)</title><rect x="856.9" y="641" width="3.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="859.94" y="653.5" ></text>
+</g>
+<g >
+<title>syscall_return_via_sysret (200,251,162 samples, 0.03%)</title><rect x="3423.4" y="2481" width="1.3" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="3426.43" y="2493.5" ></text>
+</g>
+<g >
+<title>__libc_start_call_main (76,571,585,451 samples, 11.99%)</title><rect x="306.9" y="2541" width="501.2" height="19.0" fill="rgb(210,26,6)" rx="2" ry="2" />
+<text  x="309.86" y="2553.5" >__libc_start_call_main</text>
+</g>
+<g >
+<title>execute_command_internal (862,395,726 samples, 0.14%)</title><rect x="301.2" y="1141" width="5.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.15" y="1153.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (193,994,695 samples, 0.03%)</title><rect x="835.2" y="801" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="838.18" y="813.5" ></text>
+</g>
+<g >
+<title>execute_command (1,263,560,140 samples, 0.20%)</title><rect x="860.3" y="2101" width="8.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="863.30" y="2113.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (705,583,873 samples, 0.11%)</title><rect x="296.5" y="1341" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.50" y="1353.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (307,622,012 samples, 0.05%)</title><rect x="886.3" y="261" width="2.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="889.27" y="273.5" ></text>
+</g>
+<g >
+<title>[bash] (668,489,796 samples, 0.10%)</title><rect x="852.5" y="321" width="4.3" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="855.47" y="333.5" ></text>
+</g>
+<g >
+<title>[libcrypto.so.3.2.2] (38,924,123,971 samples, 6.10%)</title><rect x="3425.6" y="2561" width="254.8" height="19.0" fill="rgb(244,181,43)" rx="2" ry="2" />
+<text  x="3428.55" y="2573.5" >[libcrypto.so.3.2.2]</text>
+</g>
+<g >
+<title>bprm_execve (211,003,922 samples, 0.03%)</title><rect x="662.7" y="1241" width="1.3" height="19.0" fill="rgb(224,91,21)" rx="2" ry="2" />
+<text  x="665.66" y="1253.5" ></text>
+</g>
+<g >
+<title>__close_nocancel (1,224,155,907 samples, 0.19%)</title><rect x="4150.9" y="2461" width="8.0" height="19.0" fill="rgb(228,109,26)" rx="2" ry="2" />
+<text  x="4153.86" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command (215,132,849 samples, 0.03%)</title><rect x="842.8" y="1181" width="1.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="845.81" y="1193.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (713,521,499 samples, 0.11%)</title><rect x="296.5" y="1481" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.45" y="1493.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (483,985,097 samples, 0.08%)</title><rect x="276.9" y="1561" width="3.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="279.92" y="1573.5" ></text>
+</g>
+<g >
+<title>alloc_empty_file (242,449,858 samples, 0.04%)</title><rect x="1471.7" y="2261" width="1.5" height="19.0" fill="rgb(215,49,11)" rx="2" ry="2" />
+<text  x="1474.66" y="2273.5" ></text>
+</g>
+<g >
+<title>[bash] (178,412,735 samples, 0.03%)</title><rect x="385.0" y="281" width="1.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="388.04" y="293.5" ></text>
+</g>
+<g >
+<title>execute_command (853,102,194 samples, 0.13%)</title><rect x="301.2" y="441" width="5.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="304.16" y="453.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (180,216,075 samples, 0.03%)</title><rect x="878.5" y="1961" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="881.48" y="1973.5" ></text>
+</g>
+<g >
+<title>[bash] (890,006,400 samples, 0.14%)</title><rect x="851.1" y="1241" width="5.8" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="854.09" y="1253.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (866,614,713 samples, 0.14%)</title><rect x="301.1" y="1701" width="5.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.12" y="1713.5" ></text>
+</g>
+<g >
+<title>execute_command (861,612,432 samples, 0.13%)</title><rect x="301.2" y="681" width="5.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="304.16" y="693.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (293,802,851 samples, 0.05%)</title><rect x="4012.8" y="2481" width="1.9" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="4015.78" y="2493.5" ></text>
+</g>
+<g >
+<title>__do_sys_newfstat (282,592,497 samples, 0.04%)</title><rect x="2046.4" y="2361" width="1.8" height="19.0" fill="rgb(225,96,23)" rx="2" ry="2" />
+<text  x="2049.38" y="2373.5" ></text>
+</g>
+<g >
+<title>execute_command (578,068,287 samples, 0.09%)</title><rect x="884.6" y="2141" width="3.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="887.62" y="2153.5" ></text>
+</g>
+<g >
+<title>__printf_chk (3,709,208,552 samples, 0.58%)</title><rect x="236.6" y="2501" width="24.3" height="19.0" fill="rgb(212,36,8)" rx="2" ry="2" />
+<text  x="239.61" y="2513.5" >_..</text>
+</g>
+<g >
+<title>_dl_map_object (175,699,957 samples, 0.03%)</title><rect x="3682.0" y="2441" width="1.1" height="19.0" fill="rgb(248,199,47)" rx="2" ry="2" />
+<text  x="3685.00" y="2453.5" ></text>
+</g>
+<g >
+<title>__close_nocancel (1,268,678,655 samples, 0.20%)</title><rect x="4003.3" y="2481" width="8.3" height="19.0" fill="rgb(228,109,26)" rx="2" ry="2" />
+<text  x="4006.32" y="2493.5" ></text>
+</g>
+<g >
+<title>__libc_start_call_main (11,235,804,325 samples, 1.76%)</title><rect x="1589.5" y="2541" width="73.5" height="19.0" fill="rgb(210,26,6)" rx="2" ry="2" />
+<text  x="1592.47" y="2553.5" >__libc_s..</text>
+</g>
+<g >
+<title>[bash] (346,158,915 samples, 0.05%)</title><rect x="889.1" y="461" width="2.3" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="892.08" y="473.5" ></text>
+</g>
+<g >
+<title>parse_and_execute (162,034,714 samples, 0.03%)</title><rect x="806.9" y="2261" width="1.1" height="19.0" fill="rgb(243,178,42)" rx="2" ry="2" />
+<text  x="809.93" y="2273.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (1,617,123,972 samples, 0.25%)</title><rect x="662.1" y="1301" width="10.6" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="665.08" y="1313.5" ></text>
+</g>
+<g >
+<title>execute_command (1,645,947,880 samples, 0.26%)</title><rect x="835.1" y="2021" width="10.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="838.10" y="2033.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (158,599,791 samples, 0.02%)</title><rect x="875.9" y="841" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="878.93" y="853.5" ></text>
+</g>
+<g >
+<title>execute_command (891,895,571 samples, 0.14%)</title><rect x="851.1" y="2421" width="5.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="854.08" y="2433.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (159,815,195 samples, 0.03%)</title><rect x="886.7" y="161" width="1.1" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="889.71" y="173.5" ></text>
+</g>
+<g >
+<title>execute_command (436,055,112 samples, 0.07%)</title><rect x="888.5" y="1961" width="2.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="891.55" y="1973.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (5,161,747,943 samples, 0.81%)</title><rect x="360.0" y="561" width="33.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="362.96" y="573.5" >ex..</text>
+</g>
+<g >
+<title>__GI___libc_write (502,158,772 samples, 0.08%)</title><rect x="1530.6" y="2421" width="3.3" height="19.0" fill="rgb(217,57,13)" rx="2" ry="2" />
+<text  x="1533.65" y="2433.5" ></text>
+</g>
+<g >
+<title>__do_sys_clone (256,839,097 samples, 0.04%)</title><rect x="853.2" y="161" width="1.7" height="19.0" fill="rgb(217,57,13)" rx="2" ry="2" />
+<text  x="856.18" y="173.5" ></text>
+</g>
+<g >
+<title>execute_command (436,055,112 samples, 0.07%)</title><rect x="888.5" y="2161" width="2.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="891.55" y="2173.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (699,290,297 samples, 0.11%)</title><rect x="296.5" y="521" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.51" y="533.5" ></text>
+</g>
+<g >
+<title>__printf_buffer (1,164,944,070 samples, 0.18%)</title><rect x="2624.9" y="2461" width="7.6" height="19.0" fill="rgb(219,68,16)" rx="2" ry="2" />
+<text  x="2627.87" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (705,583,873 samples, 0.11%)</title><rect x="296.5" y="1161" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.50" y="1173.5" ></text>
+</g>
+<g >
+<title>dispose_command (272,857,467 samples, 0.04%)</title><rect x="840.5" y="161" width="1.8" height="19.0" fill="rgb(248,201,48)" rx="2" ry="2" />
+<text  x="843.50" y="173.5" ></text>
+</g>
+<g >
+<title>memset_orig (205,700,482 samples, 0.03%)</title><rect x="3331.2" y="2261" width="1.3" height="19.0" fill="rgb(253,224,53)" rx="2" ry="2" />
+<text  x="3334.15" y="2273.5" ></text>
+</g>
+<g >
+<title>cfree@GLIBC_2.2.5 (158,700,461 samples, 0.02%)</title><rect x="544.5" y="1181" width="1.0" height="19.0" fill="rgb(233,131,31)" rx="2" ry="2" />
+<text  x="547.49" y="1193.5" ></text>
+</g>
+<g >
+<title>do_exit (2,964,126,674 samples, 0.46%)</title><rect x="808.2" y="2481" width="19.4" height="19.0" fill="rgb(238,151,36)" rx="2" ry="2" />
+<text  x="811.16" y="2493.5" ></text>
+</g>
+<g >
+<title>execute_command (7,231,057,977 samples, 1.13%)</title><rect x="308.5" y="1161" width="47.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="311.53" y="1173.5" >exec..</text>
+</g>
+<g >
+<title>execute_command (158,599,791 samples, 0.02%)</title><rect x="875.9" y="1001" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="878.93" y="1013.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (215,132,849 samples, 0.03%)</title><rect x="842.8" y="1041" width="1.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="845.81" y="1053.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (554,006,342 samples, 0.09%)</title><rect x="273.3" y="2241" width="3.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="276.29" y="2253.5" ></text>
+</g>
+<g >
+<title>bprm_execve (1,260,500,822 samples, 0.20%)</title><rect x="288.1" y="2481" width="8.2" height="19.0" fill="rgb(224,91,21)" rx="2" ry="2" />
+<text  x="291.10" y="2493.5" ></text>
+</g>
+<g >
+<title>execute_command (170,489,782 samples, 0.03%)</title><rect x="871.9" y="1161" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="874.90" y="1173.5" ></text>
+</g>
+<g >
+<title>list_string (5,423,551,569 samples, 0.85%)</title><rect x="612.2" y="1321" width="35.5" height="19.0" fill="rgb(248,201,48)" rx="2" ry="2" />
+<text  x="615.23" y="1333.5" >lis..</text>
+</g>
+<g >
+<title>execute_command_internal (215,132,849 samples, 0.03%)</title><rect x="842.8" y="1161" width="1.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="845.81" y="1173.5" ></text>
+</g>
+<g >
+<title>__libc_start_call_main (51,717,884,006 samples, 8.10%)</title><rect x="3687.1" y="2541" width="338.5" height="19.0" fill="rgb(210,26,6)" rx="2" ry="2" />
+<text  x="3690.08" y="2553.5" >__libc_start_call_main</text>
+</g>
+<g >
+<title>_IO_doallocbuf (1,467,977,765 samples, 0.23%)</title><rect x="3938.6" y="2441" width="9.6" height="19.0" fill="rgb(214,45,10)" rx="2" ry="2" />
+<text  x="3941.62" y="2453.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (889,542,281 samples, 0.14%)</title><rect x="851.1" y="1101" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.09" y="1113.5" ></text>
+</g>
+<g >
+<title>_int_free (3,036,951,382 samples, 0.48%)</title><rect x="440.8" y="1041" width="19.8" height="19.0" fill="rgb(247,196,46)" rx="2" ry="2" />
+<text  x="443.77" y="1053.5" ></text>
+</g>
+<g >
+<title>execute_command (853,210,202 samples, 0.13%)</title><rect x="301.2" y="521" width="5.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="304.16" y="533.5" ></text>
+</g>
+<g >
+<title>execute_command (849,509,116 samples, 0.13%)</title><rect x="895.3" y="1921" width="5.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="898.35" y="1933.5" ></text>
+</g>
+<g >
+<title>vfs_fstatat (173,055,451 samples, 0.03%)</title><rect x="407.8" y="941" width="1.1" height="19.0" fill="rgb(239,157,37)" rx="2" ry="2" />
+<text  x="410.76" y="953.5" ></text>
+</g>
+<g >
+<title>execute_command (356,134,455 samples, 0.06%)</title><rect x="840.5" y="1741" width="2.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="843.47" y="1753.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (215,748,926 samples, 0.03%)</title><rect x="842.8" y="1841" width="1.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="845.80" y="1853.5" ></text>
+</g>
+<g >
+<title>entry_SYSRETQ_unsafe_stack (248,810,379 samples, 0.04%)</title><rect x="4181.6" y="2481" width="1.7" height="19.0" fill="rgb(213,37,8)" rx="2" ry="2" />
+<text  x="4184.63" y="2493.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (595,672,870 samples, 0.09%)</title><rect x="891.4" y="901" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.42" y="913.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (843,061,254 samples, 0.13%)</title><rect x="895.4" y="1061" width="5.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.39" y="1073.5" ></text>
+</g>
+<g >
+<title>do_redirections (514,609,782 samples, 0.08%)</title><rect x="330.9" y="521" width="3.4" height="19.0" fill="rgb(247,193,46)" rx="2" ry="2" />
+<text  x="333.90" y="533.5" ></text>
+</g>
+<g >
+<title>avc_has_perm_noaudit (242,128,662 samples, 0.04%)</title><rect x="4130.3" y="2221" width="1.6" height="19.0" fill="rgb(209,18,4)" rx="2" ry="2" />
+<text  x="4133.35" y="2233.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (433,500,595 samples, 0.07%)</title><rect x="888.6" y="1261" width="2.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="891.56" y="1273.5" ></text>
+</g>
+<g >
+<title>[bash] (713,521,499 samples, 0.11%)</title><rect x="296.5" y="2341" width="4.6" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="299.45" y="2353.5" ></text>
+</g>
+<g >
+<title>do_dentry_open (300,346,970 samples, 0.05%)</title><rect x="1602.3" y="2241" width="2.0" height="19.0" fill="rgb(249,205,49)" rx="2" ry="2" />
+<text  x="1605.29" y="2253.5" ></text>
+</g>
+<g >
+<title>fclose@@GLIBC_2.2.5 (770,252,921 samples, 0.12%)</title><rect x="2178.0" y="2481" width="5.1" height="19.0" fill="rgb(251,213,51)" rx="2" ry="2" />
+<text  x="2181.03" y="2493.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (843,061,254 samples, 0.13%)</title><rect x="895.4" y="1341" width="5.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.39" y="1353.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (194,041,960 samples, 0.03%)</title><rect x="866.6" y="121" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="869.57" y="133.5" ></text>
+</g>
+<g >
+<title>__x64_sys_close (258,481,425 samples, 0.04%)</title><rect x="2179.3" y="2401" width="1.7" height="19.0" fill="rgb(238,153,36)" rx="2" ry="2" />
+<text  x="2182.31" y="2413.5" ></text>
+</g>
+<g >
+<title>memset_orig (281,239,155 samples, 0.04%)</title><rect x="1494.5" y="2261" width="1.8" height="19.0" fill="rgb(253,224,53)" rx="2" ry="2" />
+<text  x="1497.50" y="2273.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (483,985,097 samples, 0.08%)</title><rect x="276.9" y="2361" width="3.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="279.92" y="2373.5" ></text>
+</g>
+<g >
+<title>execute_command (192,670,319 samples, 0.03%)</title><rect x="837.6" y="1021" width="1.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="840.55" y="1033.5" ></text>
+</g>
+<g >
+<title>cfree@GLIBC_2.2.5 (274,065,854 samples, 0.04%)</title><rect x="676.4" y="1341" width="1.7" height="19.0" fill="rgb(233,131,31)" rx="2" ry="2" />
+<text  x="679.35" y="1353.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,263,560,140 samples, 0.20%)</title><rect x="860.3" y="2161" width="8.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.30" y="2173.5" ></text>
+</g>
+<g >
+<title>__GI___libc_write (637,921,675 samples, 0.10%)</title><rect x="2616.5" y="2441" width="4.2" height="19.0" fill="rgb(217,57,13)" rx="2" ry="2" />
+<text  x="2619.54" y="2453.5" ></text>
+</g>
+<g >
+<title>_IO_doallocbuf (735,811,794 samples, 0.12%)</title><rect x="195.4" y="2421" width="4.8" height="19.0" fill="rgb(214,45,10)" rx="2" ry="2" />
+<text  x="198.38" y="2433.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,150,422,968 samples, 0.18%)</title><rect x="827.6" y="2341" width="7.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.57" y="2353.5" ></text>
+</g>
+<g >
+<title>__printf_buffer_to_file_done (302,970,517 samples, 0.05%)</title><rect x="2199.9" y="2461" width="2.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="2202.93" y="2473.5" ></text>
+</g>
+<g >
+<title>__libc_start_main@@GLIBC_2.34 (12,982,486,336 samples, 2.03%)</title><rect x="2123.3" y="2561" width="85.0" height="19.0" fill="rgb(229,113,27)" rx="2" ry="2" />
+<text  x="2126.32" y="2573.5" >__libc_sta..</text>
+</g>
+<g >
+<title>[bash] (275,926,512 samples, 0.04%)</title><rect x="325.2" y="601" width="1.9" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="328.25" y="613.5" ></text>
+</g>
+<g >
+<title>[bash] (575,800,354 samples, 0.09%)</title><rect x="884.6" y="1341" width="3.8" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="887.64" y="1353.5" ></text>
+</g>
+<g >
+<title>execute_command (686,486,049 samples, 0.11%)</title><rect x="268.8" y="1461" width="4.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="271.78" y="1473.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (713,521,499 samples, 0.11%)</title><rect x="296.5" y="1681" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.45" y="1693.5" ></text>
+</g>
+<g >
+<title>memset_orig (171,966,290 samples, 0.03%)</title><rect x="2038.8" y="2261" width="1.1" height="19.0" fill="rgb(253,224,53)" rx="2" ry="2" />
+<text  x="2041.81" y="2273.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (270,476,389 samples, 0.04%)</title><rect x="2616.6" y="2421" width="1.8" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="2619.63" y="2433.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,833,940,690 samples, 0.29%)</title><rect x="868.6" y="2061" width="12.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="871.57" y="2073.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (849,509,116 samples, 0.13%)</title><rect x="895.3" y="1701" width="5.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.35" y="1713.5" ></text>
+</g>
+<g >
+<title>execute_command (194,148,063 samples, 0.03%)</title><rect x="837.5" y="1381" width="1.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="840.54" y="1393.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (215,132,849 samples, 0.03%)</title><rect x="842.8" y="1121" width="1.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="845.81" y="1133.5" ></text>
+</g>
+<g >
+<title>[cksum] (102,682,853,429 samples, 16.08%)</title><rect x="903.8" y="2581" width="672.2" height="19.0" fill="rgb(241,167,40)" rx="2" ry="2" />
+<text  x="906.82" y="2593.5" >[cksum]</text>
+</g>
+<g >
+<title>execute_command_internal (862,395,726 samples, 0.14%)</title><rect x="301.2" y="1061" width="5.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.15" y="1073.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (350,943,074 samples, 0.05%)</title><rect x="336.9" y="661" width="2.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="339.90" y="673.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (2,732,177,327 samples, 0.43%)</title><rect x="2023.0" y="2361" width="17.9" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="2026.01" y="2373.5" ></text>
+</g>
+<g >
+<title>sha256sum (73,555,197,684 samples, 11.52%)</title><rect x="2539.6" y="2601" width="481.5" height="19.0" fill="rgb(205,0,0)" rx="2" ry="2" />
+<text  x="2542.60" y="2613.5" >sha256sum</text>
+</g>
+<g >
+<title>__GI___libc_write (650,637,307 samples, 0.10%)</title><rect x="2093.8" y="2441" width="4.2" height="19.0" fill="rgb(217,57,13)" rx="2" ry="2" />
+<text  x="2096.77" y="2453.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (436,055,112 samples, 0.07%)</title><rect x="888.5" y="1541" width="2.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="891.55" y="1553.5" ></text>
+</g>
+<g >
+<title>vfs_open (357,876,713 samples, 0.06%)</title><rect x="3034.8" y="2261" width="2.3" height="19.0" fill="rgb(238,154,37)" rx="2" ry="2" />
+<text  x="3037.80" y="2273.5" ></text>
+</g>
+<g >
+<title>exc_page_fault (1,644,084,495 samples, 0.26%)</title><rect x="764.9" y="1281" width="10.7" height="19.0" fill="rgb(219,65,15)" rx="2" ry="2" />
+<text  x="767.87" y="1293.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (13,301,870,897 samples, 2.08%)</title><rect x="307.9" y="1441" width="87.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="310.94" y="1453.5" >execute_co..</text>
+</g>
+<g >
+<title>execute_command_internal (575,800,354 samples, 0.09%)</title><rect x="884.6" y="1301" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="887.64" y="1313.5" ></text>
+</g>
+<g >
+<title>copy_page_to_iter (1,609,227,836 samples, 0.25%)</title><rect x="1447.5" y="2301" width="10.6" height="19.0" fill="rgb(216,52,12)" rx="2" ry="2" />
+<text  x="1450.54" y="2313.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (554,006,342 samples, 0.09%)</title><rect x="273.3" y="2121" width="3.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="276.29" y="2133.5" ></text>
+</g>
+<g >
+<title>execute_command (554,006,342 samples, 0.09%)</title><rect x="273.3" y="2261" width="3.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="276.29" y="2273.5" ></text>
+</g>
+<g >
+<title>free_pgtables (180,329,855 samples, 0.03%)</title><rect x="288.5" y="2381" width="1.2" height="19.0" fill="rgb(215,46,11)" rx="2" ry="2" />
+<text  x="291.55" y="2393.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (861,612,432 samples, 0.13%)</title><rect x="301.2" y="821" width="5.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.16" y="833.5" ></text>
+</g>
+<g >
+<title>execute_command (891,895,571 samples, 0.14%)</title><rect x="851.1" y="2381" width="5.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="854.08" y="2393.5" ></text>
+</g>
+<g >
+<title>execute_command (1,150,422,968 samples, 0.18%)</title><rect x="827.6" y="1801" width="7.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="830.57" y="1813.5" ></text>
+</g>
+<g >
+<title>execute_command (158,744,410 samples, 0.02%)</title><rect x="875.9" y="1401" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="878.93" y="1413.5" ></text>
+</g>
+<g >
+<title>_copy_to_iter (1,950,122,419 samples, 0.31%)</title><rect x="2156.0" y="2321" width="12.8" height="19.0" fill="rgb(234,134,32)" rx="2" ry="2" />
+<text  x="2159.03" y="2333.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (598,514,664 samples, 0.09%)</title><rect x="891.4" y="2341" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.40" y="2353.5" ></text>
+</g>
+<g >
+<title>__libc_fork (180,663,134 samples, 0.03%)</title><rect x="886.7" y="201" width="1.2" height="19.0" fill="rgb(220,70,16)" rx="2" ry="2" />
+<text  x="889.70" y="213.5" ></text>
+</g>
+<g >
+<title>handle_mm_fault (471,307,925 samples, 0.07%)</title><rect x="724.7" y="1201" width="3.1" height="19.0" fill="rgb(240,165,39)" rx="2" ry="2" />
+<text  x="727.71" y="1213.5" ></text>
+</g>
+<g >
+<title>cfree@GLIBC_2.2.5 (508,846,678 samples, 0.08%)</title><rect x="689.1" y="1321" width="3.3" height="19.0" fill="rgb(233,131,31)" rx="2" ry="2" />
+<text  x="692.09" y="1333.5" ></text>
+</g>
+<g >
+<title>execute_command (713,462,810 samples, 0.11%)</title><rect x="280.1" y="981" width="4.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="283.11" y="993.5" ></text>
+</g>
+<g >
+<title>execute_command (163,954,022 samples, 0.03%)</title><rect x="870.8" y="961" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="873.82" y="973.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (598,514,664 samples, 0.09%)</title><rect x="891.4" y="1581" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.40" y="1593.5" ></text>
+</g>
+<g >
+<title>entry_SYSRETQ_unsafe_stack (267,832,534 samples, 0.04%)</title><rect x="4144.9" y="2401" width="1.8" height="19.0" fill="rgb(213,37,8)" rx="2" ry="2" />
+<text  x="4147.91" y="2413.5" ></text>
+</g>
+<g >
+<title>process_measurement (157,050,339 samples, 0.02%)</title><rect x="1488.0" y="2221" width="1.0" height="19.0" fill="rgb(214,42,10)" rx="2" ry="2" />
+<text  x="1490.98" y="2233.5" ></text>
+</g>
+<g >
+<title>execute_command (705,583,873 samples, 0.11%)</title><rect x="296.5" y="1261" width="4.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="299.50" y="1273.5" ></text>
+</g>
+<g >
+<title>_IO_file_xsgetn (763,284,859 samples, 0.12%)</title><rect x="1502.4" y="2441" width="5.0" height="19.0" fill="rgb(207,11,2)" rx="2" ry="2" />
+<text  x="1505.44" y="2453.5" ></text>
+</g>
+<g >
+<title>__memmove_evex_unaligned_erms (613,280,501 samples, 0.10%)</title><rect x="545.6" y="1201" width="4.1" height="19.0" fill="rgb(226,100,24)" rx="2" ry="2" />
+<text  x="548.64" y="1213.5" ></text>
+</g>
+<g >
+<title>malloc (509,629,930 samples, 0.08%)</title><rect x="540.6" y="1161" width="3.3" height="19.0" fill="rgb(230,119,28)" rx="2" ry="2" />
+<text  x="543.57" y="1173.5" ></text>
+</g>
+<g >
+<title>execute_command (13,306,686,716 samples, 2.08%)</title><rect x="307.9" y="1741" width="87.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="310.94" y="1753.5" >execute_co..</text>
+</g>
+<g >
+<title>openaux (285,218,439 samples, 0.04%)</title><rect x="1579.5" y="2461" width="1.9" height="19.0" fill="rgb(252,217,52)" rx="2" ry="2" />
+<text  x="1582.52" y="2473.5" ></text>
+</g>
+<g >
+<title>[bash] (188,328,554 samples, 0.03%)</title><rect x="837.6" y="461" width="1.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="840.57" y="473.5" ></text>
+</g>
+<g >
+<title>execute_command (180,216,075 samples, 0.03%)</title><rect x="878.5" y="1721" width="1.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="881.48" y="1733.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (180,216,075 samples, 0.03%)</title><rect x="878.5" y="1901" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="881.48" y="1913.5" ></text>
+</g>
+<g >
+<title>__x64_sys_openat (4,193,164,717 samples, 0.66%)</title><rect x="1470.2" y="2341" width="27.4" height="19.0" fill="rgb(208,15,3)" rx="2" ry="2" />
+<text  x="1473.17" y="2353.5" >_..</text>
+</g>
+<g >
+<title>execute_command (4,347,584,888 samples, 0.68%)</title><rect x="360.2" y="501" width="28.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="363.21" y="513.5" >ex..</text>
+</g>
+<g >
+<title>error_entry (201,188,603 samples, 0.03%)</title><rect x="776.2" y="1301" width="1.3" height="19.0" fill="rgb(247,193,46)" rx="2" ry="2" />
+<text  x="779.21" y="1313.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,263,560,140 samples, 0.20%)</title><rect x="860.3" y="1721" width="8.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.30" y="1733.5" ></text>
+</g>
+<g >
+<title>execute_command (425,053,821 samples, 0.07%)</title><rect x="888.6" y="521" width="2.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="891.57" y="533.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (866,614,713 samples, 0.14%)</title><rect x="301.1" y="2101" width="5.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.12" y="2113.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (483,985,097 samples, 0.08%)</title><rect x="276.9" y="2281" width="3.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="279.92" y="2293.5" ></text>
+</g>
+<g >
+<title>execute_command (849,509,116 samples, 0.13%)</title><rect x="895.3" y="2161" width="5.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="898.35" y="2173.5" ></text>
+</g>
+<g >
+<title>execute_command (578,068,287 samples, 0.09%)</title><rect x="884.6" y="1701" width="3.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="887.62" y="1713.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (194,148,063 samples, 0.03%)</title><rect x="837.5" y="1521" width="1.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="840.54" y="1533.5" ></text>
+</g>
+<g >
+<title>entry_SYSRETQ_unsafe_stack (165,527,846 samples, 0.03%)</title><rect x="2613.1" y="2461" width="1.1" height="19.0" fill="rgb(213,37,8)" rx="2" ry="2" />
+<text  x="2616.09" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command (164,808,262 samples, 0.03%)</title><rect x="870.8" y="1621" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="873.81" y="1633.5" ></text>
+</g>
+<g >
+<title>llseek@GLIBC_2.2.5 (1,035,338,917 samples, 0.16%)</title><rect x="4011.8" y="2501" width="6.8" height="19.0" fill="rgb(239,156,37)" rx="2" ry="2" />
+<text  x="4014.81" y="2513.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (849,509,116 samples, 0.13%)</title><rect x="895.3" y="1661" width="5.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.35" y="1673.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (516,725,798 samples, 0.08%)</title><rect x="856.9" y="2061" width="3.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="859.92" y="2073.5" ></text>
+</g>
+<g >
+<title>security_file_open (179,890,118 samples, 0.03%)</title><rect x="1603.0" y="2221" width="1.2" height="19.0" fill="rgb(215,47,11)" rx="2" ry="2" />
+<text  x="1606.03" y="2233.5" ></text>
+</g>
+<g >
+<title>execute_command (436,055,112 samples, 0.07%)</title><rect x="888.5" y="1841" width="2.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="891.55" y="1853.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (688,777,208 samples, 0.11%)</title><rect x="268.8" y="2221" width="4.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="271.77" y="2233.5" ></text>
+</g>
+<g >
+<title>execute_command (578,068,287 samples, 0.09%)</title><rect x="884.6" y="2261" width="3.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="887.62" y="2273.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (192,670,319 samples, 0.03%)</title><rect x="837.6" y="1281" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="840.55" y="1293.5" ></text>
+</g>
+<g >
+<title>execute_command (164,209,678 samples, 0.03%)</title><rect x="836.5" y="781" width="1.0" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="839.46" y="793.5" ></text>
+</g>
+<g >
+<title>syscall_return_via_sysret (319,216,741 samples, 0.05%)</title><rect x="4146.7" y="2401" width="2.0" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="4149.66" y="2413.5" ></text>
+</g>
+<g >
+<title>[bash] (1,263,560,140 samples, 0.20%)</title><rect x="860.3" y="2521" width="8.3" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="863.30" y="2533.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (513,428,353 samples, 0.08%)</title><rect x="856.9" y="941" width="3.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="859.94" y="953.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (5,188,240,893 samples, 0.81%)</title><rect x="359.8" y="601" width="34.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="362.81" y="613.5" >ex..</text>
+</g>
+<g >
+<title>parse_and_execute (717,313,739 samples, 0.11%)</title><rect x="280.1" y="2561" width="4.7" height="19.0" fill="rgb(243,178,42)" rx="2" ry="2" />
+<text  x="283.09" y="2573.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (843,061,254 samples, 0.13%)</title><rect x="895.4" y="1401" width="5.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.39" y="1413.5" ></text>
+</g>
+<g >
+<title>security_file_post_open (171,066,948 samples, 0.03%)</title><rect x="4135.6" y="2281" width="1.2" height="19.0" fill="rgb(218,63,15)" rx="2" ry="2" />
+<text  x="4138.64" y="2293.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (713,521,499 samples, 0.11%)</title><rect x="296.5" y="2281" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.45" y="2293.5" ></text>
+</g>
+<g >
+<title>__printf_buffer_flush_to_file (238,332,705 samples, 0.04%)</title><rect x="2200.4" y="2441" width="1.5" height="19.0" fill="rgb(247,197,47)" rx="2" ry="2" />
+<text  x="2203.36" y="2453.5" ></text>
+</g>
+<g >
+<title>entry_SYSRETQ_unsafe_stack (158,126,029 samples, 0.02%)</title><rect x="3380.9" y="2461" width="1.1" height="19.0" fill="rgb(213,37,8)" rx="2" ry="2" />
+<text  x="3383.92" y="2473.5" ></text>
+</g>
+<g >
+<title>__x64_sys_openat (2,790,018,144 samples, 0.44%)</title><rect x="2543.9" y="2341" width="18.3" height="19.0" fill="rgb(208,15,3)" rx="2" ry="2" />
+<text  x="2546.93" y="2353.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (228,199,340 samples, 0.04%)</title><rect x="3080.6" y="2421" width="1.5" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="3083.64" y="2433.5" ></text>
+</g>
+<g >
+<title>[bash] (510,083,620 samples, 0.08%)</title><rect x="885.1" y="361" width="3.3" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="888.05" y="373.5" ></text>
+</g>
+<g >
+<title>execute_command (548,839,992 samples, 0.09%)</title><rect x="273.3" y="661" width="3.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="276.32" y="673.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (513,954,307 samples, 0.08%)</title><rect x="856.9" y="1401" width="3.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="859.94" y="1413.5" ></text>
+</g>
+<g >
+<title>execute_command (713,521,499 samples, 0.11%)</title><rect x="296.5" y="1581" width="4.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="299.45" y="1593.5" ></text>
+</g>
+<g >
+<title>link_path_walk.part.0.constprop.0 (800,893,082 samples, 0.13%)</title><rect x="3026.3" y="2261" width="5.3" height="19.0" fill="rgb(254,229,54)" rx="2" ry="2" />
+<text  x="3029.35" y="2273.5" ></text>
+</g>
+<g >
+<title>[bash] (842,511,421 samples, 0.13%)</title><rect x="895.4" y="1021" width="5.5" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="898.39" y="1033.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (513,428,353 samples, 0.08%)</title><rect x="856.9" y="1061" width="3.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="859.94" y="1073.5" ></text>
+</g>
+<g >
+<title>execute_command (483,985,097 samples, 0.08%)</title><rect x="276.9" y="2381" width="3.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="279.92" y="2393.5" ></text>
+</g>
+<g >
+<title>execute_command (688,777,208 samples, 0.11%)</title><rect x="268.8" y="1801" width="4.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="271.77" y="1813.5" ></text>
+</g>
+<g >
+<title>execute_command (215,132,849 samples, 0.03%)</title><rect x="842.8" y="1461" width="1.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="845.81" y="1473.5" ></text>
+</g>
+<g >
+<title>execute_command (598,514,664 samples, 0.09%)</title><rect x="891.4" y="1401" width="3.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="894.40" y="1413.5" ></text>
+</g>
+<g >
+<title>execute_command (354,938,381 samples, 0.06%)</title><rect x="840.5" y="1061" width="2.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="843.48" y="1073.5" ></text>
+</g>
+<g >
+<title>do_sys_openat2 (2,668,442,431 samples, 0.42%)</title><rect x="2023.3" y="2321" width="17.4" height="19.0" fill="rgb(209,21,5)" rx="2" ry="2" />
+<text  x="2026.28" y="2333.5" ></text>
+</g>
+<g >
+<title>[bash] (374,342,155 samples, 0.06%)</title><rect x="277.5" y="321" width="2.5" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="280.53" y="333.5" ></text>
+</g>
+<g >
+<title>entry_SYSRETQ_unsafe_stack (331,207,231 samples, 0.05%)</title><rect x="1633.7" y="2441" width="2.2" height="19.0" fill="rgb(213,37,8)" rx="2" ry="2" />
+<text  x="1636.68" y="2453.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (432,872,015 samples, 0.07%)</title><rect x="888.6" y="981" width="2.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="891.57" y="993.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (192,670,319 samples, 0.03%)</title><rect x="837.6" y="1081" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="840.55" y="1093.5" ></text>
+</g>
+<g >
+<title>execute_command (842,511,421 samples, 0.13%)</title><rect x="895.4" y="961" width="5.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="898.39" y="973.5" ></text>
+</g>
+<g >
+<title>[cksum] (102,641,116,816 samples, 16.07%)</title><rect x="903.8" y="2521" width="672.0" height="19.0" fill="rgb(241,167,40)" rx="2" ry="2" />
+<text  x="906.84" y="2533.5" >[cksum]</text>
+</g>
+<g >
+<title>execute_command_internal (1,263,560,140 samples, 0.20%)</title><rect x="860.3" y="1921" width="8.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.30" y="1933.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (2,100,123,359 samples, 0.33%)</title><rect x="789.5" y="1461" width="13.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="792.45" y="1473.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (62,724,337,300 samples, 9.82%)</title><rect x="395.4" y="1641" width="410.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="398.45" y="1653.5" >execute_command_internal</text>
+</g>
+<g >
+<title>execute_command_internal (511,601,820 samples, 0.08%)</title><rect x="856.9" y="541" width="3.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="859.94" y="553.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (391,165,898 samples, 0.06%)</title><rect x="277.5" y="461" width="2.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="280.48" y="473.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (688,777,208 samples, 0.11%)</title><rect x="268.8" y="1701" width="4.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="271.77" y="1713.5" ></text>
+</g>
+<g >
+<title>execute_command (575,800,354 samples, 0.09%)</title><rect x="884.6" y="1461" width="3.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="887.64" y="1473.5" ></text>
+</g>
+<g >
+<title>execute_command (215,132,849 samples, 0.03%)</title><rect x="842.8" y="1021" width="1.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="845.81" y="1033.5" ></text>
+</g>
+<g >
+<title>execute_command (717,313,739 samples, 0.11%)</title><rect x="280.1" y="1941" width="4.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="283.09" y="1953.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (849,509,116 samples, 0.13%)</title><rect x="895.3" y="1581" width="5.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.35" y="1593.5" ></text>
+</g>
+<g >
+<title>tlb_finish_mmu (683,719,888 samples, 0.11%)</title><rect x="812.8" y="2421" width="4.4" height="19.0" fill="rgb(207,12,2)" rx="2" ry="2" />
+<text  x="815.76" y="2433.5" ></text>
+</g>
+<g >
+<title>execute_command (436,055,112 samples, 0.07%)</title><rect x="888.5" y="2041" width="2.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="891.55" y="2053.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (483,985,097 samples, 0.08%)</title><rect x="276.9" y="1521" width="3.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="279.92" y="1533.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,562,146,916 samples, 0.24%)</title><rect x="399.8" y="1121" width="10.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="402.81" y="1133.5" ></text>
+</g>
+<g >
+<title>[b2sum] (38,875,567,733 samples, 6.09%)</title><rect x="10.0" y="2521" width="254.5" height="19.0" fill="rgb(216,50,12)" rx="2" ry="2" />
+<text  x="13.00" y="2533.5" >[b2sum]</text>
+</g>
+<g >
+<title>do_syscall_64 (256,869,487 samples, 0.04%)</title><rect x="853.2" y="181" width="1.7" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="856.18" y="193.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (2,829,076,559 samples, 0.44%)</title><rect x="2022.4" y="2381" width="18.5" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="2025.37" y="2393.5" ></text>
+</g>
+<g >
+<title>execute_command (169,651,850 samples, 0.03%)</title><rect x="871.9" y="801" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="874.90" y="813.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (190,829,147 samples, 0.03%)</title><rect x="837.6" y="761" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="840.55" y="773.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (891,895,571 samples, 0.14%)</title><rect x="851.1" y="1761" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.08" y="1773.5" ></text>
+</g>
+<g >
+<title>__x64_sys_close (322,396,441 samples, 0.05%)</title><rect x="2606.4" y="2401" width="2.1" height="19.0" fill="rgb(238,153,36)" rx="2" ry="2" />
+<text  x="2609.40" y="2413.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (890,006,400 samples, 0.14%)</title><rect x="851.1" y="1461" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.09" y="1473.5" ></text>
+</g>
+<g >
+<title>execute_command (1,150,422,968 samples, 0.18%)</title><rect x="827.6" y="1601" width="7.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="830.57" y="1613.5" ></text>
+</g>
+<g >
+<title>parse_and_execute (354,900,103 samples, 0.06%)</title><rect x="840.5" y="661" width="2.3" height="19.0" fill="rgb(243,178,42)" rx="2" ry="2" />
+<text  x="843.48" y="673.5" ></text>
+</g>
+<g >
+<title>__do_sys_newfstat (424,774,230 samples, 0.07%)</title><rect x="3941.3" y="2361" width="2.7" height="19.0" fill="rgb(225,96,23)" rx="2" ry="2" />
+<text  x="3944.26" y="2373.5" ></text>
+</g>
+<g >
+<title>avc_has_perm_noaudit (164,879,870 samples, 0.03%)</title><rect x="3320.5" y="2201" width="1.1" height="19.0" fill="rgb(209,18,4)" rx="2" ry="2" />
+<text  x="3323.48" y="2213.5" ></text>
+</g>
+<g >
+<title>alloc_empty_file (178,590,430 samples, 0.03%)</title><rect x="3315.4" y="2261" width="1.1" height="19.0" fill="rgb(215,49,11)" rx="2" ry="2" />
+<text  x="3318.35" y="2273.5" ></text>
+</g>
+<g >
+<title>read_builtin (373,798,244 samples, 0.06%)</title><rect x="404.1" y="1001" width="2.5" height="19.0" fill="rgb(235,139,33)" rx="2" ry="2" />
+<text  x="407.10" y="1013.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (598,514,664 samples, 0.09%)</title><rect x="891.4" y="1781" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.40" y="1793.5" ></text>
+</g>
+<g >
+<title>asm_exc_page_fault (153,574,529 samples, 0.02%)</title><rect x="3684.5" y="2481" width="1.0" height="19.0" fill="rgb(231,123,29)" rx="2" ry="2" />
+<text  x="3687.48" y="2493.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (323,026,366 samples, 0.05%)</title><rect x="868.7" y="1461" width="2.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="871.70" y="1473.5" ></text>
+</g>
+<g >
+<title>execute_command (866,614,713 samples, 0.14%)</title><rect x="301.1" y="1561" width="5.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="304.12" y="1573.5" ></text>
+</g>
+<g >
+<title>read (3,410,611,991 samples, 0.53%)</title><rect x="1443.0" y="2421" width="22.3" height="19.0" fill="rgb(252,216,51)" rx="2" ry="2" />
+<text  x="1445.98" y="2433.5" >r..</text>
+</g>
+<g >
+<title>execute_command (891,895,571 samples, 0.14%)</title><rect x="851.1" y="1661" width="5.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="854.08" y="1673.5" ></text>
+</g>
+<g >
+<title>_dl_catch_exception (196,445,265 samples, 0.03%)</title><rect x="3015.9" y="2481" width="1.3" height="19.0" fill="rgb(253,223,53)" rx="2" ry="2" />
+<text  x="3018.87" y="2493.5" ></text>
+</g>
+<g >
+<title>[unknown] (305,263,770 samples, 0.05%)</title><rect x="3012.2" y="2561" width="2.0" height="19.0" fill="rgb(210,24,5)" rx="2" ry="2" />
+<text  x="3015.21" y="2573.5" ></text>
+</g>
+<g >
+<title>execute_command (190,829,147 samples, 0.03%)</title><rect x="837.6" y="821" width="1.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="840.55" y="833.5" ></text>
+</g>
+<g >
+<title>execute_command (866,614,713 samples, 0.14%)</title><rect x="301.1" y="2461" width="5.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="304.12" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,147,316,451 samples, 0.18%)</title><rect x="827.6" y="1381" width="7.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.59" y="1393.5" ></text>
+</g>
+<g >
+<title>dispose_command (278,740,081 samples, 0.04%)</title><rect x="840.5" y="281" width="1.8" height="19.0" fill="rgb(248,201,48)" rx="2" ry="2" />
+<text  x="843.48" y="293.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (166,042,857 samples, 0.03%)</title><rect x="836.5" y="1361" width="1.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="839.46" y="1373.5" ></text>
+</g>
+<g >
+<title>memset_orig (280,260,477 samples, 0.04%)</title><rect x="4162.7" y="2361" width="1.9" height="19.0" fill="rgb(253,224,53)" rx="2" ry="2" />
+<text  x="4165.72" y="2373.5" ></text>
+</g>
+<g >
+<title>walk_component (175,692,296 samples, 0.03%)</title><rect x="1597.7" y="2241" width="1.2" height="19.0" fill="rgb(247,197,47)" rx="2" ry="2" />
+<text  x="1600.74" y="2253.5" ></text>
+</g>
+<g >
+<title>execute_command (574,909,828 samples, 0.09%)</title><rect x="884.6" y="661" width="3.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="887.64" y="673.5" ></text>
+</g>
+<g >
+<title>execute_command (5,855,050,786 samples, 0.92%)</title><rect x="356.1" y="1021" width="38.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="359.09" y="1033.5" >exe..</text>
+</g>
+<g >
+<title>execute_command (1,150,422,968 samples, 0.18%)</title><rect x="827.6" y="2001" width="7.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="830.57" y="2013.5" ></text>
+</g>
+<g >
+<title>vfs_read (2,818,117,664 samples, 0.44%)</title><rect x="3347.5" y="2381" width="18.4" height="19.0" fill="rgb(230,118,28)" rx="2" ry="2" />
+<text  x="3350.49" y="2393.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,281,803,985 samples, 0.20%)</title><rect x="868.6" y="1901" width="8.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="871.57" y="1913.5" ></text>
+</g>
+<g >
+<title>[bash] (550,247,149 samples, 0.09%)</title><rect x="269.5" y="321" width="3.6" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="272.54" y="333.5" ></text>
+</g>
+<g >
+<title>__handle_mm_fault (715,777,376 samples, 0.11%)</title><rect x="735.0" y="1161" width="4.7" height="19.0" fill="rgb(213,39,9)" rx="2" ry="2" />
+<text  x="738.02" y="1173.5" ></text>
+</g>
+<g >
+<title>dl_main (500,903,341 samples, 0.08%)</title><rect x="1843.2" y="2521" width="3.3" height="19.0" fill="rgb(236,145,34)" rx="2" ry="2" />
+<text  x="1846.19" y="2533.5" ></text>
+</g>
+<g >
+<title>[bash] (274,340,976 samples, 0.04%)</title><rect x="357.0" y="821" width="1.8" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="359.99" y="833.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (717,313,739 samples, 0.11%)</title><rect x="280.1" y="2001" width="4.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.09" y="2013.5" ></text>
+</g>
+<g >
+<title>execute_command (158,744,410 samples, 0.02%)</title><rect x="875.9" y="1201" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="878.93" y="1213.5" ></text>
+</g>
+<g >
+<title>_copy_to_iter (1,573,761,485 samples, 0.25%)</title><rect x="1512.0" y="2301" width="10.3" height="19.0" fill="rgb(234,134,32)" rx="2" ry="2" />
+<text  x="1515.04" y="2313.5" ></text>
+</g>
+<g >
+<title>dl_main (345,890,561 samples, 0.05%)</title><rect x="4186.6" y="2521" width="2.3" height="19.0" fill="rgb(236,145,34)" rx="2" ry="2" />
+<text  x="4189.62" y="2533.5" ></text>
+</g>
+<g >
+<title>kernel_clone (442,577,833 samples, 0.07%)</title><rect x="862.9" y="101" width="2.9" height="19.0" fill="rgb(248,199,47)" rx="2" ry="2" />
+<text  x="865.91" y="113.5" ></text>
+</g>
+<g >
+<title>[sha384sum] (13,034,907,763 samples, 2.04%)</title><rect x="3021.2" y="2521" width="85.3" height="19.0" fill="rgb(253,223,53)" rx="2" ry="2" />
+<text  x="3024.21" y="2533.5" >[sha384sum]</text>
+</g>
+<g >
+<title>execute_command (169,596,485 samples, 0.03%)</title><rect x="871.9" y="681" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="874.90" y="693.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (891,895,571 samples, 0.14%)</title><rect x="851.1" y="1801" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.08" y="1813.5" ></text>
+</g>
+<g >
+<title>[bash] (354,911,948 samples, 0.06%)</title><rect x="840.5" y="681" width="2.3" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="843.48" y="693.5" ></text>
+</g>
+<g >
+<title>execute_command (889,542,281 samples, 0.14%)</title><rect x="851.1" y="701" width="5.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="854.09" y="713.5" ></text>
+</g>
+<g >
+<title>execute_command (866,614,713 samples, 0.14%)</title><rect x="301.1" y="2041" width="5.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="304.12" y="2053.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (713,521,499 samples, 0.11%)</title><rect x="296.5" y="1801" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.45" y="1813.5" ></text>
+</g>
+<g >
+<title>malloc (506,036,457 samples, 0.08%)</title><rect x="639.3" y="1281" width="3.4" height="19.0" fill="rgb(230,119,28)" rx="2" ry="2" />
+<text  x="642.34" y="1293.5" ></text>
+</g>
+<g >
+<title>__do_sys_clone (268,202,598 samples, 0.04%)</title><rect x="830.7" y="141" width="1.8" height="19.0" fill="rgb(217,57,13)" rx="2" ry="2" />
+<text  x="833.73" y="153.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (549,214,247 samples, 0.09%)</title><rect x="273.3" y="761" width="3.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="276.32" y="773.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,150,422,968 samples, 0.18%)</title><rect x="827.6" y="2421" width="7.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.57" y="2433.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (4,486,907,152 samples, 0.70%)</title><rect x="309.9" y="741" width="29.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="312.86" y="753.5" >ex..</text>
+</g>
+<g >
+<title>execute_command_internal (813,926,528 samples, 0.13%)</title><rect x="868.6" y="1741" width="5.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="871.57" y="1753.5" ></text>
+</g>
+<g >
+<title>execute_command (598,514,664 samples, 0.09%)</title><rect x="891.4" y="1641" width="3.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="894.40" y="1653.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (575,800,354 samples, 0.09%)</title><rect x="884.6" y="1241" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="887.64" y="1253.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (289,139,639 samples, 0.05%)</title><rect x="785.9" y="1341" width="1.9" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="788.93" y="1353.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (685,594,707 samples, 0.11%)</title><rect x="268.8" y="661" width="4.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="271.79" y="673.5" ></text>
+</g>
+<g >
+<title>[bash] (226,064,216 samples, 0.04%)</title><rect x="351.7" y="521" width="1.5" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="354.72" y="533.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (3,759,130,245 samples, 0.59%)</title><rect x="4120.3" y="2401" width="24.6" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="4123.30" y="2413.5" >e..</text>
+</g>
+<g >
+<title>[bash] (76,568,426,836 samples, 11.99%)</title><rect x="306.9" y="2501" width="501.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="309.86" y="2513.5" >[bash]</text>
+</g>
+<g >
+<title>[bash] (205,460,312 samples, 0.03%)</title><rect x="354.2" y="821" width="1.4" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="357.23" y="833.5" ></text>
+</g>
+<g >
+<title>syscall_return_via_sysret (204,556,514 samples, 0.03%)</title><rect x="3387.6" y="2421" width="1.3" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="3390.58" y="2433.5" ></text>
+</g>
+<g >
+<title>[bash] (575,800,354 samples, 0.09%)</title><rect x="884.6" y="1321" width="3.8" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="887.64" y="1333.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,263,560,140 samples, 0.20%)</title><rect x="860.3" y="1841" width="8.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.30" y="1853.5" ></text>
+</g>
+<g >
+<title>[bash] (166,943,806 samples, 0.03%)</title><rect x="871.9" y="581" width="1.1" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="874.92" y="593.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (516,725,798 samples, 0.08%)</title><rect x="856.9" y="2381" width="3.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="859.92" y="2393.5" ></text>
+</g>
+<g >
+<title>execute_command (840,181,758 samples, 0.13%)</title><rect x="895.4" y="521" width="5.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="898.39" y="533.5" ></text>
+</g>
+<g >
+<title>execute_command (1,261,220,789 samples, 0.20%)</title><rect x="860.3" y="901" width="8.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="863.32" y="913.5" ></text>
+</g>
+<g >
+<title>execute_command (575,055,300 samples, 0.09%)</title><rect x="884.6" y="781" width="3.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="887.64" y="793.5" ></text>
+</g>
+<g >
+<title>execute_command (889,542,281 samples, 0.14%)</title><rect x="851.1" y="901" width="5.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="854.09" y="913.5" ></text>
+</g>
+<g >
+<title>__do_sys_wait4 (208,388,612 samples, 0.03%)</title><rect x="785.9" y="1301" width="1.4" height="19.0" fill="rgb(225,96,23)" rx="2" ry="2" />
+<text  x="788.94" y="1313.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (431,942,788 samples, 0.07%)</title><rect x="2045.6" y="2401" width="2.8" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="2048.56" y="2413.5" ></text>
+</g>
+<g >
+<title>posix_fadvise (672,943,818 samples, 0.11%)</title><rect x="3420.3" y="2501" width="4.4" height="19.0" fill="rgb(245,186,44)" rx="2" ry="2" />
+<text  x="3423.33" y="2513.5" ></text>
+</g>
+<g >
+<title>execute_command (840,181,758 samples, 0.13%)</title><rect x="895.4" y="561" width="5.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="898.39" y="573.5" ></text>
+</g>
+<g >
+<title>make_child (335,068,987 samples, 0.05%)</title><rect x="853.1" y="261" width="2.2" height="19.0" fill="rgb(242,170,40)" rx="2" ry="2" />
+<text  x="856.11" y="273.5" ></text>
+</g>
+<g >
+<title>lookup_fast (332,472,764 samples, 0.05%)</title><rect x="4176.2" y="2321" width="2.2" height="19.0" fill="rgb(226,97,23)" rx="2" ry="2" />
+<text  x="4179.22" y="2333.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (179,777,548 samples, 0.03%)</title><rect x="878.5" y="1101" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="881.48" y="1113.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (42,262,607,967 samples, 6.62%)</title><rect x="512.8" y="1421" width="276.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="515.77" y="1433.5" >execute_command_internal</text>
+</g>
+<g >
+<title>do_user_addr_fault (176,934,495 samples, 0.03%)</title><rect x="1583.5" y="2441" width="1.2" height="19.0" fill="rgb(235,138,33)" rx="2" ry="2" />
+<text  x="1586.55" y="2453.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (598,514,664 samples, 0.09%)</title><rect x="891.4" y="1821" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.40" y="1833.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (171,847,094 samples, 0.03%)</title><rect x="871.9" y="1341" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="874.89" y="1353.5" ></text>
+</g>
+<g >
+<title>[bash] (163,954,022 samples, 0.03%)</title><rect x="870.8" y="1261" width="1.1" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="873.82" y="1273.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (333,534,868 samples, 0.05%)</title><rect x="351.5" y="721" width="2.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="354.55" y="733.5" ></text>
+</g>
+<g >
+<title>_dl_start (706,855,746 samples, 0.11%)</title><rect x="3681.5" y="2561" width="4.6" height="19.0" fill="rgb(237,151,36)" rx="2" ry="2" />
+<text  x="3684.52" y="2573.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (171,847,094 samples, 0.03%)</title><rect x="871.9" y="1441" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="874.89" y="1453.5" ></text>
+</g>
+<g >
+<title>__fread_unlocked_chk (5,037,244,083 samples, 0.79%)</title><rect x="2144.8" y="2481" width="33.0" height="19.0" fill="rgb(225,94,22)" rx="2" ry="2" />
+<text  x="2147.78" y="2493.5" >__..</text>
+</g>
+<g >
+<title>execute_command_internal (169,651,850 samples, 0.03%)</title><rect x="871.9" y="781" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="874.90" y="793.5" ></text>
+</g>
+<g >
+<title>link_path_walk.part.0.constprop.0 (1,406,747,768 samples, 0.22%)</title><rect x="4166.5" y="2341" width="9.2" height="19.0" fill="rgb(254,229,54)" rx="2" ry="2" />
+<text  x="4169.49" y="2353.5" ></text>
+</g>
+<g >
+<title>execute_command (596,118,643 samples, 0.09%)</title><rect x="891.4" y="1281" width="3.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="894.42" y="1293.5" ></text>
+</g>
+<g >
+<title>source_builtin (62,818,603,029 samples, 9.84%)</title><rect x="395.1" y="1741" width="411.2" height="19.0" fill="rgb(252,219,52)" rx="2" ry="2" />
+<text  x="398.10" y="1753.5" >source_builtin</text>
+</g>
+<g >
+<title>[b2sum] (33,895,027,800 samples, 5.31%)</title><rect x="10.7" y="2501" width="221.9" height="19.0" fill="rgb(216,50,12)" rx="2" ry="2" />
+<text  x="13.68" y="2513.5" >[b2sum]</text>
+</g>
+<g >
+<title>execute_command_internal (169,596,485 samples, 0.03%)</title><rect x="871.9" y="701" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="874.90" y="713.5" ></text>
+</g>
+<g >
+<title>execute_command (436,055,112 samples, 0.07%)</title><rect x="888.5" y="1681" width="2.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="891.55" y="1693.5" ></text>
+</g>
+<g >
+<title>lookup_fast (302,396,210 samples, 0.05%)</title><rect x="4173.7" y="2301" width="2.0" height="19.0" fill="rgb(226,97,23)" rx="2" ry="2" />
+<text  x="4176.72" y="2313.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (215,748,926 samples, 0.03%)</title><rect x="842.8" y="1801" width="1.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="845.80" y="1813.5" ></text>
+</g>
+<g >
+<title>schedule_tail (274,070,835 samples, 0.04%)</title><rect x="708.3" y="1241" width="1.8" height="19.0" fill="rgb(245,187,44)" rx="2" ry="2" />
+<text  x="711.29" y="1253.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (598,514,664 samples, 0.09%)</title><rect x="891.4" y="2021" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.40" y="2033.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (306,370,682 samples, 0.05%)</title><rect x="886.3" y="241" width="2.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="889.28" y="253.5" ></text>
+</g>
+<g >
+<title>execute_command (212,618,566 samples, 0.03%)</title><rect x="827.6" y="201" width="1.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="830.59" y="213.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (165,145,742 samples, 0.03%)</title><rect x="871.9" y="461" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="874.92" y="473.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (554,006,342 samples, 0.09%)</title><rect x="273.3" y="1841" width="3.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="276.29" y="1853.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,342,995,571 samples, 0.21%)</title><rect x="316.4" y="601" width="8.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="319.41" y="613.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (862,395,726 samples, 0.14%)</title><rect x="301.2" y="1161" width="5.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.15" y="1173.5" ></text>
+</g>
+<g >
+<title>execute_command (843,061,254 samples, 0.13%)</title><rect x="895.4" y="1321" width="5.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="898.39" y="1333.5" ></text>
+</g>
+<g >
+<title>_dl_sysdep_start (520,525,966 samples, 0.08%)</title><rect x="1843.1" y="2541" width="3.4" height="19.0" fill="rgb(234,137,32)" rx="2" ry="2" />
+<text  x="1846.11" y="2553.5" ></text>
+</g>
+<g >
+<title>execute_command (179,777,548 samples, 0.03%)</title><rect x="878.5" y="1161" width="1.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="881.48" y="1173.5" ></text>
+</g>
+<g >
+<title>[bash] (695,066,351 samples, 0.11%)</title><rect x="268.7" y="2561" width="4.6" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="271.73" y="2573.5" ></text>
+</g>
+<g >
+<title>do_dentry_open (304,406,480 samples, 0.05%)</title><rect x="3035.1" y="2241" width="2.0" height="19.0" fill="rgb(249,205,49)" rx="2" ry="2" />
+<text  x="3038.15" y="2253.5" ></text>
+</g>
+<g >
+<title>llseek@GLIBC_2.2.5 (507,810,207 samples, 0.08%)</title><rect x="3076.3" y="2481" width="3.3" height="19.0" fill="rgb(239,156,37)" rx="2" ry="2" />
+<text  x="3079.32" y="2493.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (215,132,849 samples, 0.03%)</title><rect x="842.8" y="961" width="1.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="845.81" y="973.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (713,987,302 samples, 0.11%)</title><rect x="280.1" y="1321" width="4.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.11" y="1333.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (322,256,264 samples, 0.05%)</title><rect x="868.7" y="1181" width="2.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="871.70" y="1193.5" ></text>
+</g>
+<g >
+<title>filemap_get_entry (460,729,767 samples, 0.07%)</title><rect x="3982.4" y="2321" width="3.0" height="19.0" fill="rgb(253,222,53)" rx="2" ry="2" />
+<text  x="3985.40" y="2333.5" ></text>
+</g>
+<g >
+<title>[bash] (215,126,890 samples, 0.03%)</title><rect x="842.8" y="641" width="1.4" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="845.81" y="653.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (354,998,378 samples, 0.06%)</title><rect x="840.5" y="1361" width="2.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="843.48" y="1373.5" ></text>
+</g>
+<g >
+<title>[bash] (866,614,713 samples, 0.14%)</title><rect x="301.1" y="2421" width="5.7" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="304.12" y="2433.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,150,422,968 samples, 0.18%)</title><rect x="827.6" y="1781" width="7.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.57" y="1793.5" ></text>
+</g>
+<g >
+<title>[bash] (1,408,820,420 samples, 0.22%)</title><rect x="851.1" y="2561" width="9.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="854.08" y="2573.5" ></text>
+</g>
+<g >
+<title>[bash] (322,256,264 samples, 0.05%)</title><rect x="868.7" y="1221" width="2.1" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="871.70" y="1233.5" ></text>
+</g>
+<g >
+<title>avc_has_perm_noaudit (246,009,768 samples, 0.04%)</title><rect x="1479.0" y="2201" width="1.6" height="19.0" fill="rgb(209,18,4)" rx="2" ry="2" />
+<text  x="1482.02" y="2213.5" ></text>
+</g>
+<g >
+<title>malloc_consolidate (642,726,366 samples, 0.10%)</title><rect x="553.6" y="1141" width="4.2" height="19.0" fill="rgb(239,159,38)" rx="2" ry="2" />
+<text  x="556.59" y="1153.5" ></text>
+</g>
+<g >
+<title>vfs_read (2,300,794,327 samples, 0.36%)</title><rect x="1510.1" y="2361" width="15.1" height="19.0" fill="rgb(230,118,28)" rx="2" ry="2" />
+<text  x="1513.10" y="2373.5" ></text>
+</g>
+<g >
+<title>[bash] (245,639,225 samples, 0.04%)</title><rect x="325.3" y="561" width="1.6" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="328.29" y="573.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (861,612,432 samples, 0.13%)</title><rect x="301.2" y="901" width="5.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.16" y="913.5" ></text>
+</g>
+<g >
+<title>inode_permission (158,124,656 samples, 0.02%)</title><rect x="4167.8" y="2321" width="1.1" height="19.0" fill="rgb(215,48,11)" rx="2" ry="2" />
+<text  x="4170.84" y="2333.5" ></text>
+</g>
+<g >
+<title>dl_main (1,012,374,988 samples, 0.16%)</title><rect x="1579.0" y="2521" width="6.6" height="19.0" fill="rgb(236,145,34)" rx="2" ry="2" />
+<text  x="1581.97" y="2533.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (1,260,500,822 samples, 0.20%)</title><rect x="288.1" y="2541" width="8.2" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="291.10" y="2553.5" ></text>
+</g>
+<g >
+<title>syscall_return_via_sysret (299,114,461 samples, 0.05%)</title><rect x="1556.1" y="2441" width="2.0" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="1559.13" y="2453.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (170,489,782 samples, 0.03%)</title><rect x="871.9" y="1061" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="874.90" y="1073.5" ></text>
+</g>
+<g >
+<title>execute_command (2,213,511,194 samples, 0.35%)</title><rect x="868.6" y="2361" width="14.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="871.57" y="2373.5" ></text>
+</g>
+<g >
+<title>parse_and_execute (275,675,745 samples, 0.04%)</title><rect x="898.4" y="201" width="1.8" height="19.0" fill="rgb(243,178,42)" rx="2" ry="2" />
+<text  x="901.35" y="213.5" ></text>
+</g>
+<g >
+<title>fallocate (202,852,583 samples, 0.03%)</title><rect x="1587.2" y="2601" width="1.3" height="19.0" fill="rgb(247,196,46)" rx="2" ry="2" />
+<text  x="1590.19" y="2613.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,900,834,313 samples, 0.30%)</title><rect x="835.1" y="2121" width="12.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="838.10" y="2133.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (288,172,525 samples, 0.05%)</title><rect x="785.9" y="1321" width="1.9" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="788.93" y="1333.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (713,462,810 samples, 0.11%)</title><rect x="280.1" y="841" width="4.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.11" y="853.5" ></text>
+</g>
+<g >
+<title>execute_command (164,072,262 samples, 0.03%)</title><rect x="836.5" y="741" width="1.0" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="839.46" y="753.5" ></text>
+</g>
+<g >
+<title>execute_command (1,150,422,968 samples, 0.18%)</title><rect x="827.6" y="2041" width="7.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="830.57" y="2053.5" ></text>
+</g>
+<g >
+<title>[bash] (158,741,628 samples, 0.02%)</title><rect x="836.5" y="601" width="1.0" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="839.50" y="613.5" ></text>
+</g>
+<g >
+<title>[bash] (158,643,683 samples, 0.02%)</title><rect x="836.5" y="501" width="1.0" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="839.50" y="513.5" ></text>
+</g>
+<g >
+<title>[bash] (688,777,208 samples, 0.11%)</title><rect x="268.8" y="2481" width="4.5" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="271.77" y="2493.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (866,614,713 samples, 0.14%)</title><rect x="301.1" y="2021" width="5.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.12" y="2033.5" ></text>
+</g>
+<g >
+<title>[bash] (167,338,397 samples, 0.03%)</title><rect x="803.8" y="1481" width="1.1" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="806.79" y="1493.5" ></text>
+</g>
+<g >
+<title>execute_command (354,998,378 samples, 0.06%)</title><rect x="840.5" y="1461" width="2.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="843.48" y="1473.5" ></text>
+</g>
+<g >
+<title>[bash] (513,954,307 samples, 0.08%)</title><rect x="856.9" y="1361" width="3.4" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="859.94" y="1373.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (849,509,116 samples, 0.13%)</title><rect x="895.3" y="1941" width="5.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.35" y="1953.5" ></text>
+</g>
+<g >
+<title>execute_command (322,183,311 samples, 0.05%)</title><rect x="351.6" y="681" width="2.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="354.62" y="693.5" ></text>
+</g>
+<g >
+<title>inherit_event.isra.0 (174,390,604 samples, 0.03%)</title><rect x="273.9" y="181" width="1.1" height="19.0" fill="rgb(213,38,9)" rx="2" ry="2" />
+<text  x="276.87" y="193.5" ></text>
+</g>
+<g >
+<title>error_entry (260,730,773 samples, 0.04%)</title><rect x="458.9" y="1021" width="1.7" height="19.0" fill="rgb(247,193,46)" rx="2" ry="2" />
+<text  x="461.93" y="1033.5" ></text>
+</g>
+<g >
+<title>fclose@@GLIBC_2.2.5 (806,943,349 samples, 0.13%)</title><rect x="3071.0" y="2481" width="5.3" height="19.0" fill="rgb(251,213,51)" rx="2" ry="2" />
+<text  x="3074.02" y="2493.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (5,184,972,329 samples, 0.81%)</title><rect x="4072.3" y="2401" width="33.9" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="4075.29" y="2413.5" >do..</text>
+</g>
+<g >
+<title>execute_command_internal (180,216,075 samples, 0.03%)</title><rect x="878.5" y="1941" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="881.48" y="1953.5" ></text>
+</g>
+<g >
+<title>[libcrypto.so.3.2.2] (56,093,444,251 samples, 8.78%)</title><rect x="2644.5" y="2561" width="367.2" height="19.0" fill="rgb(244,181,43)" rx="2" ry="2" />
+<text  x="2647.51" y="2573.5" >[libcrypto.so.3.2.2]</text>
+</g>
+<g >
+<title>string_list_dollar_at (1,794,379,150 samples, 0.28%)</title><rect x="650.3" y="1321" width="11.7" height="19.0" fill="rgb(224,87,20)" rx="2" ry="2" />
+<text  x="653.29" y="1333.5" ></text>
+</g>
+<g >
+<title>[bash] (185,309,721 samples, 0.03%)</title><rect x="835.2" y="441" width="1.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="838.23" y="453.5" ></text>
+</g>
+<g >
+<title>[bash] (207,324,048 samples, 0.03%)</title><rect x="869.4" y="361" width="1.4" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="872.43" y="373.5" ></text>
+</g>
+<g >
+<title>do_sys_openat2 (2,104,286,072 samples, 0.33%)</title><rect x="1592.3" y="2321" width="13.8" height="19.0" fill="rgb(209,21,5)" rx="2" ry="2" />
+<text  x="1595.32" y="2333.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (323,026,366 samples, 0.05%)</title><rect x="868.7" y="1501" width="2.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="871.70" y="1513.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,263,560,140 samples, 0.20%)</title><rect x="860.3" y="1681" width="8.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.30" y="1693.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (164,808,262 samples, 0.03%)</title><rect x="870.8" y="1641" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="873.81" y="1653.5" ></text>
+</g>
+<g >
+<title>execute_command (356,134,455 samples, 0.06%)</title><rect x="840.5" y="1781" width="2.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="843.47" y="1793.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (356,134,455 samples, 0.06%)</title><rect x="840.5" y="1561" width="2.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="843.47" y="1573.5" ></text>
+</g>
+<g >
+<title>__GI___libc_write (525,616,249 samples, 0.08%)</title><rect x="232.7" y="2441" width="3.5" height="19.0" fill="rgb(217,57,13)" rx="2" ry="2" />
+<text  x="235.74" y="2453.5" ></text>
+</g>
+<g >
+<title>getname_flags.part.0 (360,308,002 samples, 0.06%)</title><rect x="3330.9" y="2301" width="2.3" height="19.0" fill="rgb(213,39,9)" rx="2" ry="2" />
+<text  x="3333.89" y="2313.5" ></text>
+</g>
+<g >
+<title>entry_SYSRETQ_unsafe_stack (430,675,859 samples, 0.07%)</title><rect x="2598.2" y="2441" width="2.8" height="19.0" fill="rgb(213,37,8)" rx="2" ry="2" />
+<text  x="2601.21" y="2453.5" ></text>
+</g>
+<g >
+<title>do_user_addr_fault (179,715,708 samples, 0.03%)</title><rect x="590.9" y="1261" width="1.2" height="19.0" fill="rgb(235,138,33)" rx="2" ry="2" />
+<text  x="593.92" y="1273.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (575,908,296 samples, 0.09%)</title><rect x="350.3" y="801" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="353.32" y="813.5" ></text>
+</g>
+<g >
+<title>shmem_get_folio_gfp (222,653,826 samples, 0.03%)</title><rect x="901.2" y="2341" width="1.5" height="19.0" fill="rgb(219,67,16)" rx="2" ry="2" />
+<text  x="904.21" y="2353.5" ></text>
+</g>
+<g >
+<title>[bash] (685,976,378 samples, 0.11%)</title><rect x="268.8" y="1101" width="4.5" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="271.79" y="1113.5" ></text>
+</g>
+<g >
+<title>execute_command (1,150,422,968 samples, 0.18%)</title><rect x="827.6" y="2121" width="7.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="830.57" y="2133.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (853,102,194 samples, 0.13%)</title><rect x="301.2" y="421" width="5.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.16" y="433.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (193,792,882 samples, 0.03%)</title><rect x="835.2" y="641" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="838.18" y="653.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (433,500,595 samples, 0.07%)</title><rect x="888.6" y="1421" width="2.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="891.56" y="1433.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (215,132,849 samples, 0.03%)</title><rect x="842.8" y="861" width="1.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="845.81" y="873.5" ></text>
+</g>
+<g >
+<title>execute_command (163,385,330 samples, 0.03%)</title><rect x="870.8" y="641" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="873.82" y="653.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (2,358,585,540 samples, 0.37%)</title><rect x="176.9" y="2381" width="15.4" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="179.89" y="2393.5" ></text>
+</g>
+<g >
+<title>x86_pmu_event_init (258,268,813 samples, 0.04%)</title><rect x="704.7" y="1081" width="1.7" height="19.0" fill="rgb(216,51,12)" rx="2" ry="2" />
+<text  x="707.73" y="1093.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (354,998,378 samples, 0.06%)</title><rect x="840.5" y="1441" width="2.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="843.48" y="1453.5" ></text>
+</g>
+<g >
+<title>[unknown] (300,978,281 samples, 0.05%)</title><rect x="2531.6" y="2561" width="2.0" height="19.0" fill="rgb(210,24,5)" rx="2" ry="2" />
+<text  x="2534.65" y="2573.5" ></text>
+</g>
+<g >
+<title>do_sys_openat2 (2,887,100,875 samples, 0.45%)</title><rect x="3314.5" y="2321" width="18.9" height="19.0" fill="rgb(209,21,5)" rx="2" ry="2" />
+<text  x="3317.49" y="2333.5" ></text>
+</g>
+<g >
+<title>[bash] (330,023,123 samples, 0.05%)</title><rect x="407.6" y="1041" width="2.1" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="410.58" y="1053.5" ></text>
+</g>
+<g >
+<title>malloc (809,132,290 samples, 0.13%)</title><rect x="552.6" y="1181" width="5.3" height="19.0" fill="rgb(230,119,28)" rx="2" ry="2" />
+<text  x="555.62" y="1193.5" ></text>
+</g>
+<g >
+<title>execute_command (890,006,400 samples, 0.14%)</title><rect x="851.1" y="1341" width="5.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="854.09" y="1353.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (866,614,713 samples, 0.14%)</title><rect x="301.1" y="1941" width="5.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.12" y="1953.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,261,220,789 samples, 0.20%)</title><rect x="860.3" y="881" width="8.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.32" y="893.5" ></text>
+</g>
+<g >
+<title>handle_mm_fault (162,311,418 samples, 0.03%)</title><rect x="668.8" y="1161" width="1.1" height="19.0" fill="rgb(240,165,39)" rx="2" ry="2" />
+<text  x="671.81" y="1173.5" ></text>
+</g>
+<g >
+<title>security_file_open (354,726,695 samples, 0.06%)</title><rect x="1491.5" y="2221" width="2.3" height="19.0" fill="rgb(215,47,11)" rx="2" ry="2" />
+<text  x="1494.47" y="2233.5" ></text>
+</g>
+<g >
+<title>filemap_get_entry (241,600,618 samples, 0.04%)</title><rect x="1631.4" y="2321" width="1.6" height="19.0" fill="rgb(253,222,53)" rx="2" ry="2" />
+<text  x="1634.39" y="2333.5" ></text>
+</g>
+<g >
+<title>entry_SYSRETQ_unsafe_stack (181,371,552 samples, 0.03%)</title><rect x="2570.1" y="2401" width="1.2" height="19.0" fill="rgb(213,37,8)" rx="2" ry="2" />
+<text  x="2573.08" y="2413.5" ></text>
+</g>
+<g >
+<title>__d_lookup_rcu (290,979,366 samples, 0.05%)</title><rect x="3917.3" y="2221" width="1.9" height="19.0" fill="rgb(235,139,33)" rx="2" ry="2" />
+<text  x="3920.26" y="2233.5" ></text>
+</g>
+<g >
+<title>execute_command (158,744,410 samples, 0.02%)</title><rect x="875.9" y="1441" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="878.93" y="1453.5" ></text>
+</g>
+<g >
+<title>execute_command (849,509,116 samples, 0.13%)</title><rect x="895.3" y="2321" width="5.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="898.35" y="2333.5" ></text>
+</g>
+<g >
+<title>parse_and_execute (167,019,592 samples, 0.03%)</title><rect x="278.7" y="301" width="1.1" height="19.0" fill="rgb(243,178,42)" rx="2" ry="2" />
+<text  x="281.71" y="313.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,150,422,968 samples, 0.18%)</title><rect x="827.6" y="2501" width="7.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.57" y="2513.5" ></text>
+</g>
+<g >
+<title>[bash] (195,916,485 samples, 0.03%)</title><rect x="835.2" y="1421" width="1.3" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="838.17" y="1433.5" ></text>
+</g>
+<g >
+<title>[bash] (340,330,125 samples, 0.05%)</title><rect x="282.1" y="221" width="2.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="285.11" y="233.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (843,061,254 samples, 0.13%)</title><rect x="895.4" y="1101" width="5.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.39" y="1113.5" ></text>
+</g>
+<g >
+<title>execute_command (891,895,571 samples, 0.14%)</title><rect x="851.1" y="1741" width="5.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="854.08" y="1753.5" ></text>
+</g>
+<g >
+<title>walk_component (331,430,103 samples, 0.05%)</title><rect x="4173.5" y="2321" width="2.2" height="19.0" fill="rgb(247,197,47)" rx="2" ry="2" />
+<text  x="4176.53" y="2333.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (513,954,307 samples, 0.08%)</title><rect x="856.9" y="1301" width="3.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="859.94" y="1313.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (842,511,421 samples, 0.13%)</title><rect x="895.4" y="661" width="5.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.39" y="673.5" ></text>
+</g>
+<g >
+<title>[bash] (546,782,451 samples, 0.09%)</title><rect x="403.5" y="1041" width="3.6" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="406.53" y="1053.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,263,560,140 samples, 0.20%)</title><rect x="860.3" y="2241" width="8.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.30" y="2253.5" ></text>
+</g>
+<g >
+<title>execute_command (436,055,112 samples, 0.07%)</title><rect x="888.5" y="1561" width="2.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="891.55" y="1573.5" ></text>
+</g>
+<g >
+<title>execute_command (5,305,276,657 samples, 0.83%)</title><rect x="359.2" y="781" width="34.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="362.18" y="793.5" >ex..</text>
+</g>
+<g >
+<title>execute_command_internal (483,985,097 samples, 0.08%)</title><rect x="276.9" y="2041" width="3.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="279.92" y="2053.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (76,556,775,991 samples, 11.99%)</title><rect x="306.9" y="2461" width="501.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="309.94" y="2473.5" >execute_command_internal</text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (231,216,232 samples, 0.04%)</title><rect x="2187.7" y="2421" width="1.5" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="2190.73" y="2433.5" ></text>
+</g>
+<g >
+<title>execute_command (861,612,432 samples, 0.13%)</title><rect x="301.2" y="721" width="5.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="304.16" y="733.5" ></text>
+</g>
+<g >
+<title>execute_command (2,286,100,543 samples, 0.36%)</title><rect x="835.1" y="2421" width="15.0" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="838.10" y="2433.5" ></text>
+</g>
+<g >
+<title>execute_command (164,808,262 samples, 0.03%)</title><rect x="870.8" y="1561" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="873.81" y="1573.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (685,976,378 samples, 0.11%)</title><rect x="268.8" y="981" width="4.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="271.79" y="993.5" ></text>
+</g>
+<g >
+<title>make_child (3,166,330,774 samples, 0.50%)</title><rect x="693.0" y="1341" width="20.7" height="19.0" fill="rgb(242,170,40)" rx="2" ry="2" />
+<text  x="695.99" y="1353.5" ></text>
+</g>
+<g >
+<title>execute_command (2,242,449,573 samples, 0.35%)</title><rect x="835.1" y="2381" width="14.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="838.10" y="2393.5" ></text>
+</g>
+<g >
+<title>execute_command (842,511,421 samples, 0.13%)</title><rect x="895.4" y="841" width="5.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="898.39" y="853.5" ></text>
+</g>
+<g >
+<title>_IO_file_overflow@@GLIBC_2.2.5 (551,507,206 samples, 0.09%)</title><rect x="232.6" y="2501" width="3.6" height="19.0" fill="rgb(239,157,37)" rx="2" ry="2" />
+<text  x="235.58" y="2513.5" ></text>
+</g>
+<g >
+<title>execute_command (713,521,499 samples, 0.11%)</title><rect x="296.5" y="1381" width="4.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="299.45" y="1393.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (163,563,240 samples, 0.03%)</title><rect x="870.8" y="821" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="873.82" y="833.5" ></text>
+</g>
+<g >
+<title>execute_command (889,118,394 samples, 0.14%)</title><rect x="851.1" y="661" width="5.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="854.09" y="673.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (475,993,542 samples, 0.07%)</title><rect x="400.3" y="1041" width="3.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="403.31" y="1053.5" ></text>
+</g>
+<g >
+<title>[bash] (1,321,785,319 samples, 0.21%)</title><rect x="650.3" y="1301" width="8.7" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="653.30" y="1313.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,122,093,800 samples, 0.18%)</title><rect x="868.6" y="1861" width="7.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="871.57" y="1873.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (849,509,116 samples, 0.13%)</title><rect x="895.3" y="2061" width="5.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.35" y="2073.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (513,428,353 samples, 0.08%)</title><rect x="856.9" y="981" width="3.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="859.94" y="993.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (842,511,421 samples, 0.13%)</title><rect x="895.4" y="821" width="5.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.39" y="833.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (713,462,810 samples, 0.11%)</title><rect x="280.1" y="601" width="4.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.11" y="613.5" ></text>
+</g>
+<g >
+<title>[bash] (76,480,528,448 samples, 11.98%)</title><rect x="307.3" y="2301" width="500.7" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="310.33" y="2313.5" >[bash]</text>
+</g>
+<g >
+<title>malloc_consolidate (302,702,485 samples, 0.05%)</title><rect x="585.0" y="1241" width="2.0" height="19.0" fill="rgb(239,159,38)" rx="2" ry="2" />
+<text  x="588.03" y="1253.5" ></text>
+</g>
+<g >
+<title>_int_malloc (364,095,450 samples, 0.06%)</title><rect x="575.7" y="1221" width="2.4" height="19.0" fill="rgb(215,47,11)" rx="2" ry="2" />
+<text  x="578.74" y="1233.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (5,855,435,935 samples, 0.92%)</title><rect x="356.1" y="1041" width="38.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="359.09" y="1053.5" >exe..</text>
+</g>
+<g >
+<title>execute_command_internal (195,916,485 samples, 0.03%)</title><rect x="835.2" y="1581" width="1.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="838.17" y="1593.5" ></text>
+</g>
+<g >
+<title>execute_command (1,261,220,789 samples, 0.20%)</title><rect x="860.3" y="981" width="8.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="863.32" y="993.5" ></text>
+</g>
+<g >
+<title>shmem_get_folio_gfp (320,591,305 samples, 0.05%)</title><rect x="3063.4" y="2341" width="2.1" height="19.0" fill="rgb(219,67,16)" rx="2" ry="2" />
+<text  x="3066.42" y="2353.5" ></text>
+</g>
+<g >
+<title>[bash] (566,180,061 samples, 0.09%)</title><rect x="269.5" y="381" width="3.7" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="272.52" y="393.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (890,006,400 samples, 0.14%)</title><rect x="851.1" y="1321" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.09" y="1333.5" ></text>
+</g>
+<g >
+<title>__do_sys_newfstat (362,548,538 samples, 0.06%)</title><rect x="4059.6" y="2341" width="2.3" height="19.0" fill="rgb(225,96,23)" rx="2" ry="2" />
+<text  x="4062.57" y="2353.5" ></text>
+</g>
+<g >
+<title>execute_command (699,234,233 samples, 0.11%)</title><rect x="296.5" y="461" width="4.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="299.51" y="473.5" ></text>
+</g>
+<g >
+<title>execute_command (2,000,346,964 samples, 0.31%)</title><rect x="399.4" y="1181" width="13.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="402.37" y="1193.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (163,954,022 samples, 0.03%)</title><rect x="870.8" y="1061" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="873.82" y="1073.5" ></text>
+</g>
+<g >
+<title>anon_vma_fork (231,971,398 samples, 0.04%)</title><rect x="695.1" y="1181" width="1.5" height="19.0" fill="rgb(231,120,28)" rx="2" ry="2" />
+<text  x="698.10" y="1193.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (5,905,271,973 samples, 0.92%)</title><rect x="356.1" y="1201" width="38.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="359.07" y="1213.5" >exe..</text>
+</g>
+<g >
+<title>execute_command (554,006,342 samples, 0.09%)</title><rect x="273.3" y="1661" width="3.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="276.29" y="1673.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,146,830,397 samples, 0.18%)</title><rect x="827.6" y="941" width="7.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.59" y="953.5" ></text>
+</g>
+<g >
+<title>parse_and_execute (282,941,023 samples, 0.04%)</title><rect x="858.4" y="361" width="1.8" height="19.0" fill="rgb(243,178,42)" rx="2" ry="2" />
+<text  x="861.36" y="373.5" ></text>
+</g>
+<g >
+<title>[unknown] (164,768,608 samples, 0.03%)</title><rect x="1576.0" y="2561" width="1.1" height="19.0" fill="rgb(210,24,5)" rx="2" ry="2" />
+<text  x="1579.03" y="2573.5" ></text>
+</g>
+<g >
+<title>[bash] (7,228,344,567 samples, 1.13%)</title><rect x="308.5" y="1041" width="47.4" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="311.54" y="1053.5" >[bash]</text>
+</g>
+<g >
+<title>execute_command_internal (166,042,857 samples, 0.03%)</title><rect x="836.5" y="1621" width="1.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="839.46" y="1633.5" ></text>
+</g>
+<g >
+<title>execute_command (195,916,485 samples, 0.03%)</title><rect x="835.2" y="1541" width="1.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="838.17" y="1553.5" ></text>
+</g>
+<g >
+<title>[bash] (158,599,791 samples, 0.02%)</title><rect x="875.9" y="701" width="1.1" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="878.93" y="713.5" ></text>
+</g>
+<g >
+<title>execute_command (1,122,093,800 samples, 0.18%)</title><rect x="868.6" y="1881" width="7.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="871.57" y="1893.5" ></text>
+</g>
+<g >
+<title>filename_lookup (1,936,982,454 samples, 0.30%)</title><rect x="4165.7" y="2381" width="12.7" height="19.0" fill="rgb(222,82,19)" rx="2" ry="2" />
+<text  x="4168.72" y="2393.5" ></text>
+</g>
+<g >
+<title>execute_command (13,303,664,977 samples, 2.08%)</title><rect x="307.9" y="1581" width="87.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="310.94" y="1593.5" >execute_co..</text>
+</g>
+<g >
+<title>[bash] (186,159,797 samples, 0.03%)</title><rect x="334.5" y="521" width="1.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="337.52" y="533.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,261,568,072 samples, 0.20%)</title><rect x="860.3" y="1361" width="8.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.31" y="1373.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (234,763,360 samples, 0.04%)</title><rect x="354.1" y="881" width="1.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="357.14" y="893.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (483,985,097 samples, 0.08%)</title><rect x="276.9" y="1681" width="3.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="279.92" y="1693.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (456,488,838 samples, 0.07%)</title><rect x="2605.6" y="2441" width="3.0" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="2608.63" y="2453.5" ></text>
+</g>
+<g >
+<title>execute_command (688,777,208 samples, 0.11%)</title><rect x="268.8" y="2401" width="4.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="271.77" y="2413.5" ></text>
+</g>
+<g >
+<title>syscall_return_via_sysret (192,298,880 samples, 0.03%)</title><rect x="2619.5" y="2421" width="1.2" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="2622.46" y="2433.5" ></text>
+</g>
+<g >
+<title>execute_command (227,825,630 samples, 0.04%)</title><rect x="354.2" y="861" width="1.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="357.18" y="873.5" ></text>
+</g>
+<g >
+<title>make_child (323,502,561 samples, 0.05%)</title><rect x="830.7" y="241" width="2.1" height="19.0" fill="rgb(242,170,40)" rx="2" ry="2" />
+<text  x="833.70" y="253.5" ></text>
+</g>
+<g >
+<title>[bash] (5,890,378,945 samples, 0.92%)</title><rect x="356.1" y="1081" width="38.5" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="359.07" y="1093.5" >[ba..</text>
+</g>
+<g >
+<title>execute_command_internal (2,418,202,317 samples, 0.38%)</title><rect x="835.1" y="2521" width="15.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="838.10" y="2533.5" ></text>
+</g>
+<g >
+<title>exc_page_fault (178,347,763 samples, 0.03%)</title><rect x="1583.5" y="2461" width="1.2" height="19.0" fill="rgb(219,65,15)" rx="2" ry="2" />
+<text  x="1586.54" y="2473.5" ></text>
+</g>
+<g >
+<title>__strchr_evex (372,047,598 samples, 0.06%)</title><rect x="635.9" y="1301" width="2.4" height="19.0" fill="rgb(253,223,53)" rx="2" ry="2" />
+<text  x="638.90" y="1313.5" ></text>
+</g>
+<g >
+<title>copy_strings.isra.0 (1,179,744,914 samples, 0.18%)</title><rect x="664.3" y="1241" width="7.7" height="19.0" fill="rgb(230,116,27)" rx="2" ry="2" />
+<text  x="667.29" y="1253.5" ></text>
+</g>
+<g >
+<title>cfree@GLIBC_2.2.5 (629,982,729 samples, 0.10%)</title><rect x="529.5" y="1201" width="4.1" height="19.0" fill="rgb(233,131,31)" rx="2" ry="2" />
+<text  x="532.51" y="1213.5" ></text>
+</g>
+<g >
+<title>execute_command (511,601,820 samples, 0.08%)</title><rect x="856.9" y="561" width="3.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="859.94" y="573.5" ></text>
+</g>
+<g >
+<title>walk_component (186,926,412 samples, 0.03%)</title><rect x="183.4" y="2241" width="1.3" height="19.0" fill="rgb(247,197,47)" rx="2" ry="2" />
+<text  x="186.44" y="2253.5" ></text>
+</g>
+<g >
+<title>do_redirections (158,599,791 samples, 0.02%)</title><rect x="875.9" y="801" width="1.1" height="19.0" fill="rgb(247,193,46)" rx="2" ry="2" />
+<text  x="878.93" y="813.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (426,401,754 samples, 0.07%)</title><rect x="351.1" y="761" width="2.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="354.10" y="773.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (891,895,571 samples, 0.14%)</title><rect x="851.1" y="2281" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.08" y="2293.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (190,829,147 samples, 0.03%)</title><rect x="837.6" y="841" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="840.55" y="853.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (194,148,063 samples, 0.03%)</title><rect x="837.5" y="1401" width="1.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="840.54" y="1413.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (158,599,791 samples, 0.02%)</title><rect x="875.9" y="941" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="878.93" y="953.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (194,148,063 samples, 0.03%)</title><rect x="837.5" y="1441" width="1.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="840.54" y="1453.5" ></text>
+</g>
+<g >
+<title>lookup_fast (343,133,198 samples, 0.05%)</title><rect x="1483.4" y="2261" width="2.3" height="19.0" fill="rgb(226,97,23)" rx="2" ry="2" />
+<text  x="1486.42" y="2273.5" ></text>
+</g>
+<g >
+<title>execute_command (433,500,595 samples, 0.07%)</title><rect x="888.6" y="1501" width="2.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="891.56" y="1513.5" ></text>
+</g>
+<g >
+<title>execute_command (3,868,419,175 samples, 0.61%)</title><rect x="361.1" y="381" width="25.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="364.09" y="393.5" >e..</text>
+</g>
+<g >
+<title>do_user_addr_fault (167,850,023 samples, 0.03%)</title><rect x="779.6" y="1241" width="1.1" height="19.0" fill="rgb(235,138,33)" rx="2" ry="2" />
+<text  x="782.59" y="1253.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (195,267,188 samples, 0.03%)</title><rect x="835.2" y="1121" width="1.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="838.18" y="1133.5" ></text>
+</g>
+<g >
+<title>vfs_open (361,247,885 samples, 0.06%)</title><rect x="187.8" y="2261" width="2.4" height="19.0" fill="rgb(238,154,37)" rx="2" ry="2" />
+<text  x="190.82" y="2273.5" ></text>
+</g>
+<g >
+<title>[bash] (14,660,437,104 samples, 2.30%)</title><rect x="412.5" y="1161" width="96.0" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="415.50" y="1173.5" >[bash]</text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (188,366,533 samples, 0.03%)</title><rect x="2089.0" y="2461" width="1.2" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="2092.00" y="2473.5" ></text>
+</g>
+<g >
+<title>__vfprintf_internal (2,199,837,597 samples, 0.34%)</title><rect x="2623.9" y="2481" width="14.4" height="19.0" fill="rgb(232,125,30)" rx="2" ry="2" />
+<text  x="2626.89" y="2493.5" ></text>
+</g>
+<g >
+<title>execute_command (849,509,116 samples, 0.13%)</title><rect x="895.3" y="2541" width="5.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="898.35" y="2553.5" ></text>
+</g>
+<g >
+<title>dequote_list (2,023,107,157 samples, 0.32%)</title><rect x="595.0" y="1321" width="13.2" height="19.0" fill="rgb(228,108,25)" rx="2" ry="2" />
+<text  x="597.99" y="1333.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (686,486,049 samples, 0.11%)</title><rect x="268.8" y="1141" width="4.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="271.78" y="1153.5" ></text>
+</g>
+<g >
+<title>__handle_mm_fault (1,463,132,338 samples, 0.23%)</title><rect x="765.3" y="1221" width="9.6" height="19.0" fill="rgb(213,39,9)" rx="2" ry="2" />
+<text  x="768.34" y="1233.5" ></text>
+</g>
+<g >
+<title>[bash] (185,604,918 samples, 0.03%)</title><rect x="835.2" y="561" width="1.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="838.23" y="573.5" ></text>
+</g>
+<g >
+<title>execute_command (436,055,112 samples, 0.07%)</title><rect x="888.5" y="2361" width="2.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="891.55" y="2373.5" ></text>
+</g>
+<g >
+<title>copy_page_to_iter (1,665,361,605 samples, 0.26%)</title><rect x="3052.2" y="2341" width="10.9" height="19.0" fill="rgb(216,52,12)" rx="2" ry="2" />
+<text  x="3055.22" y="2353.5" ></text>
+</g>
+<g >
+<title>execute_command (705,583,873 samples, 0.11%)</title><rect x="296.5" y="1021" width="4.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="299.50" y="1033.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,263,560,140 samples, 0.20%)</title><rect x="860.3" y="1441" width="8.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.30" y="1453.5" ></text>
+</g>
+<g >
+<title>do_wp_page (403,035,294 samples, 0.06%)</title><rect x="725.0" y="1161" width="2.6" height="19.0" fill="rgb(219,66,15)" rx="2" ry="2" />
+<text  x="728.00" y="1173.5" ></text>
+</g>
+<g >
+<title>getname_flags.part.0 (493,748,522 samples, 0.08%)</title><rect x="3929.8" y="2321" width="3.2" height="19.0" fill="rgb(213,39,9)" rx="2" ry="2" />
+<text  x="3932.78" y="2333.5" ></text>
+</g>
+<g >
+<title>[bash] (257,127,002 samples, 0.04%)</title><rect x="898.4" y="141" width="1.7" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="901.39" y="153.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (436,055,112 samples, 0.07%)</title><rect x="888.5" y="2461" width="2.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="891.55" y="2473.5" ></text>
+</g>
+<g >
+<title>posix_fadvise (1,030,119,661 samples, 0.16%)</title><rect x="1569.0" y="2501" width="6.7" height="19.0" fill="rgb(245,186,44)" rx="2" ry="2" />
+<text  x="1571.99" y="2513.5" ></text>
+</g>
+<g >
+<title>unmap_vmas (1,448,410,043 samples, 0.23%)</title><rect x="817.2" y="2421" width="9.5" height="19.0" fill="rgb(249,206,49)" rx="2" ry="2" />
+<text  x="820.24" y="2433.5" ></text>
+</g>
+<g >
+<title>redirection_expand (797,977,712 samples, 0.12%)</title><rect x="829.8" y="321" width="5.2" height="19.0" fill="rgb(218,63,15)" rx="2" ry="2" />
+<text  x="832.82" y="333.5" ></text>
+</g>
+<g >
+<title>execute_command (436,055,112 samples, 0.07%)</title><rect x="888.5" y="2121" width="2.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="891.55" y="2133.5" ></text>
+</g>
+<g >
+<title>avc_has_perm_noaudit (244,671,417 samples, 0.04%)</title><rect x="4171.5" y="2281" width="1.6" height="19.0" fill="rgb(209,18,4)" rx="2" ry="2" />
+<text  x="4174.45" y="2293.5" ></text>
+</g>
+<g >
+<title>execute_command (170,489,782 samples, 0.03%)</title><rect x="871.9" y="1121" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="874.90" y="1133.5" ></text>
+</g>
+<g >
+<title>__fstat64 (777,795,370 samples, 0.12%)</title><rect x="2145.5" y="2421" width="5.0" height="19.0" fill="rgb(224,88,21)" rx="2" ry="2" />
+<text  x="2148.45" y="2433.5" ></text>
+</g>
+<g >
+<title>execute_command (232,870,656 samples, 0.04%)</title><rect x="383.4" y="281" width="1.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="386.39" y="293.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (567,730,480 samples, 0.09%)</title><rect x="835.1" y="1721" width="3.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="838.10" y="1733.5" ></text>
+</g>
+<g >
+<title>execute_command (849,509,116 samples, 0.13%)</title><rect x="895.3" y="1441" width="5.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="898.35" y="1453.5" ></text>
+</g>
+<g >
+<title>_int_malloc (412,365,792 samples, 0.06%)</title><rect x="541.1" y="1141" width="2.7" height="19.0" fill="rgb(215,47,11)" rx="2" ry="2" />
+<text  x="544.13" y="1153.5" ></text>
+</g>
+<g >
+<title>execute_command (432,872,015 samples, 0.07%)</title><rect x="888.6" y="761" width="2.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="891.57" y="773.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (575,055,300 samples, 0.09%)</title><rect x="884.6" y="961" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="887.64" y="973.5" ></text>
+</g>
+<g >
+<title>shmem_file_read_iter (3,073,908,533 samples, 0.48%)</title><rect x="2577.7" y="2361" width="20.1" height="19.0" fill="rgb(238,152,36)" rx="2" ry="2" />
+<text  x="2580.66" y="2373.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (578,068,287 samples, 0.09%)</title><rect x="884.6" y="1881" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="887.62" y="1893.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (7,231,852,508 samples, 1.13%)</title><rect x="308.5" y="1181" width="47.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="311.53" y="1193.5" >exec..</text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (335,944,925 samples, 0.05%)</title><rect x="3043.4" y="2401" width="2.2" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="3046.39" y="2413.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (475,657,449 samples, 0.07%)</title><rect x="276.9" y="561" width="3.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="279.94" y="573.5" ></text>
+</g>
+<g >
+<title>[bash] (704,492,242 samples, 0.11%)</title><rect x="296.5" y="961" width="4.6" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="299.51" y="973.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (250,613,330 samples, 0.04%)</title><rect x="275.2" y="301" width="1.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="278.20" y="313.5" ></text>
+</g>
+<g >
+<title>[bash] (510,501,332 samples, 0.08%)</title><rect x="885.1" y="381" width="3.3" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="888.05" y="393.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,548,468,389 samples, 0.24%)</title><rect x="339.3" y="761" width="10.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="342.25" y="773.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (713,521,499 samples, 0.11%)</title><rect x="296.5" y="1921" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.45" y="1933.5" ></text>
+</g>
+<g >
+<title>copy_page_to_iter (2,215,694,375 samples, 0.35%)</title><rect x="2057.0" y="2341" width="14.5" height="19.0" fill="rgb(216,52,12)" rx="2" ry="2" />
+<text  x="2060.01" y="2353.5" ></text>
+</g>
+<g >
+<title>[bash] (511,725,483 samples, 0.08%)</title><rect x="885.0" y="481" width="3.4" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="888.05" y="493.5" ></text>
+</g>
+<g >
+<title>__printf_chk (4,647,887,766 samples, 0.73%)</title><rect x="3389.6" y="2501" width="30.4" height="19.0" fill="rgb(212,36,8)" rx="2" ry="2" />
+<text  x="3392.56" y="2513.5" >__..</text>
+</g>
+<g >
+<title>__irqentry_text_end (179,763,784 samples, 0.03%)</title><rect x="722.8" y="1261" width="1.1" height="19.0" fill="rgb(254,228,54)" rx="2" ry="2" />
+<text  x="725.77" y="1273.5" ></text>
+</g>
+<g >
+<title>[bash] (2,076,452,672 samples, 0.33%)</title><rect x="789.5" y="1441" width="13.6" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="792.50" y="1453.5" ></text>
+</g>
+<g >
+<title>rep_movs_alternative (1,514,627,503 samples, 0.24%)</title><rect x="1448.2" y="2261" width="9.9" height="19.0" fill="rgb(211,31,7)" rx="2" ry="2" />
+<text  x="1451.16" y="2273.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (2,272,153,807 samples, 0.36%)</title><rect x="177.5" y="2361" width="14.8" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="180.45" y="2373.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (517,533,844 samples, 0.08%)</title><rect x="273.5" y="541" width="3.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="276.52" y="553.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (516,725,798 samples, 0.08%)</title><rect x="856.9" y="1861" width="3.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="859.92" y="1873.5" ></text>
+</g>
+<g >
+<title>execute_command (1,146,830,397 samples, 0.18%)</title><rect x="827.6" y="881" width="7.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="830.59" y="893.5" ></text>
+</g>
+<g >
+<title>execute_command (685,976,378 samples, 0.11%)</title><rect x="268.8" y="961" width="4.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="271.79" y="973.5" ></text>
+</g>
+<g >
+<title>execute_command (679,053,243 samples, 0.11%)</title><rect x="268.8" y="481" width="4.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="271.79" y="493.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (187,401,127 samples, 0.03%)</title><rect x="3421.0" y="2481" width="1.2" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="3423.98" y="2493.5" ></text>
+</g>
+<g >
+<title>[bash] (10,564,748,197 samples, 1.65%)</title><rect x="518.4" y="1321" width="69.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="521.43" y="1333.5" >[bash]</text>
+</g>
+<g >
+<title>execute_command_internal (2,242,449,573 samples, 0.35%)</title><rect x="835.1" y="2361" width="14.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="838.10" y="2373.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (2,721,795,460 samples, 0.43%)</title><rect x="3048.3" y="2441" width="17.8" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="3051.32" y="2453.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (717,313,739 samples, 0.11%)</title><rect x="280.1" y="1681" width="4.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.09" y="1693.5" ></text>
+</g>
+<g >
+<title>ksys_read (2,325,305,246 samples, 0.36%)</title><rect x="1445.4" y="2361" width="15.3" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="1448.45" y="2373.5" ></text>
+</g>
+<g >
+<title>[bash] (157,001,214 samples, 0.02%)</title><rect x="870.9" y="581" width="1.0" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="873.86" y="593.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (554,006,342 samples, 0.09%)</title><rect x="273.3" y="2001" width="3.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="276.29" y="2013.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (844,832,793 samples, 0.13%)</title><rect x="301.2" y="341" width="5.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.16" y="353.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (513,954,307 samples, 0.08%)</title><rect x="856.9" y="1381" width="3.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="859.94" y="1393.5" ></text>
+</g>
+<g >
+<title>asm_exc_page_fault (221,731,738 samples, 0.03%)</title><rect x="1583.3" y="2481" width="1.5" height="19.0" fill="rgb(231,123,29)" rx="2" ry="2" />
+<text  x="1586.34" y="2493.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (866,614,713 samples, 0.14%)</title><rect x="301.1" y="1341" width="5.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.12" y="1353.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (172,854,598 samples, 0.03%)</title><rect x="2617.3" y="2401" width="1.1" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="2620.27" y="2413.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (891,895,571 samples, 0.14%)</title><rect x="851.1" y="2361" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.08" y="2373.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (717,313,739 samples, 0.11%)</title><rect x="280.1" y="1601" width="4.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.09" y="1613.5" ></text>
+</g>
+<g >
+<title>_int_realloc (407,768,765 samples, 0.06%)</title><rect x="584.5" y="1281" width="2.7" height="19.0" fill="rgb(230,117,28)" rx="2" ry="2" />
+<text  x="587.53" y="1293.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (717,313,739 samples, 0.11%)</title><rect x="280.1" y="2441" width="4.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.09" y="2453.5" ></text>
+</g>
+<g >
+<title>dequote_string (1,550,466,778 samples, 0.24%)</title><rect x="597.9" y="1301" width="10.2" height="19.0" fill="rgb(213,40,9)" rx="2" ry="2" />
+<text  x="600.93" y="1313.5" ></text>
+</g>
+<g >
+<title>syscall_return_via_sysret (293,489,266 samples, 0.05%)</title><rect x="1563.0" y="2461" width="2.0" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="1566.04" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (513,428,353 samples, 0.08%)</title><rect x="856.9" y="781" width="3.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="859.94" y="793.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (705,583,873 samples, 0.11%)</title><rect x="296.5" y="1281" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.50" y="1293.5" ></text>
+</g>
+<g >
+<title>__x64_sys_openat (157,694,271 samples, 0.02%)</title><rect x="331.5" y="421" width="1.0" height="19.0" fill="rgb(208,15,3)" rx="2" ry="2" />
+<text  x="334.48" y="433.5" ></text>
+</g>
+<g >
+<title>execute_command (688,777,208 samples, 0.11%)</title><rect x="268.8" y="2441" width="4.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="271.77" y="2453.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,834,564,270 samples, 0.29%)</title><rect x="327.2" y="681" width="12.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="330.20" y="693.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (163,415,529 samples, 0.03%)</title><rect x="870.8" y="661" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="873.82" y="673.5" ></text>
+</g>
+<g >
+<title>[bash] (215,126,890 samples, 0.03%)</title><rect x="842.8" y="661" width="1.4" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="845.81" y="673.5" ></text>
+</g>
+<g >
+<title>make_child (185,640,354 samples, 0.03%)</title><rect x="273.8" y="381" width="1.3" height="19.0" fill="rgb(242,170,40)" rx="2" ry="2" />
+<text  x="276.84" y="393.5" ></text>
+</g>
+<g >
+<title>execute_command (598,514,664 samples, 0.09%)</title><rect x="891.4" y="1481" width="3.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="894.40" y="1493.5" ></text>
+</g>
+<g >
+<title>_IO_file_overflow@@GLIBC_2.2.5 (668,741,136 samples, 0.10%)</title><rect x="2616.3" y="2501" width="4.4" height="19.0" fill="rgb(239,157,37)" rx="2" ry="2" />
+<text  x="2619.35" y="2513.5" ></text>
+</g>
+<g >
+<title>execute_command (4,996,390,301 samples, 0.78%)</title><rect x="360.0" y="541" width="32.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="363.01" y="553.5" >ex..</text>
+</g>
+<g >
+<title>do_user_addr_fault (566,495,163 samples, 0.09%)</title><rect x="454.3" y="981" width="3.7" height="19.0" fill="rgb(235,138,33)" rx="2" ry="2" />
+<text  x="457.30" y="993.5" ></text>
+</g>
+<g >
+<title>copy_page_to_iter (1,645,752,255 samples, 0.26%)</title><rect x="204.7" y="2321" width="10.7" height="19.0" fill="rgb(216,52,12)" rx="2" ry="2" />
+<text  x="207.67" y="2333.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (866,614,713 samples, 0.14%)</title><rect x="301.1" y="2261" width="5.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.12" y="2273.5" ></text>
+</g>
+<g >
+<title>handle_mm_fault (155,764,134 samples, 0.02%)</title><rect x="779.6" y="1221" width="1.0" height="19.0" fill="rgb(240,165,39)" rx="2" ry="2" />
+<text  x="782.61" y="1233.5" ></text>
+</g>
+<g >
+<title>[bash] (354,900,103 samples, 0.06%)</title><rect x="840.5" y="601" width="2.3" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="843.48" y="613.5" ></text>
+</g>
+<g >
+<title>__d_lookup_rcu (329,340,359 samples, 0.05%)</title><rect x="4176.2" y="2301" width="2.2" height="19.0" fill="rgb(235,139,33)" rx="2" ry="2" />
+<text  x="4179.24" y="2313.5" ></text>
+</g>
+<g >
+<title>[bash] (713,987,302 samples, 0.11%)</title><rect x="280.1" y="1181" width="4.7" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="283.11" y="1193.5" ></text>
+</g>
+<g >
+<title>execute_command (554,006,342 samples, 0.09%)</title><rect x="273.3" y="2501" width="3.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="276.29" y="2513.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (717,313,739 samples, 0.11%)</title><rect x="280.1" y="2501" width="4.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.09" y="2513.5" ></text>
+</g>
+<g >
+<title>execute_command (842,511,421 samples, 0.13%)</title><rect x="895.4" y="681" width="5.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="898.39" y="693.5" ></text>
+</g>
+<g >
+<title>[bash] (5,998,059,891 samples, 0.94%)</title><rect x="518.7" y="1241" width="39.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="521.67" y="1253.5" >[ba..</text>
+</g>
+<g >
+<title>execute_command (891,895,571 samples, 0.14%)</title><rect x="851.1" y="2181" width="5.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="854.08" y="2193.5" ></text>
+</g>
+<g >
+<title>[bash] (215,132,849 samples, 0.03%)</title><rect x="842.8" y="801" width="1.4" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="845.81" y="813.5" ></text>
+</g>
+<g >
+<title>[bash] (1,013,042,098 samples, 0.16%)</title><rect x="374.5" y="201" width="6.6" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="377.45" y="213.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (354,998,378 samples, 0.06%)</title><rect x="840.5" y="1161" width="2.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="843.48" y="1173.5" ></text>
+</g>
+<g >
+<title>array_create_element (1,362,824,247 samples, 0.21%)</title><rect x="417.9" y="1061" width="8.9" height="19.0" fill="rgb(252,218,52)" rx="2" ry="2" />
+<text  x="420.88" y="1073.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (215,748,926 samples, 0.03%)</title><rect x="842.8" y="1601" width="1.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="845.80" y="1613.5" ></text>
+</g>
+<g >
+<title>execute_command (506,573,132 samples, 0.08%)</title><rect x="868.6" y="1681" width="3.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="871.57" y="1693.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (5,075,090,635 samples, 0.79%)</title><rect x="3953.4" y="2421" width="33.3" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="3956.45" y="2433.5" >do..</text>
+</g>
+<g >
+<title>_IO_file_open (4,417,339,554 samples, 0.69%)</title><rect x="4119.8" y="2441" width="29.0" height="19.0" fill="rgb(249,205,49)" rx="2" ry="2" />
+<text  x="4122.83" y="2453.5" >_I..</text>
+</g>
+<g >
+<title>do_dentry_open (307,374,902 samples, 0.05%)</title><rect x="188.2" y="2241" width="2.0" height="19.0" fill="rgb(249,205,49)" rx="2" ry="2" />
+<text  x="191.17" y="2253.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (598,514,664 samples, 0.09%)</title><rect x="891.4" y="2381" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.40" y="2393.5" ></text>
+</g>
+<g >
+<title>shmem_get_folio_gfp (388,897,793 samples, 0.06%)</title><rect x="3362.9" y="2341" width="2.6" height="19.0" fill="rgb(219,67,16)" rx="2" ry="2" />
+<text  x="3365.94" y="2353.5" ></text>
+</g>
+<g >
+<title>execute_command (1,256,343,819 samples, 0.20%)</title><rect x="860.3" y="501" width="8.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="863.32" y="513.5" ></text>
+</g>
+<g >
+<title>__libc_start_main@@GLIBC_2.34 (102,680,864,589 samples, 16.08%)</title><rect x="903.8" y="2561" width="672.2" height="19.0" fill="rgb(229,113,27)" rx="2" ry="2" />
+<text  x="906.83" y="2573.5" >__libc_start_main@@GLIBC_2.34</text>
+</g>
+<g >
+<title>[bash] (215,748,926 samples, 0.03%)</title><rect x="842.8" y="1701" width="1.4" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="845.80" y="1713.5" ></text>
+</g>
+<g >
+<title>[bash] (182,077,142 samples, 0.03%)</title><rect x="340.8" y="521" width="1.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="343.76" y="533.5" ></text>
+</g>
+<g >
+<title>execute_command (5,278,632,918 samples, 0.83%)</title><rect x="359.3" y="741" width="34.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="362.34" y="753.5" >ex..</text>
+</g>
+<g >
+<title>security_file_open (346,610,832 samples, 0.05%)</title><rect x="4139.1" y="2241" width="2.3" height="19.0" fill="rgb(215,47,11)" rx="2" ry="2" />
+<text  x="4142.14" y="2253.5" ></text>
+</g>
+<g >
+<title>execute_command (499,574,568 samples, 0.08%)</title><rect x="400.2" y="1061" width="3.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="403.20" y="1073.5" ></text>
+</g>
+<g >
+<title>do_redirections (166,943,806 samples, 0.03%)</title><rect x="871.9" y="601" width="1.1" height="19.0" fill="rgb(247,193,46)" rx="2" ry="2" />
+<text  x="874.92" y="613.5" ></text>
+</g>
+<g >
+<title>__d_lookup_rcu (163,038,299 samples, 0.03%)</title><rect x="2132.8" y="2201" width="1.1" height="19.0" fill="rgb(235,139,33)" rx="2" ry="2" />
+<text  x="2135.82" y="2213.5" ></text>
+</g>
+<g >
+<title>_dl_relocate_object (372,474,936 samples, 0.06%)</title><rect x="2119.2" y="2501" width="2.5" height="19.0" fill="rgb(231,120,28)" rx="2" ry="2" />
+<text  x="2122.22" y="2513.5" ></text>
+</g>
+<g >
+<title>copy_process (245,392,913 samples, 0.04%)</title><rect x="830.7" y="101" width="1.6" height="19.0" fill="rgb(239,160,38)" rx="2" ry="2" />
+<text  x="833.73" y="113.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (686,486,049 samples, 0.11%)</title><rect x="268.8" y="1321" width="4.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="271.78" y="1333.5" ></text>
+</g>
+<g >
+<title>kmem_cache_alloc_noprof (196,804,684 samples, 0.03%)</title><rect x="2038.6" y="2281" width="1.3" height="19.0" fill="rgb(205,0,0)" rx="2" ry="2" />
+<text  x="2041.65" y="2293.5" ></text>
+</g>
+<g >
+<title>__GI___libc_write (991,426,906 samples, 0.16%)</title><rect x="3896.1" y="2421" width="6.5" height="19.0" fill="rgb(217,57,13)" rx="2" ry="2" />
+<text  x="3899.06" y="2433.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (861,612,432 samples, 0.13%)</title><rect x="301.2" y="621" width="5.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.16" y="633.5" ></text>
+</g>
+<g >
+<title>execute_command (849,509,116 samples, 0.13%)</title><rect x="895.3" y="1721" width="5.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="898.35" y="1733.5" ></text>
+</g>
+<g >
+<title>execute_command (849,509,116 samples, 0.13%)</title><rect x="895.3" y="2121" width="5.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="898.35" y="2133.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (678,420,226 samples, 0.11%)</title><rect x="868.6" y="1701" width="4.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="871.57" y="1713.5" ></text>
+</g>
+<g >
+<title>__irqentry_text_end (381,518,327 samples, 0.06%)</title><rect x="761.1" y="1301" width="2.5" height="19.0" fill="rgb(254,228,54)" rx="2" ry="2" />
+<text  x="764.06" y="1313.5" ></text>
+</g>
+<g >
+<title>bpf_trampoline_6442533562 (161,228,444 samples, 0.03%)</title><rect x="2558.4" y="2181" width="1.0" height="19.0" fill="rgb(221,78,18)" rx="2" ry="2" />
+<text  x="2561.35" y="2193.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,263,560,140 samples, 0.20%)</title><rect x="860.3" y="2461" width="8.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.30" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (76,227,296,333 samples, 11.94%)</title><rect x="307.9" y="2281" width="499.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="310.93" y="2293.5" >execute_command_internal</text>
+</g>
+<g >
+<title>execute_command_internal (516,725,798 samples, 0.08%)</title><rect x="856.9" y="1901" width="3.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="859.92" y="1913.5" ></text>
+</g>
+<g >
+<title>execute_command (2,420,545,736 samples, 0.38%)</title><rect x="868.6" y="2521" width="15.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="871.57" y="2533.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (2,455,514,825 samples, 0.38%)</title><rect x="2125.9" y="2381" width="16.1" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="2128.89" y="2393.5" ></text>
+</g>
+<g >
+<title>execute_command (598,514,664 samples, 0.09%)</title><rect x="891.4" y="2281" width="3.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="894.40" y="2293.5" ></text>
+</g>
+<g >
+<title>__GI___libc_write (508,667,300 samples, 0.08%)</title><rect x="1647.8" y="2441" width="3.3" height="19.0" fill="rgb(217,57,13)" rx="2" ry="2" />
+<text  x="1650.81" y="2453.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (550,598,300 samples, 0.09%)</title><rect x="273.3" y="1001" width="3.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="276.32" y="1013.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (595,672,870 samples, 0.09%)</title><rect x="891.4" y="781" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.42" y="793.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (416,681,683 samples, 0.07%)</title><rect x="3338.8" y="2401" width="2.7" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="3341.81" y="2413.5" ></text>
+</g>
+<g >
+<title>[bash] (253,996,257 samples, 0.04%)</title><rect x="866.2" y="161" width="1.7" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="869.20" y="173.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (554,006,342 samples, 0.09%)</title><rect x="273.3" y="1961" width="3.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="276.29" y="1973.5" ></text>
+</g>
+<g >
+<title>execute_command (866,614,713 samples, 0.14%)</title><rect x="301.1" y="1841" width="5.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="304.12" y="1853.5" ></text>
+</g>
+<g >
+<title>execute_command (426,616,470 samples, 0.07%)</title><rect x="888.6" y="601" width="2.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="891.57" y="613.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (158,744,410 samples, 0.02%)</title><rect x="875.9" y="1261" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="878.93" y="1273.5" ></text>
+</g>
+<g >
+<title>__strchrnul_evex (400,124,458 samples, 0.06%)</title><rect x="3416.1" y="2461" width="2.7" height="19.0" fill="rgb(239,159,38)" rx="2" ry="2" />
+<text  x="3419.13" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (717,313,739 samples, 0.11%)</title><rect x="280.1" y="1641" width="4.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.09" y="1653.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (554,006,342 samples, 0.09%)</title><rect x="273.3" y="2361" width="3.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="276.29" y="2373.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (578,068,287 samples, 0.09%)</title><rect x="884.6" y="1721" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="887.62" y="1733.5" ></text>
+</g>
+<g >
+<title>may_open (158,602,520 samples, 0.02%)</title><rect x="2033.0" y="2261" width="1.1" height="19.0" fill="rgb(240,162,38)" rx="2" ry="2" />
+<text  x="2036.01" y="2273.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (436,055,112 samples, 0.07%)</title><rect x="888.5" y="1981" width="2.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="891.55" y="1993.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (2,834,923,738 samples, 0.44%)</title><rect x="2543.8" y="2361" width="18.5" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="2546.78" y="2373.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (713,521,499 samples, 0.11%)</title><rect x="296.5" y="2321" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.45" y="2333.5" ></text>
+</g>
+<g >
+<title>execute_command (436,055,112 samples, 0.07%)</title><rect x="888.5" y="1761" width="2.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="891.55" y="1773.5" ></text>
+</g>
+<g >
+<title>execute_command (159,253,151 samples, 0.02%)</title><rect x="851.1" y="381" width="1.0" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="854.09" y="393.5" ></text>
+</g>
+<g >
+<title>[bash] (158,593,817 samples, 0.02%)</title><rect x="875.9" y="641" width="1.1" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="878.93" y="653.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (433,500,595 samples, 0.07%)</title><rect x="888.6" y="1361" width="2.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="891.56" y="1373.5" ></text>
+</g>
+<g >
+<title>[bash] (253,166,721 samples, 0.04%)</title><rect x="832.9" y="181" width="1.6" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="835.86" y="193.5" ></text>
+</g>
+<g >
+<title>__libc_fork (296,481,570 samples, 0.05%)</title><rect x="830.7" y="221" width="1.9" height="19.0" fill="rgb(220,70,16)" rx="2" ry="2" />
+<text  x="833.70" y="233.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (705,583,873 samples, 0.11%)</title><rect x="296.5" y="1081" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.50" y="1093.5" ></text>
+</g>
+<g >
+<title>ret_from_fork (276,719,394 samples, 0.04%)</title><rect x="708.3" y="1261" width="1.8" height="19.0" fill="rgb(234,134,32)" rx="2" ry="2" />
+<text  x="711.28" y="1273.5" ></text>
+</g>
+<g >
+<title>execute_command (516,725,798 samples, 0.08%)</title><rect x="856.9" y="1801" width="3.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="859.92" y="1813.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (849,509,116 samples, 0.13%)</title><rect x="895.3" y="2021" width="5.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.35" y="2033.5" ></text>
+</g>
+<g >
+<title>execute_command (76,162,814,457 samples, 11.93%)</title><rect x="307.9" y="2021" width="498.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="310.94" y="2033.5" >execute_command</text>
+</g>
+<g >
+<title>do_syscall_64 (231,564,763 samples, 0.04%)</title><rect x="1503.9" y="2361" width="1.5" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="1506.93" y="2373.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (190,829,147 samples, 0.03%)</title><rect x="837.6" y="801" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="840.55" y="813.5" ></text>
+</g>
+<g >
+<title>execute_command (688,777,208 samples, 0.11%)</title><rect x="268.8" y="2281" width="4.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="271.77" y="2293.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (866,614,713 samples, 0.14%)</title><rect x="301.1" y="2441" width="5.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.12" y="2453.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (575,055,300 samples, 0.09%)</title><rect x="884.6" y="1121" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="887.64" y="1133.5" ></text>
+</g>
+<g >
+<title>execute_command (432,872,015 samples, 0.07%)</title><rect x="888.6" y="1041" width="2.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="891.57" y="1053.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,150,422,968 samples, 0.18%)</title><rect x="827.6" y="2141" width="7.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.57" y="2153.5" ></text>
+</g>
+<g >
+<title>execute_command (713,462,810 samples, 0.11%)</title><rect x="280.1" y="661" width="4.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="283.11" y="673.5" ></text>
+</g>
+<g >
+<title>execute_command (436,055,112 samples, 0.07%)</title><rect x="888.5" y="1881" width="2.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="891.55" y="1893.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (891,895,571 samples, 0.14%)</title><rect x="851.1" y="2481" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.08" y="2493.5" ></text>
+</g>
+<g >
+<title>execute_command (843,061,254 samples, 0.13%)</title><rect x="895.4" y="1081" width="5.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="898.39" y="1093.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (356,134,455 samples, 0.06%)</title><rect x="840.5" y="1681" width="2.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="843.47" y="1693.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (177,941,456 samples, 0.03%)</title><rect x="2094.6" y="2401" width="1.1" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="2097.56" y="2413.5" ></text>
+</g>
+<g >
+<title>[bash] (379,498,561 samples, 0.06%)</title><rect x="277.5" y="341" width="2.5" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="280.53" y="353.5" ></text>
+</g>
+<g >
+<title>execute_command (1,988,959,591 samples, 0.31%)</title><rect x="868.6" y="2241" width="13.0" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="871.57" y="2253.5" ></text>
+</g>
+<g >
+<title>execute_command (354,998,378 samples, 0.06%)</title><rect x="840.5" y="1141" width="2.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="843.48" y="1153.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (238,090,729 samples, 0.04%)</title><rect x="827.6" y="221" width="1.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.59" y="233.5" ></text>
+</g>
+<g >
+<title>[bash] (516,726,976 samples, 0.08%)</title><rect x="273.5" y="401" width="3.4" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="276.52" y="413.5" ></text>
+</g>
+<g >
+<title>[bash] (305,508,174 samples, 0.05%)</title><rect x="868.8" y="461" width="2.0" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="871.80" y="473.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (866,614,713 samples, 0.14%)</title><rect x="301.1" y="1461" width="5.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.12" y="1473.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (800,932,783 samples, 0.13%)</title><rect x="310.1" y="621" width="5.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="313.08" y="633.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (158,599,791 samples, 0.02%)</title><rect x="875.9" y="1061" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="878.93" y="1073.5" ></text>
+</g>
+<g >
+<title>_dl_start (710,651,335 samples, 0.11%)</title><rect x="3015.4" y="2561" width="4.6" height="19.0" fill="rgb(237,151,36)" rx="2" ry="2" />
+<text  x="3018.39" y="2573.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,925,898,782 samples, 0.30%)</title><rect x="868.6" y="2141" width="12.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="871.57" y="2153.5" ></text>
+</g>
+<g >
+<title>execute_command (322,256,264 samples, 0.05%)</title><rect x="868.7" y="1001" width="2.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="871.70" y="1013.5" ></text>
+</g>
+<g >
+<title>execute_command (76,163,853,185 samples, 11.93%)</title><rect x="307.9" y="2181" width="498.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="310.93" y="2193.5" >execute_command</text>
+</g>
+<g >
+<title>execute_command (179,777,548 samples, 0.03%)</title><rect x="878.5" y="1081" width="1.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="881.48" y="1093.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (598,514,664 samples, 0.09%)</title><rect x="891.4" y="2481" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.40" y="2493.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (179,777,548 samples, 0.03%)</title><rect x="878.5" y="1061" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="881.48" y="1073.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (158,744,410 samples, 0.02%)</title><rect x="875.9" y="1521" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="878.93" y="1533.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (483,985,097 samples, 0.08%)</title><rect x="276.9" y="1881" width="3.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="279.92" y="1893.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,261,220,789 samples, 0.20%)</title><rect x="860.3" y="761" width="8.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.32" y="773.5" ></text>
+</g>
+<g >
+<title>_IO_file_overflow@@GLIBC_2.2.5 (156,862,057 samples, 0.02%)</title><rect x="4026.7" y="2541" width="1.0" height="19.0" fill="rgb(239,157,37)" rx="2" ry="2" />
+<text  x="4029.70" y="2553.5" ></text>
+</g>
+<g >
+<title>_IO_do_write@@GLIBC_2.2.5 (540,525,956 samples, 0.08%)</title><rect x="3080.5" y="2481" width="3.5" height="19.0" fill="rgb(238,155,37)" rx="2" ry="2" />
+<text  x="3083.45" y="2493.5" ></text>
+</g>
+<g >
+<title>redirection_expand (166,943,806 samples, 0.03%)</title><rect x="871.9" y="561" width="1.1" height="19.0" fill="rgb(218,63,15)" rx="2" ry="2" />
+<text  x="874.92" y="573.5" ></text>
+</g>
+<g >
+<title>execute_command (436,055,112 samples, 0.07%)</title><rect x="888.5" y="2441" width="2.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="891.55" y="2453.5" ></text>
+</g>
+<g >
+<title>[bash] (190,019,711 samples, 0.03%)</title><rect x="837.6" y="641" width="1.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="840.56" y="653.5" ></text>
+</g>
+<g >
+<title>execute_command (685,976,378 samples, 0.11%)</title><rect x="268.8" y="921" width="4.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="271.79" y="933.5" ></text>
+</g>
+<g >
+<title>_dl_start_user (729,377,544 samples, 0.11%)</title><rect x="3681.4" y="2581" width="4.7" height="19.0" fill="rgb(236,145,34)" rx="2" ry="2" />
+<text  x="3684.37" y="2593.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (551,359,579 samples, 0.09%)</title><rect x="273.3" y="1281" width="3.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="276.31" y="1293.5" ></text>
+</g>
+<g >
+<title>string_list_dollar_at (3,678,957,057 samples, 0.58%)</title><rect x="533.8" y="1221" width="24.1" height="19.0" fill="rgb(224,87,20)" rx="2" ry="2" />
+<text  x="536.85" y="1233.5" >s..</text>
+</g>
+<g >
+<title>do_filp_open (3,498,661,566 samples, 0.55%)</title><rect x="1471.0" y="2301" width="22.9" height="19.0" fill="rgb(217,58,13)" rx="2" ry="2" />
+<text  x="1474.01" y="2313.5" >d..</text>
+</g>
+<g >
+<title>[unknown] (162,224,619 samples, 0.03%)</title><rect x="4025.6" y="2541" width="1.1" height="19.0" fill="rgb(210,24,5)" rx="2" ry="2" />
+<text  x="4028.64" y="2553.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,150,422,968 samples, 0.18%)</title><rect x="827.6" y="1941" width="7.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.57" y="1953.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (566,738,277 samples, 0.09%)</title><rect x="403.5" y="1061" width="3.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="406.47" y="1073.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (866,614,713 samples, 0.14%)</title><rect x="301.1" y="1821" width="5.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.12" y="1833.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (159,710,185 samples, 0.03%)</title><rect x="875.9" y="1581" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="878.92" y="1593.5" ></text>
+</g>
+<g >
+<title>malloc (3,510,083,098 samples, 0.55%)</title><rect x="719.1" y="1321" width="23.0" height="19.0" fill="rgb(230,119,28)" rx="2" ry="2" />
+<text  x="722.13" y="1333.5" >m..</text>
+</g>
+<g >
+<title>execute_command (578,068,287 samples, 0.09%)</title><rect x="884.6" y="1981" width="3.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="887.62" y="1993.5" ></text>
+</g>
+<g >
+<title>[bash] (305,555,597 samples, 0.05%)</title><rect x="868.8" y="501" width="2.0" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="871.80" y="513.5" ></text>
+</g>
+<g >
+<title>execute_command (17,151,221,343 samples, 2.69%)</title><rect x="398.5" y="1341" width="112.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="401.45" y="1353.5" >execute_command</text>
+</g>
+<g >
+<title>execute_command_internal (686,486,049 samples, 0.11%)</title><rect x="268.8" y="1221" width="4.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="271.78" y="1233.5" ></text>
+</g>
+<g >
+<title>execute_command (717,313,739 samples, 0.11%)</title><rect x="280.1" y="1661" width="4.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="283.09" y="1673.5" ></text>
+</g>
+<g >
+<title>__fopen_internal (4,604,741,693 samples, 0.72%)</title><rect x="4119.5" y="2481" width="30.2" height="19.0" fill="rgb(248,197,47)" rx="2" ry="2" />
+<text  x="4122.54" y="2493.5" >__..</text>
+</g>
+<g >
+<title>execute_command_internal (5,853,569,678 samples, 0.92%)</title><rect x="356.1" y="961" width="38.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="359.09" y="973.5" >exe..</text>
+</g>
+<g >
+<title>[xxhsum] (12,825,968,762 samples, 2.01%)</title><rect x="4035.3" y="2481" width="84.0" height="19.0" fill="rgb(249,206,49)" rx="2" ry="2" />
+<text  x="4038.33" y="2493.5" >[xxhsum]</text>
+</g>
+<g >
+<title>execute_command (713,462,810 samples, 0.11%)</title><rect x="280.1" y="781" width="4.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="283.11" y="793.5" ></text>
+</g>
+<g >
+<title>execute_command (891,895,571 samples, 0.14%)</title><rect x="851.1" y="1901" width="5.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="854.08" y="1913.5" ></text>
+</g>
+<g >
+<title>dispose_words (4,010,127,684 samples, 0.63%)</title><rect x="756.2" y="1361" width="26.3" height="19.0" fill="rgb(235,141,33)" rx="2" ry="2" />
+<text  x="759.20" y="1373.5" >d..</text>
+</g>
+<g >
+<title>[bash] (578,517,568 samples, 0.09%)</title><rect x="269.4" y="421" width="3.8" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="272.44" y="433.5" ></text>
+</g>
+<g >
+<title>[sha1sum] (14,647,220,376 samples, 2.29%)</title><rect x="2019.4" y="2581" width="95.9" height="19.0" fill="rgb(214,42,10)" rx="2" ry="2" />
+<text  x="2022.39" y="2593.5" >[sha1sum]</text>
+</g>
+<g >
+<title>walk_component (223,691,037 samples, 0.04%)</title><rect x="2030.2" y="2241" width="1.4" height="19.0" fill="rgb(247,197,47)" rx="2" ry="2" />
+<text  x="2033.16" y="2253.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (713,987,302 samples, 0.11%)</title><rect x="280.1" y="1201" width="4.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.11" y="1213.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (187,532,328 samples, 0.03%)</title><rect x="890.0" y="301" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="892.97" y="313.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (890,006,400 samples, 0.14%)</title><rect x="851.1" y="1361" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.09" y="1373.5" ></text>
+</g>
+<g >
+<title>[bash] (167,008,815 samples, 0.03%)</title><rect x="871.9" y="621" width="1.1" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="874.92" y="633.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (2,437,764,054 samples, 0.38%)</title><rect x="1509.4" y="2401" width="16.0" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="1512.43" y="2413.5" ></text>
+</g>
+<g >
+<title>__printf_buffer_write (185,924,918 samples, 0.03%)</title><rect x="3095.0" y="2441" width="1.2" height="19.0" fill="rgb(220,73,17)" rx="2" ry="2" />
+<text  x="3097.99" y="2453.5" ></text>
+</g>
+<g >
+<title>execute_command (595,672,870 samples, 0.09%)</title><rect x="891.4" y="921" width="3.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="894.42" y="933.5" ></text>
+</g>
+<g >
+<title>handle_mm_fault (759,519,782 samples, 0.12%)</title><rect x="734.9" y="1181" width="5.0" height="19.0" fill="rgb(240,165,39)" rx="2" ry="2" />
+<text  x="737.91" y="1193.5" ></text>
+</g>
+<g >
+<title>do_redirections (410,272,199 samples, 0.06%)</title><rect x="282.0" y="301" width="2.7" height="19.0" fill="rgb(247,193,46)" rx="2" ry="2" />
+<text  x="284.97" y="313.5" ></text>
+</g>
+<g >
+<title>dl_main (506,551,884 samples, 0.08%)</title><rect x="3305.7" y="2521" width="3.4" height="19.0" fill="rgb(236,145,34)" rx="2" ry="2" />
+<text  x="3308.74" y="2533.5" ></text>
+</g>
+<g >
+<title>[bash] (846,738,469 samples, 0.13%)</title><rect x="375.3" y="161" width="5.6" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="378.31" y="173.5" ></text>
+</g>
+<g >
+<title>path_openat (2,873,609,336 samples, 0.45%)</title><rect x="4122.7" y="2301" width="18.8" height="19.0" fill="rgb(205,2,0)" rx="2" ry="2" />
+<text  x="4125.72" y="2313.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,150,422,968 samples, 0.18%)</title><rect x="827.6" y="2101" width="7.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.57" y="2113.5" ></text>
+</g>
+<g >
+<title>execute_command (516,725,798 samples, 0.08%)</title><rect x="856.9" y="2001" width="3.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="859.92" y="2013.5" ></text>
+</g>
+<g >
+<title>execute_command (717,313,739 samples, 0.11%)</title><rect x="280.1" y="1861" width="4.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="283.09" y="1873.5" ></text>
+</g>
+<g >
+<title>array_insert (1,601,031,890 samples, 0.25%)</title><rect x="416.6" y="1081" width="10.5" height="19.0" fill="rgb(222,78,18)" rx="2" ry="2" />
+<text  x="419.62" y="1093.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (897,666,085 samples, 0.14%)</title><rect x="868.6" y="1781" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="871.57" y="1793.5" ></text>
+</g>
+<g >
+<title>filemap_get_entry (271,506,491 samples, 0.04%)</title><rect x="3363.7" y="2321" width="1.8" height="19.0" fill="rgb(253,222,53)" rx="2" ry="2" />
+<text  x="3366.70" y="2333.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (76,163,081,250 samples, 11.93%)</title><rect x="307.9" y="2041" width="498.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="310.94" y="2053.5" >execute_command_internal</text>
+</g>
+<g >
+<title>execute_command (5,259,224,680 samples, 0.82%)</title><rect x="359.4" y="701" width="34.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="362.45" y="713.5" >ex..</text>
+</g>
+<g >
+<title>execute_command_internal (598,514,664 samples, 0.09%)</title><rect x="891.4" y="1541" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.40" y="1553.5" ></text>
+</g>
+<g >
+<title>asm_exc_page_fault (1,107,459,318 samples, 0.17%)</title><rect x="733.6" y="1241" width="7.2" height="19.0" fill="rgb(231,123,29)" rx="2" ry="2" />
+<text  x="736.57" y="1253.5" ></text>
+</g>
+<g >
+<title>_IO_do_write@@GLIBC_2.2.5 (518,078,789 samples, 0.08%)</title><rect x="1530.5" y="2461" width="3.4" height="19.0" fill="rgb(238,155,37)" rx="2" ry="2" />
+<text  x="1533.55" y="2473.5" ></text>
+</g>
+<g >
+<title>do_redirections (215,132,849 samples, 0.03%)</title><rect x="842.8" y="821" width="1.4" height="19.0" fill="rgb(247,193,46)" rx="2" ry="2" />
+<text  x="845.81" y="833.5" ></text>
+</g>
+<g >
+<title>execute_command (866,614,713 samples, 0.14%)</title><rect x="301.1" y="2121" width="5.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="304.12" y="2133.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (598,514,664 samples, 0.09%)</title><rect x="891.4" y="2181" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.40" y="2193.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,146,830,397 samples, 0.18%)</title><rect x="827.6" y="1081" width="7.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.59" y="1093.5" ></text>
+</g>
+<g >
+<title>zgetline (703,188,544 samples, 0.11%)</title><rect x="366.6" y="181" width="4.6" height="19.0" fill="rgb(219,65,15)" rx="2" ry="2" />
+<text  x="369.58" y="193.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (554,006,342 samples, 0.09%)</title><rect x="273.3" y="2521" width="3.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="276.29" y="2533.5" ></text>
+</g>
+<g >
+<title>execute_command (1,934,760,318 samples, 0.30%)</title><rect x="835.1" y="2181" width="12.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="838.10" y="2193.5" ></text>
+</g>
+<g >
+<title>process_measurement (160,642,431 samples, 0.03%)</title><rect x="3923.6" y="2241" width="1.1" height="19.0" fill="rgb(214,42,10)" rx="2" ry="2" />
+<text  x="3926.61" y="2253.5" ></text>
+</g>
+<g >
+<title>shmem_file_write_iter (272,500,715 samples, 0.04%)</title><rect x="901.0" y="2401" width="1.8" height="19.0" fill="rgb(214,43,10)" rx="2" ry="2" />
+<text  x="903.97" y="2413.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (866,614,713 samples, 0.14%)</title><rect x="301.1" y="2341" width="5.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.12" y="2353.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (164,072,262 samples, 0.03%)</title><rect x="836.5" y="721" width="1.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="839.46" y="733.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,263,560,140 samples, 0.20%)</title><rect x="860.3" y="2201" width="8.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.30" y="2213.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (164,731,865 samples, 0.03%)</title><rect x="836.5" y="881" width="1.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="839.46" y="893.5" ></text>
+</g>
+<g >
+<title>perf_event_init_task (494,698,639 samples, 0.08%)</title><rect x="703.4" y="1181" width="3.2" height="19.0" fill="rgb(254,225,53)" rx="2" ry="2" />
+<text  x="706.39" y="1193.5" ></text>
+</g>
+<g >
+<title>[bash] (337,851,906 samples, 0.05%)</title><rect x="889.1" y="341" width="2.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="892.10" y="353.5" ></text>
+</g>
+<g >
+<title>entry_SYSRETQ_unsafe_stack (641,005,024 samples, 0.10%)</title><rect x="3987.1" y="2441" width="4.1" height="19.0" fill="rgb(213,37,8)" rx="2" ry="2" />
+<text  x="3990.05" y="2453.5" ></text>
+</g>
+<g >
+<title>kmem_cache_alloc_noprof (315,847,462 samples, 0.05%)</title><rect x="4162.5" y="2381" width="2.1" height="19.0" fill="rgb(205,0,0)" rx="2" ry="2" />
+<text  x="4165.49" y="2393.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (179,777,548 samples, 0.03%)</title><rect x="878.5" y="1501" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="881.48" y="1513.5" ></text>
+</g>
+<g >
+<title>parse_and_execute (76,556,824,556 samples, 11.99%)</title><rect x="306.9" y="2481" width="501.2" height="19.0" fill="rgb(243,178,42)" rx="2" ry="2" />
+<text  x="309.94" y="2493.5" >parse_and_execute</text>
+</g>
+<g >
+<title>execute_command (890,006,400 samples, 0.14%)</title><rect x="851.1" y="1181" width="5.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="854.09" y="1193.5" ></text>
+</g>
+<g >
+<title>sha224sum (63,651,548,698 samples, 9.97%)</title><rect x="2122.9" y="2601" width="416.7" height="19.0" fill="rgb(237,149,35)" rx="2" ry="2" />
+<text  x="2125.92" y="2613.5" >sha224sum</text>
+</g>
+<g >
+<title>_dl_map_object_deps (288,891,629 samples, 0.05%)</title><rect x="1579.5" y="2501" width="1.9" height="19.0" fill="rgb(219,68,16)" rx="2" ry="2" />
+<text  x="1582.51" y="2513.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (215,748,926 samples, 0.03%)</title><rect x="842.8" y="1861" width="1.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="845.80" y="1873.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (699,234,233 samples, 0.11%)</title><rect x="296.5" y="441" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.51" y="453.5" ></text>
+</g>
+<g >
+<title>[bash] (166,042,857 samples, 0.03%)</title><rect x="836.5" y="1441" width="1.0" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="839.46" y="1453.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (212,197,076 samples, 0.03%)</title><rect x="895.4" y="301" width="1.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.39" y="313.5" ></text>
+</g>
+<g >
+<title>[bash] (6,006,274,317 samples, 0.94%)</title><rect x="518.7" y="1261" width="39.3" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="521.66" y="1273.5" >[ba..</text>
+</g>
+<g >
+<title>execute_command (179,777,548 samples, 0.03%)</title><rect x="878.5" y="1041" width="1.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="881.48" y="1053.5" ></text>
+</g>
+<g >
+<title>execute_command (842,511,421 samples, 0.13%)</title><rect x="895.4" y="761" width="5.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="898.39" y="773.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,261,568,072 samples, 0.20%)</title><rect x="860.3" y="1261" width="8.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.31" y="1273.5" ></text>
+</g>
+<g >
+<title>[bash] (158,643,683 samples, 0.02%)</title><rect x="836.5" y="561" width="1.0" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="839.50" y="573.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (433,500,595 samples, 0.07%)</title><rect x="888.6" y="1521" width="2.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="891.56" y="1533.5" ></text>
+</g>
+<g >
+<title>[bash] (153,423,277 samples, 0.02%)</title><rect x="389.3" y="401" width="1.0" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="392.30" y="413.5" ></text>
+</g>
+<g >
+<title>x64_sys_call (207,707,782 samples, 0.03%)</title><rect x="1585.8" y="2541" width="1.4" height="19.0" fill="rgb(253,224,53)" rx="2" ry="2" />
+<text  x="1588.83" y="2553.5" ></text>
+</g>
+<g >
+<title>execute_command (516,725,798 samples, 0.08%)</title><rect x="856.9" y="1881" width="3.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="859.92" y="1893.5" ></text>
+</g>
+<g >
+<title>execute_command (1,263,560,140 samples, 0.20%)</title><rect x="860.3" y="1821" width="8.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="863.30" y="1833.5" ></text>
+</g>
+<g >
+<title>execute_command (483,985,097 samples, 0.08%)</title><rect x="276.9" y="1821" width="3.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="279.92" y="1833.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (275,380,542 samples, 0.04%)</title><rect x="498.9" y="1021" width="1.8" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="501.88" y="1033.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (713,462,810 samples, 0.11%)</title><rect x="280.1" y="641" width="4.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.11" y="653.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (5,903,964,736 samples, 0.92%)</title><rect x="356.1" y="1141" width="38.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="359.07" y="1153.5" >exe..</text>
+</g>
+<g >
+<title>execute_command (678,420,226 samples, 0.11%)</title><rect x="868.6" y="1721" width="4.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="871.57" y="1733.5" ></text>
+</g>
+<g >
+<title>dispose_command (278,788,607 samples, 0.04%)</title><rect x="840.5" y="461" width="1.8" height="19.0" fill="rgb(248,201,48)" rx="2" ry="2" />
+<text  x="843.48" y="473.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (166,042,857 samples, 0.03%)</title><rect x="836.5" y="1421" width="1.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="839.46" y="1433.5" ></text>
+</g>
+<g >
+<title>execute_command (1,263,560,140 samples, 0.20%)</title><rect x="860.3" y="1621" width="8.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="863.30" y="1633.5" ></text>
+</g>
+<g >
+<title>execute_command (2,276,144,711 samples, 0.36%)</title><rect x="868.6" y="2401" width="14.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="871.57" y="2413.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (13,303,664,977 samples, 2.08%)</title><rect x="307.9" y="1561" width="87.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="310.94" y="1573.5" >execute_co..</text>
+</g>
+<g >
+<title>execute_command_internal (596,118,643 samples, 0.09%)</title><rect x="891.4" y="1261" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.42" y="1273.5" ></text>
+</g>
+<g >
+<title>syscall_return_via_sysret (198,099,919 samples, 0.03%)</title><rect x="2113.5" y="2481" width="1.3" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="2116.49" y="2493.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (688,777,208 samples, 0.11%)</title><rect x="268.8" y="1621" width="4.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="271.77" y="1633.5" ></text>
+</g>
+<g >
+<title>[bash] (191,929,166 samples, 0.03%)</title><rect x="327.4" y="621" width="1.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="330.38" y="633.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,150,422,968 samples, 0.18%)</title><rect x="827.6" y="1661" width="7.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.57" y="1673.5" ></text>
+</g>
+<g >
+<title>execute_command (891,895,571 samples, 0.14%)</title><rect x="851.1" y="1581" width="5.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="854.08" y="1593.5" ></text>
+</g>
+<g >
+<title>execute_command (842,511,421 samples, 0.13%)</title><rect x="895.4" y="1001" width="5.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="898.39" y="1013.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (575,055,300 samples, 0.09%)</title><rect x="884.6" y="761" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="887.64" y="773.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,146,830,397 samples, 0.18%)</title><rect x="827.6" y="781" width="7.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.59" y="793.5" ></text>
+</g>
+<g >
+<title>entry_SYSRETQ_unsafe_stack (256,204,589 samples, 0.04%)</title><rect x="3933.5" y="2401" width="1.6" height="19.0" fill="rgb(213,37,8)" rx="2" ry="2" />
+<text  x="3936.46" y="2413.5" ></text>
+</g>
+<g >
+<title>_IO_doallocbuf (758,449,593 samples, 0.12%)</title><rect x="3042.7" y="2441" width="4.9" height="19.0" fill="rgb(214,45,10)" rx="2" ry="2" />
+<text  x="3045.66" y="2453.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (551,359,579 samples, 0.09%)</title><rect x="273.3" y="1421" width="3.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="276.31" y="1433.5" ></text>
+</g>
+<g >
+<title>execute_command (1,263,560,140 samples, 0.20%)</title><rect x="860.3" y="2021" width="8.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="863.30" y="2033.5" ></text>
+</g>
+<g >
+<title>execute_command (717,313,739 samples, 0.11%)</title><rect x="280.1" y="2301" width="4.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="283.09" y="2313.5" ></text>
+</g>
+<g >
+<title>__fput (288,823,037 samples, 0.05%)</title><rect x="4004.8" y="2401" width="1.9" height="19.0" fill="rgb(205,0,0)" rx="2" ry="2" />
+<text  x="4007.78" y="2413.5" ></text>
+</g>
+<g >
+<title>execute_command (3,582,156,947 samples, 0.56%)</title><rect x="361.5" y="341" width="23.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="364.51" y="353.5" >e..</text>
+</g>
+<g >
+<title>[sha384sum] (8,843,110,246 samples, 1.38%)</title><rect x="3021.9" y="2501" width="57.9" height="19.0" fill="rgb(253,223,53)" rx="2" ry="2" />
+<text  x="3024.95" y="2513.5" >[sha38..</text>
+</g>
+<g >
+<title>dispose_words (607,548,928 samples, 0.10%)</title><rect x="688.4" y="1341" width="4.0" height="19.0" fill="rgb(235,141,33)" rx="2" ry="2" />
+<text  x="691.44" y="1353.5" ></text>
+</g>
+<g >
+<title>cfree@GLIBC_2.2.5 (4,299,645,046 samples, 0.67%)</title><rect x="433.9" y="1061" width="28.1" height="19.0" fill="rgb(233,131,31)" rx="2" ry="2" />
+<text  x="436.88" y="1073.5" >c..</text>
+</g>
+<g >
+<title>execute_command_internal (842,511,421 samples, 0.13%)</title><rect x="895.4" y="861" width="5.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.39" y="873.5" ></text>
+</g>
+<g >
+<title>execute_command (686,486,049 samples, 0.11%)</title><rect x="268.8" y="1401" width="4.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="271.78" y="1413.5" ></text>
+</g>
+<g >
+<title>execute_command (891,895,571 samples, 0.14%)</title><rect x="851.1" y="2101" width="5.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="854.08" y="2113.5" ></text>
+</g>
+<g >
+<title>execute_command (5,209,628,309 samples, 0.82%)</title><rect x="359.7" y="621" width="34.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="362.69" y="633.5" >ex..</text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (419,297,826 samples, 0.07%)</title><rect x="3896.2" y="2401" width="2.7" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="3899.20" y="2413.5" ></text>
+</g>
+<g >
+<title>execute_command (354,998,378 samples, 0.06%)</title><rect x="840.5" y="1261" width="2.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="843.48" y="1273.5" ></text>
+</g>
+<g >
+<title>execute_command (1,261,568,072 samples, 0.20%)</title><rect x="860.3" y="1101" width="8.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="863.31" y="1113.5" ></text>
+</g>
+<g >
+<title>execute_command (335,137,133 samples, 0.05%)</title><rect x="351.5" y="741" width="2.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="354.54" y="753.5" ></text>
+</g>
+<g >
+<title>__close_nocancel (715,019,450 samples, 0.11%)</title><rect x="3071.6" y="2461" width="4.6" height="19.0" fill="rgb(228,109,26)" rx="2" ry="2" />
+<text  x="3074.56" y="2473.5" ></text>
+</g>
+<g >
+<title>_dl_map_object_deps (198,512,514 samples, 0.03%)</title><rect x="3015.9" y="2501" width="1.3" height="19.0" fill="rgb(219,68,16)" rx="2" ry="2" />
+<text  x="3018.86" y="2513.5" ></text>
+</g>
+<g >
+<title>entry_SYSRETQ_unsafe_stack (255,821,437 samples, 0.04%)</title><rect x="1572.1" y="2481" width="1.7" height="19.0" fill="rgb(213,37,8)" rx="2" ry="2" />
+<text  x="1575.10" y="2493.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (154,353,143 samples, 0.02%)</title><rect x="2204.7" y="2481" width="1.0" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="2207.70" y="2493.5" ></text>
+</g>
+<g >
+<title>[bash] (849,509,116 samples, 0.13%)</title><rect x="895.3" y="2501" width="5.6" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="898.35" y="2513.5" ></text>
+</g>
+<g >
+<title>security_file_post_open (191,862,812 samples, 0.03%)</title><rect x="1487.8" y="2261" width="1.3" height="19.0" fill="rgb(218,63,15)" rx="2" ry="2" />
+<text  x="1490.83" y="2273.5" ></text>
+</g>
+<g >
+<title>[bash] (890,006,400 samples, 0.14%)</title><rect x="851.1" y="1261" width="5.8" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="854.09" y="1273.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (516,725,798 samples, 0.08%)</title><rect x="856.9" y="1741" width="3.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="859.92" y="1753.5" ></text>
+</g>
+<g >
+<title>__vfprintf_internal (4,092,100,491 samples, 0.64%)</title><rect x="3393.2" y="2481" width="26.8" height="19.0" fill="rgb(232,125,30)" rx="2" ry="2" />
+<text  x="3396.19" y="2493.5" >_..</text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (181,373,291 samples, 0.03%)</title><rect x="273.8" y="321" width="1.2" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="276.84" y="333.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (1,260,500,822 samples, 0.20%)</title><rect x="288.1" y="2561" width="8.2" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="291.10" y="2573.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (170,489,782 samples, 0.03%)</title><rect x="871.9" y="1101" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="874.90" y="1113.5" ></text>
+</g>
+<g >
+<title>execute_command (433,879,872 samples, 0.07%)</title><rect x="351.1" y="781" width="2.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="354.06" y="793.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (180,216,075 samples, 0.03%)</title><rect x="878.5" y="1821" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="881.48" y="1833.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (695,079,167 samples, 0.11%)</title><rect x="280.1" y="401" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.11" y="413.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (249,423,603 samples, 0.04%)</title><rect x="275.2" y="281" width="1.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="278.21" y="293.5" ></text>
+</g>
+<g >
+<title>[bash] (389,960,806 samples, 0.06%)</title><rect x="330.9" y="501" width="2.6" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="333.91" y="513.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (163,563,240 samples, 0.03%)</title><rect x="870.8" y="781" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="873.82" y="793.5" ></text>
+</g>
+<g >
+<title>execute_command (889,542,281 samples, 0.14%)</title><rect x="851.1" y="1021" width="5.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="854.09" y="1033.5" ></text>
+</g>
+<g >
+<title>[bash] (384,143,818 samples, 0.06%)</title><rect x="892.6" y="261" width="2.6" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="895.64" y="273.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (516,725,798 samples, 0.08%)</title><rect x="856.9" y="1781" width="3.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="859.92" y="1793.5" ></text>
+</g>
+<g >
+<title>syscall_return_via_sysret (159,655,580 samples, 0.03%)</title><rect x="1661.6" y="2481" width="1.0" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="1664.60" y="2493.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (5,291,623,730 samples, 0.83%)</title><rect x="359.3" y="761" width="34.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="362.26" y="773.5" >ex..</text>
+</g>
+<g >
+<title>redirection_expand (379,026,381 samples, 0.06%)</title><rect x="282.1" y="261" width="2.5" height="19.0" fill="rgb(218,63,15)" rx="2" ry="2" />
+<text  x="285.11" y="273.5" ></text>
+</g>
+<g >
+<title>inode_permission (157,756,189 samples, 0.02%)</title><rect x="1475.3" y="2241" width="1.0" height="19.0" fill="rgb(215,48,11)" rx="2" ry="2" />
+<text  x="1478.29" y="2253.5" ></text>
+</g>
+<g >
+<title>execute_command (793,433,486 samples, 0.12%)</title><rect x="310.1" y="601" width="5.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="313.13" y="613.5" ></text>
+</g>
+<g >
+<title>selinux_inode_permission (290,917,375 samples, 0.05%)</title><rect x="181.3" y="2221" width="1.9" height="19.0" fill="rgb(238,156,37)" rx="2" ry="2" />
+<text  x="184.27" y="2233.5" ></text>
+</g>
+<g >
+<title>execute_command (1,263,560,140 samples, 0.20%)</title><rect x="860.3" y="1541" width="8.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="863.30" y="1553.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (704,492,242 samples, 0.11%)</title><rect x="296.5" y="881" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.51" y="893.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (592,793,695 samples, 0.09%)</title><rect x="891.4" y="461" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.42" y="473.5" ></text>
+</g>
+<g >
+<title>execute_command (713,462,810 samples, 0.11%)</title><rect x="280.1" y="861" width="4.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="283.11" y="873.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,850,506,935 samples, 0.29%)</title><rect x="327.1" y="721" width="12.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="330.12" y="733.5" ></text>
+</g>
+<g >
+<title>execute_command (171,847,094 samples, 0.03%)</title><rect x="871.9" y="1401" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="874.89" y="1413.5" ></text>
+</g>
+<g >
+<title>execute_command (354,938,381 samples, 0.06%)</title><rect x="840.5" y="1021" width="2.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="843.48" y="1033.5" ></text>
+</g>
+<g >
+<title>dispose_command (277,064,418 samples, 0.04%)</title><rect x="840.5" y="221" width="1.8" height="19.0" fill="rgb(248,201,48)" rx="2" ry="2" />
+<text  x="843.48" y="233.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (513,954,307 samples, 0.08%)</title><rect x="856.9" y="1321" width="3.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="859.94" y="1333.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (890,006,400 samples, 0.14%)</title><rect x="851.1" y="1221" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.09" y="1233.5" ></text>
+</g>
+<g >
+<title>execute_command (5,853,599,547 samples, 0.92%)</title><rect x="356.1" y="981" width="38.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="359.09" y="993.5" >exe..</text>
+</g>
+<g >
+<title>syscall_return_via_sysret (211,377,746 samples, 0.03%)</title><rect x="2571.3" y="2401" width="1.4" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="2574.27" y="2413.5" ></text>
+</g>
+<g >
+<title>_IO_file_overflow@@GLIBC_2.2.5 (552,325,555 samples, 0.09%)</title><rect x="3080.4" y="2501" width="3.6" height="19.0" fill="rgb(239,157,37)" rx="2" ry="2" />
+<text  x="3083.39" y="2513.5" ></text>
+</g>
+<g >
+<title>execute_command (354,938,381 samples, 0.06%)</title><rect x="840.5" y="981" width="2.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="843.48" y="993.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (713,462,810 samples, 0.11%)</title><rect x="280.1" y="721" width="4.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.11" y="733.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (679,053,243 samples, 0.11%)</title><rect x="268.8" y="461" width="4.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="271.79" y="473.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (842,511,421 samples, 0.13%)</title><rect x="895.4" y="621" width="5.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.39" y="633.5" ></text>
+</g>
+<g >
+<title>dispose_words (718,104,872 samples, 0.11%)</title><rect x="528.9" y="1221" width="4.7" height="19.0" fill="rgb(235,141,33)" rx="2" ry="2" />
+<text  x="531.93" y="1233.5" ></text>
+</g>
+<g >
+<title>filemap_get_entry (449,436,507 samples, 0.07%)</title><rect x="4101.8" y="2301" width="2.9" height="19.0" fill="rgb(253,222,53)" rx="2" ry="2" />
+<text  x="4104.80" y="2313.5" ></text>
+</g>
+<g >
+<title>folio_remove_rmap_ptes (172,166,800 samples, 0.03%)</title><rect x="294.6" y="2341" width="1.2" height="19.0" fill="rgb(226,98,23)" rx="2" ry="2" />
+<text  x="297.64" y="2353.5" ></text>
+</g>
+<g >
+<title>execute_command (195,267,188 samples, 0.03%)</title><rect x="835.2" y="901" width="1.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="838.18" y="913.5" ></text>
+</g>
+<g >
+<title>execute_command (554,006,342 samples, 0.09%)</title><rect x="273.3" y="1781" width="3.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="276.29" y="1793.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (889,542,281 samples, 0.14%)</title><rect x="851.1" y="961" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.09" y="973.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (840,181,758 samples, 0.13%)</title><rect x="895.4" y="501" width="5.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.39" y="513.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (215,132,849 samples, 0.03%)</title><rect x="842.8" y="1281" width="1.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="845.81" y="1293.5" ></text>
+</g>
+<g >
+<title>do_redirections (185,467,659 samples, 0.03%)</title><rect x="835.2" y="541" width="1.2" height="19.0" fill="rgb(247,193,46)" rx="2" ry="2" />
+<text  x="838.23" y="553.5" ></text>
+</g>
+<g >
+<title>security_file_open (187,164,291 samples, 0.03%)</title><rect x="3035.9" y="2221" width="1.2" height="19.0" fill="rgb(215,47,11)" rx="2" ry="2" />
+<text  x="3038.86" y="2233.5" ></text>
+</g>
+<g >
+<title>_Fork (286,852,407 samples, 0.04%)</title><rect x="830.7" y="201" width="1.9" height="19.0" fill="rgb(252,220,52)" rx="2" ry="2" />
+<text  x="833.70" y="213.5" ></text>
+</g>
+<g >
+<title>entry_SYSRETQ_unsafe_stack (389,095,443 samples, 0.06%)</title><rect x="3366.3" y="2441" width="2.6" height="19.0" fill="rgb(213,37,8)" rx="2" ry="2" />
+<text  x="3369.33" y="2453.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (172,984,794 samples, 0.03%)</title><rect x="869.6" y="321" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="872.64" y="333.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (436,055,112 samples, 0.07%)</title><rect x="888.5" y="1901" width="2.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="891.55" y="1913.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (2,992,429,596 samples, 0.47%)</title><rect x="3346.6" y="2421" width="19.6" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="3349.63" y="2433.5" ></text>
+</g>
+<g >
+<title>memset_orig (153,308,375 samples, 0.02%)</title><rect x="2140.2" y="2261" width="1.0" height="19.0" fill="rgb(253,224,53)" rx="2" ry="2" />
+<text  x="2143.16" y="2273.5" ></text>
+</g>
+<g >
+<title>execute_command (323,026,366 samples, 0.05%)</title><rect x="868.7" y="1521" width="2.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="871.70" y="1533.5" ></text>
+</g>
+<g >
+<title>__GI___fstatat64 (3,947,881,949 samples, 0.62%)</title><rect x="4159.3" y="2501" width="25.9" height="19.0" fill="rgb(227,101,24)" rx="2" ry="2" />
+<text  x="4162.34" y="2513.5" >_..</text>
+</g>
+<g >
+<title>[bash] (194,164,989 samples, 0.03%)</title><rect x="334.5" y="541" width="1.3" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="337.51" y="553.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (159,710,185 samples, 0.03%)</title><rect x="875.9" y="1641" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="878.92" y="1653.5" ></text>
+</g>
+<g >
+<title>security_inode_permission (455,413,517 samples, 0.07%)</title><rect x="3318.6" y="2241" width="3.0" height="19.0" fill="rgb(215,47,11)" rx="2" ry="2" />
+<text  x="3321.57" y="2253.5" ></text>
+</g>
+<g >
+<title>do_redirections (517,034,501 samples, 0.08%)</title><rect x="273.5" y="501" width="3.4" height="19.0" fill="rgb(247,193,46)" rx="2" ry="2" />
+<text  x="276.52" y="513.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (685,976,378 samples, 0.11%)</title><rect x="268.8" y="821" width="4.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="271.79" y="833.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (891,895,571 samples, 0.14%)</title><rect x="851.1" y="1561" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.08" y="1573.5" ></text>
+</g>
+<g >
+<title>link_path_walk.part.0.constprop.0 (1,366,566,926 samples, 0.21%)</title><rect x="4125.2" y="2281" width="9.0" height="19.0" fill="rgb(254,229,54)" rx="2" ry="2" />
+<text  x="4128.23" y="2293.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (283,153,165 samples, 0.04%)</title><rect x="345.4" y="621" width="1.8" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="348.38" y="633.5" ></text>
+</g>
+<g >
+<title>[sha256sum] (3,625,704,777 samples, 0.57%)</title><rect x="2541.7" y="2481" width="23.7" height="19.0" fill="rgb(216,53,12)" rx="2" ry="2" />
+<text  x="2544.67" y="2493.5" >[..</text>
+</g>
+<g >
+<title>execute_command (192,670,319 samples, 0.03%)</title><rect x="837.6" y="1221" width="1.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="840.55" y="1233.5" ></text>
+</g>
+<g >
+<title>__d_lookup_rcu (174,971,148 samples, 0.03%)</title><rect x="3031.6" y="2241" width="1.1" height="19.0" fill="rgb(235,139,33)" rx="2" ry="2" />
+<text  x="3034.60" y="2253.5" ></text>
+</g>
+<g >
+<title>[bash] (390,542,663 samples, 0.06%)</title><rect x="316.5" y="561" width="2.6" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="319.53" y="573.5" ></text>
+</g>
+<g >
+<title>_IO_do_write@@GLIBC_2.2.5 (514,789,839 samples, 0.08%)</title><rect x="1565.0" y="2481" width="3.4" height="19.0" fill="rgb(238,155,37)" rx="2" ry="2" />
+<text  x="1568.02" y="2493.5" ></text>
+</g>
+<g >
+<title>read (4,833,091,209 samples, 0.76%)</title><rect x="2572.8" y="2461" width="31.7" height="19.0" fill="rgb(252,216,51)" rx="2" ry="2" />
+<text  x="2575.84" y="2473.5" >read</text>
+</g>
+<g >
+<title>execute_command (2,315,069,913 samples, 0.36%)</title><rect x="868.6" y="2441" width="15.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="871.57" y="2453.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (159,815,195 samples, 0.03%)</title><rect x="886.7" y="141" width="1.1" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="889.71" y="153.5" ></text>
+</g>
+<g >
+<title>[bash] (1,001,501,687 samples, 0.16%)</title><rect x="861.9" y="321" width="6.6" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="864.91" y="333.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (193,994,695 samples, 0.03%)</title><rect x="835.2" y="721" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="838.18" y="733.5" ></text>
+</g>
+<g >
+<title>__fstat64 (1,393,628,522 samples, 0.22%)</title><rect x="3939.0" y="2421" width="9.2" height="19.0" fill="rgb(224,88,21)" rx="2" ry="2" />
+<text  x="3942.05" y="2433.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (842,511,421 samples, 0.13%)</title><rect x="895.4" y="701" width="5.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.39" y="713.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (159,710,185 samples, 0.03%)</title><rect x="875.9" y="1881" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="878.92" y="1893.5" ></text>
+</g>
+<g >
+<title>[bash] (187,214,818 samples, 0.03%)</title><rect x="890.0" y="281" width="1.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="892.97" y="293.5" ></text>
+</g>
+<g >
+<title>[bash] (188,767,708 samples, 0.03%)</title><rect x="385.0" y="301" width="1.3" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="388.03" y="313.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (575,800,354 samples, 0.09%)</title><rect x="884.6" y="1361" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="887.64" y="1373.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (891,895,571 samples, 0.14%)</title><rect x="851.1" y="2001" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.08" y="2013.5" ></text>
+</g>
+<g >
+<title>__d_lookup_rcu (169,543,110 samples, 0.03%)</title><rect x="184.7" y="2241" width="1.1" height="19.0" fill="rgb(235,139,33)" rx="2" ry="2" />
+<text  x="187.67" y="2253.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (578,068,287 samples, 0.09%)</title><rect x="884.6" y="1961" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="887.62" y="1973.5" ></text>
+</g>
+<g >
+<title>[sha256sum] (11,421,929,068 samples, 1.79%)</title><rect x="2540.9" y="2501" width="74.8" height="19.0" fill="rgb(216,53,12)" rx="2" ry="2" />
+<text  x="2543.90" y="2513.5" >[sha256s..</text>
+</g>
+<g >
+<title>execute_command_internal (190,829,147 samples, 0.03%)</title><rect x="837.6" y="681" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="840.55" y="693.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,263,560,140 samples, 0.20%)</title><rect x="860.3" y="1521" width="8.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.30" y="1533.5" ></text>
+</g>
+<g >
+<title>_dl_start_user (411,156,925 samples, 0.06%)</title><rect x="4028.7" y="2581" width="2.7" height="19.0" fill="rgb(236,145,34)" rx="2" ry="2" />
+<text  x="4031.68" y="2593.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (153,474,164 samples, 0.02%)</title><rect x="278.7" y="281" width="1.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="281.72" y="293.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (215,132,849 samples, 0.03%)</title><rect x="842.8" y="1401" width="1.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="845.81" y="1413.5" ></text>
+</g>
+<g >
+<title>do_dentry_open (393,784,226 samples, 0.06%)</title><rect x="2557.2" y="2241" width="2.6" height="19.0" fill="rgb(249,205,49)" rx="2" ry="2" />
+<text  x="2560.21" y="2253.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (217,946,827 samples, 0.03%)</title><rect x="334.5" y="581" width="1.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="337.47" y="593.5" ></text>
+</g>
+<g >
+<title>execute_command (713,521,499 samples, 0.11%)</title><rect x="296.5" y="2141" width="4.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="299.45" y="2153.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (468,180,180 samples, 0.07%)</title><rect x="892.1" y="321" width="3.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="895.13" y="333.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (175,915,574 samples, 0.03%)</title><rect x="3379.7" y="2461" width="1.1" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="3382.65" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command (436,055,112 samples, 0.07%)</title><rect x="888.5" y="1921" width="2.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="891.55" y="1933.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (154,472,811 samples, 0.02%)</title><rect x="807.0" y="2241" width="1.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="809.96" y="2253.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (219,529,411 samples, 0.03%)</title><rect x="385.0" y="341" width="1.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="387.96" y="353.5" ></text>
+</g>
+<g >
+<title>execute_command (849,636,646 samples, 0.13%)</title><rect x="301.2" y="401" width="5.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="304.16" y="413.5" ></text>
+</g>
+<g >
+<title>execute_command (717,313,739 samples, 0.11%)</title><rect x="280.1" y="1501" width="4.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="283.09" y="1513.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (158,744,410 samples, 0.02%)</title><rect x="875.9" y="1301" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="878.93" y="1313.5" ></text>
+</g>
+<g >
+<title>_IO_file_fopen@@GLIBC_2.2.5 (3,519,488,647 samples, 0.55%)</title><rect x="2542.0" y="2441" width="23.1" height="19.0" fill="rgb(237,148,35)" rx="2" ry="2" />
+<text  x="2545.02" y="2453.5" >_..</text>
+</g>
+<g >
+<title>do_syscall_64 (4,259,106,998 samples, 0.67%)</title><rect x="1470.0" y="2361" width="27.9" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="1472.97" y="2373.5" >d..</text>
+</g>
+<g >
+<title>execute_command (891,895,571 samples, 0.14%)</title><rect x="851.1" y="2061" width="5.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="854.08" y="2073.5" ></text>
+</g>
+<g >
+<title>entry_SYSRETQ_unsafe_stack (267,802,273 samples, 0.04%)</title><rect x="4014.9" y="2481" width="1.7" height="19.0" fill="rgb(213,37,8)" rx="2" ry="2" />
+<text  x="4017.87" y="2493.5" ></text>
+</g>
+<g >
+<title>execute_command (2,383,635,423 samples, 0.37%)</title><rect x="868.6" y="2481" width="15.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="871.57" y="2493.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (76,160,644,766 samples, 11.93%)</title><rect x="307.9" y="1921" width="498.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="310.94" y="1933.5" >execute_command_internal</text>
+</g>
+<g >
+<title>execute_command (1,263,560,140 samples, 0.20%)</title><rect x="860.3" y="2181" width="8.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="863.30" y="2193.5" ></text>
+</g>
+<g >
+<title>execute_command (688,777,208 samples, 0.11%)</title><rect x="268.8" y="1641" width="4.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="271.77" y="1653.5" ></text>
+</g>
+<g >
+<title>execute_command (849,509,116 samples, 0.13%)</title><rect x="895.3" y="2281" width="5.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="898.35" y="2293.5" ></text>
+</g>
+<g >
+<title>__x64_sys_openat (2,328,568,959 samples, 0.36%)</title><rect x="2126.6" y="2341" width="15.2" height="19.0" fill="rgb(208,15,3)" rx="2" ry="2" />
+<text  x="2129.58" y="2353.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (578,068,287 samples, 0.09%)</title><rect x="884.6" y="2361" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="887.62" y="2373.5" ></text>
+</g>
+<g >
+<title>execute_command (436,055,112 samples, 0.07%)</title><rect x="888.5" y="2281" width="2.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="891.55" y="2293.5" ></text>
+</g>
+<g >
+<title>[bash] (2,130,740,273 samples, 0.33%)</title><rect x="415.4" y="1101" width="13.9" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="418.35" y="1113.5" ></text>
+</g>
+<g >
+<title>execute_command (685,976,378 samples, 0.11%)</title><rect x="268.8" y="1001" width="4.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="271.79" y="1013.5" ></text>
+</g>
+<g >
+<title>_IO_do_write@@GLIBC_2.2.5 (527,167,175 samples, 0.08%)</title><rect x="1647.7" y="2481" width="3.4" height="19.0" fill="rgb(238,155,37)" rx="2" ry="2" />
+<text  x="1650.69" y="2493.5" ></text>
+</g>
+<g >
+<title>[bash] (254,634,117 samples, 0.04%)</title><rect x="325.3" y="581" width="1.6" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="328.28" y="593.5" ></text>
+</g>
+<g >
+<title>_int_malloc (311,296,750 samples, 0.05%)</title><rect x="632.8" y="1241" width="2.1" height="19.0" fill="rgb(215,47,11)" rx="2" ry="2" />
+<text  x="635.84" y="1253.5" ></text>
+</g>
+<g >
+<title>[bash] (649,210,830 samples, 0.10%)</title><rect x="852.5" y="281" width="4.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="855.47" y="293.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (513,428,353 samples, 0.08%)</title><rect x="856.9" y="821" width="3.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="859.94" y="833.5" ></text>
+</g>
+<g >
+<title>[bash] (185,433,810 samples, 0.03%)</title><rect x="835.2" y="461" width="1.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="838.23" y="473.5" ></text>
+</g>
+<g >
+<title>execute_command (866,614,713 samples, 0.14%)</title><rect x="301.1" y="1481" width="5.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="304.12" y="1493.5" ></text>
+</g>
+<g >
+<title>execute_command (158,744,410 samples, 0.02%)</title><rect x="875.9" y="1361" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="878.93" y="1373.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (713,987,302 samples, 0.11%)</title><rect x="280.1" y="1341" width="4.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.11" y="1353.5" ></text>
+</g>
+<g >
+<title>copy_page_to_iter (1,597,125,422 samples, 0.25%)</title><rect x="1511.9" y="2321" width="10.4" height="19.0" fill="rgb(216,52,12)" rx="2" ry="2" />
+<text  x="1514.89" y="2333.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (207,707,782 samples, 0.03%)</title><rect x="1585.8" y="2561" width="1.4" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="1588.83" y="2573.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (786,292,451 samples, 0.12%)</title><rect x="310.2" y="581" width="5.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="313.17" y="593.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (849,509,116 samples, 0.13%)</title><rect x="895.3" y="1781" width="5.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.35" y="1793.5" ></text>
+</g>
+<g >
+<title>_IO_file_fopen@@GLIBC_2.2.5 (3,651,570,688 samples, 0.57%)</title><rect x="3312.4" y="2441" width="23.9" height="19.0" fill="rgb(237,148,35)" rx="2" ry="2" />
+<text  x="3315.36" y="2453.5" >_..</text>
+</g>
+<g >
+<title>__GI___wait4 (325,910,229 samples, 0.05%)</title><rect x="785.8" y="1361" width="2.2" height="19.0" fill="rgb(205,4,1)" rx="2" ry="2" />
+<text  x="788.82" y="1373.5" ></text>
+</g>
+<g >
+<title>execute_command (807,424,876 samples, 0.13%)</title><rect x="310.1" y="641" width="5.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="313.05" y="653.5" ></text>
+</g>
+<g >
+<title>execute_command (866,614,713 samples, 0.14%)</title><rect x="301.1" y="1801" width="5.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="304.12" y="1813.5" ></text>
+</g>
+<g >
+<title>execute_command (76,226,712,624 samples, 11.94%)</title><rect x="307.9" y="2261" width="499.0" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="310.93" y="2273.5" >execute_command</text>
+</g>
+<g >
+<title>execute_command (592,850,596 samples, 0.09%)</title><rect x="891.4" y="521" width="3.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="894.42" y="533.5" ></text>
+</g>
+<g >
+<title>[bash] (305,383,261 samples, 0.05%)</title><rect x="868.8" y="441" width="2.0" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="871.80" y="453.5" ></text>
+</g>
+<g >
+<title>execute_command (432,726,851 samples, 0.07%)</title><rect x="888.6" y="721" width="2.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="891.57" y="733.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (192,670,319 samples, 0.03%)</title><rect x="837.6" y="1041" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="840.55" y="1053.5" ></text>
+</g>
+<g >
+<title>execute_command (684,696,176 samples, 0.11%)</title><rect x="296.5" y="341" width="4.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="299.51" y="353.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (195,916,485 samples, 0.03%)</title><rect x="835.2" y="1621" width="1.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="838.17" y="1633.5" ></text>
+</g>
+<g >
+<title>execute_command (170,489,782 samples, 0.03%)</title><rect x="871.9" y="1201" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="874.90" y="1213.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (550,598,300 samples, 0.09%)</title><rect x="273.3" y="921" width="3.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="276.32" y="933.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (578,068,287 samples, 0.09%)</title><rect x="884.6" y="1641" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="887.62" y="1653.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,263,560,140 samples, 0.20%)</title><rect x="860.3" y="1761" width="8.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.30" y="1773.5" ></text>
+</g>
+<g >
+<title>[bash] (595,672,870 samples, 0.09%)</title><rect x="891.4" y="981" width="3.9" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="894.42" y="993.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,147,316,451 samples, 0.18%)</title><rect x="827.6" y="1101" width="7.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.59" y="1113.5" ></text>
+</g>
+<g >
+<title>[bash] (1,261,220,789 samples, 0.20%)</title><rect x="860.3" y="1041" width="8.3" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="863.32" y="1053.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (516,725,798 samples, 0.08%)</title><rect x="856.9" y="2021" width="3.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="859.92" y="2033.5" ></text>
+</g>
+<g >
+<title>[bash] (483,985,097 samples, 0.08%)</title><rect x="276.9" y="2501" width="3.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="279.92" y="2513.5" ></text>
+</g>
+<g >
+<title>__do_sys_newfstat (204,666,315 samples, 0.03%)</title><rect x="1504.0" y="2341" width="1.3" height="19.0" fill="rgb(225,96,23)" rx="2" ry="2" />
+<text  x="1506.99" y="2353.5" ></text>
+</g>
+<g >
+<title>__d_lookup_rcu (284,354,494 samples, 0.04%)</title><rect x="1481.6" y="2201" width="1.8" height="19.0" fill="rgb(235,139,33)" rx="2" ry="2" />
+<text  x="1484.55" y="2213.5" ></text>
+</g>
+<g >
+<title>execute_command (596,118,643 samples, 0.09%)</title><rect x="891.4" y="1041" width="3.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="894.42" y="1053.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (76,556,548,766 samples, 11.99%)</title><rect x="306.9" y="2421" width="501.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="309.94" y="2433.5" >execute_command_internal</text>
+</g>
+<g >
+<title>_itoa_word (153,686,873 samples, 0.02%)</title><rect x="3419.0" y="2461" width="1.0" height="19.0" fill="rgb(246,191,45)" rx="2" ry="2" />
+<text  x="3421.96" y="2473.5" ></text>
+</g>
+<g >
+<title>[bash] (843,061,254 samples, 0.13%)</title><rect x="895.4" y="1181" width="5.5" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="898.39" y="1193.5" ></text>
+</g>
+<g >
+<title>entry_SYSRETQ_unsafe_stack (161,310,070 samples, 0.03%)</title><rect x="2618.4" y="2421" width="1.1" height="19.0" fill="rgb(213,37,8)" rx="2" ry="2" />
+<text  x="2621.40" y="2433.5" ></text>
+</g>
+<g >
+<title>execute_command (866,614,713 samples, 0.14%)</title><rect x="301.1" y="1681" width="5.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="304.12" y="1693.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (321,115,914 samples, 0.05%)</title><rect x="2046.3" y="2381" width="2.1" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="2049.29" y="2393.5" ></text>
+</g>
+<g >
+<title>execute_command (168,230,392 samples, 0.03%)</title><rect x="280.1" y="221" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="283.11" y="233.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (481,813,209 samples, 0.08%)</title><rect x="276.9" y="1441" width="3.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="279.93" y="1453.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (3,210,243,438 samples, 0.50%)</title><rect x="362.1" y="281" width="21.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="365.07" y="293.5" ></text>
+</g>
+<g >
+<title>__printf_buffer (974,144,676 samples, 0.15%)</title><rect x="1537.2" y="2441" width="6.3" height="19.0" fill="rgb(219,68,16)" rx="2" ry="2" />
+<text  x="1540.15" y="2453.5" ></text>
+</g>
+<g >
+<title>__GI___libc_open (180,003,575 samples, 0.03%)</title><rect x="331.4" y="481" width="1.2" height="19.0" fill="rgb(249,202,48)" rx="2" ry="2" />
+<text  x="334.42" y="493.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (5,854,988,198 samples, 0.92%)</title><rect x="356.1" y="1001" width="38.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="359.09" y="1013.5" >exe..</text>
+</g>
+<g >
+<title>execute_command_internal (426,616,470 samples, 0.07%)</title><rect x="888.6" y="581" width="2.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="891.57" y="593.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (372,371,838 samples, 0.06%)</title><rect x="2178.7" y="2441" width="2.4" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="2181.65" y="2453.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (866,614,713 samples, 0.14%)</title><rect x="301.1" y="1621" width="5.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.12" y="1633.5" ></text>
+</g>
+<g >
+<title>rw_verify_area (180,097,269 samples, 0.03%)</title><rect x="4074.9" y="2341" width="1.2" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="4077.89" y="2353.5" ></text>
+</g>
+<g >
+<title>[sha1sum] (14,556,058,487 samples, 2.28%)</title><rect x="2019.5" y="2521" width="95.3" height="19.0" fill="rgb(214,42,10)" rx="2" ry="2" />
+<text  x="2022.51" y="2533.5" >[sha1sum]</text>
+</g>
+<g >
+<title>execute_command (180,216,075 samples, 0.03%)</title><rect x="878.5" y="1921" width="1.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="881.48" y="1933.5" ></text>
+</g>
+<g >
+<title>[bash] (551,359,579 samples, 0.09%)</title><rect x="273.3" y="1361" width="3.6" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="276.31" y="1373.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (195,916,485 samples, 0.03%)</title><rect x="835.2" y="1561" width="1.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="838.17" y="1573.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (192,670,319 samples, 0.03%)</title><rect x="837.6" y="1341" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="840.55" y="1353.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (602,106,038 samples, 0.09%)</title><rect x="896.8" y="361" width="4.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="899.84" y="373.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (163,415,529 samples, 0.03%)</title><rect x="870.8" y="701" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="873.82" y="713.5" ></text>
+</g>
+<g >
+<title>[unknown] (197,304,191 samples, 0.03%)</title><rect x="2115.3" y="2581" width="1.3" height="19.0" fill="rgb(210,24,5)" rx="2" ry="2" />
+<text  x="2118.28" y="2593.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (322,256,264 samples, 0.05%)</title><rect x="868.7" y="1021" width="2.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="871.70" y="1033.5" ></text>
+</g>
+<g >
+<title>[bash] (165,145,742 samples, 0.03%)</title><rect x="871.9" y="441" width="1.1" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="874.92" y="453.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (842,511,421 samples, 0.13%)</title><rect x="895.4" y="1041" width="5.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.39" y="1053.5" ></text>
+</g>
+<g >
+<title>[libcrypto.so.3.2.2] (27,332,326,970 samples, 4.28%)</title><rect x="1663.0" y="2561" width="178.9" height="19.0" fill="rgb(244,181,43)" rx="2" ry="2" />
+<text  x="1666.02" y="2573.5" >[libcrypto.so.3.2.2]</text>
+</g>
+<g >
+<title>execute_command (688,777,208 samples, 0.11%)</title><rect x="268.8" y="2241" width="4.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="271.77" y="2253.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (2,367,484,030 samples, 0.37%)</title><rect x="2126.5" y="2361" width="15.5" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="2129.46" y="2373.5" ></text>
+</g>
+<g >
+<title>__vfprintf_internal (1,863,098,821 samples, 0.29%)</title><rect x="1536.4" y="2461" width="12.2" height="19.0" fill="rgb(232,125,30)" rx="2" ry="2" />
+<text  x="1539.36" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (688,777,208 samples, 0.11%)</title><rect x="268.8" y="1861" width="4.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="271.77" y="1873.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,150,422,968 samples, 0.18%)</title><rect x="827.6" y="2221" width="7.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.57" y="2233.5" ></text>
+</g>
+<g >
+<title>_dl_map_object_deps (178,379,694 samples, 0.03%)</title><rect x="3682.0" y="2501" width="1.2" height="19.0" fill="rgb(219,68,16)" rx="2" ry="2" />
+<text  x="3684.99" y="2513.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,146,830,397 samples, 0.18%)</title><rect x="827.6" y="1021" width="7.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.59" y="1033.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,261,568,072 samples, 0.20%)</title><rect x="860.3" y="1121" width="8.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.31" y="1133.5" ></text>
+</g>
+<g >
+<title>execute_command (190,829,147 samples, 0.03%)</title><rect x="837.6" y="861" width="1.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="840.55" y="873.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (180,216,075 samples, 0.03%)</title><rect x="878.5" y="1761" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="881.48" y="1773.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (889,542,281 samples, 0.14%)</title><rect x="851.1" y="841" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.09" y="853.5" ></text>
+</g>
+<g >
+<title>read_builtin (173,585,290 samples, 0.03%)</title><rect x="827.8" y="101" width="1.2" height="19.0" fill="rgb(235,139,33)" rx="2" ry="2" />
+<text  x="830.83" y="113.5" ></text>
+</g>
+<g >
+<title>[bash] (464,305,358 samples, 0.07%)</title><rect x="791.7" y="1341" width="3.1" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="794.74" y="1353.5" ></text>
+</g>
+<g >
+<title>[unknown] (247,600,944 samples, 0.04%)</title><rect x="1576.0" y="2581" width="1.6" height="19.0" fill="rgb(210,24,5)" rx="2" ry="2" />
+<text  x="1579.02" y="2593.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,259,613,163 samples, 0.20%)</title><rect x="860.3" y="521" width="8.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.32" y="533.5" ></text>
+</g>
+<g >
+<title>asm_exc_page_fault (666,257,162 samples, 0.10%)</title><rect x="723.9" y="1261" width="4.4" height="19.0" fill="rgb(231,123,29)" rx="2" ry="2" />
+<text  x="726.95" y="1273.5" ></text>
+</g>
+<g >
+<title>execute_command (166,473,899 samples, 0.03%)</title><rect x="851.1" y="421" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="854.09" y="433.5" ></text>
+</g>
+<g >
+<title>_copy_to_iter (2,181,125,551 samples, 0.34%)</title><rect x="2057.2" y="2321" width="14.3" height="19.0" fill="rgb(234,134,32)" rx="2" ry="2" />
+<text  x="2060.24" y="2333.5" ></text>
+</g>
+<g >
+<title>entry_SYSRETQ_unsafe_stack (170,986,789 samples, 0.03%)</title><rect x="2048.5" y="2401" width="1.1" height="19.0" fill="rgb(213,37,8)" rx="2" ry="2" />
+<text  x="2051.51" y="2413.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (525,225,707 samples, 0.08%)</title><rect x="4004.5" y="2441" width="3.5" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="4007.52" y="2453.5" ></text>
+</g>
+<g >
+<title>__GI___libc_open (2,667,016,357 samples, 0.42%)</title><rect x="176.8" y="2401" width="17.4" height="19.0" fill="rgb(249,202,48)" rx="2" ry="2" />
+<text  x="179.76" y="2413.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (190,829,147 samples, 0.03%)</title><rect x="837.6" y="881" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="840.55" y="893.5" ></text>
+</g>
+<g >
+<title>syscall_return_via_sysret (768,838,725 samples, 0.12%)</title><rect x="3991.2" y="2441" width="5.1" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="3994.25" y="2453.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (513,428,353 samples, 0.08%)</title><rect x="856.9" y="1141" width="3.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="859.94" y="1153.5" ></text>
+</g>
+<g >
+<title>__printf_buffer_to_file_done (184,838,823 samples, 0.03%)</title><rect x="1656.4" y="2461" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="1659.41" y="2473.5" ></text>
+</g>
+<g >
+<title>rep_movs_alternative (2,090,139,867 samples, 0.33%)</title><rect x="2057.8" y="2301" width="13.7" height="19.0" fill="rgb(211,31,7)" rx="2" ry="2" />
+<text  x="2060.84" y="2313.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (481,191,724 samples, 0.08%)</title><rect x="276.9" y="801" width="3.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="279.94" y="813.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (688,777,208 samples, 0.11%)</title><rect x="268.8" y="1581" width="4.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="271.77" y="1593.5" ></text>
+</g>
+<g >
+<title>execute_command (1,654,732,852 samples, 0.26%)</title><rect x="316.3" y="661" width="10.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="319.26" y="673.5" ></text>
+</g>
+<g >
+<title>execute_command (596,118,643 samples, 0.09%)</title><rect x="891.4" y="1081" width="3.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="894.42" y="1093.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (890,006,400 samples, 0.14%)</title><rect x="851.1" y="1121" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.09" y="1133.5" ></text>
+</g>
+<g >
+<title>[bash] (199,504,634 samples, 0.03%)</title><rect x="340.7" y="541" width="1.3" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="343.73" y="553.5" ></text>
+</g>
+<g >
+<title>security_inode_getattr (228,623,195 samples, 0.04%)</title><rect x="4178.6" y="2361" width="1.5" height="19.0" fill="rgb(223,82,19)" rx="2" ry="2" />
+<text  x="4181.65" y="2373.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (685,976,378 samples, 0.11%)</title><rect x="268.8" y="861" width="4.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="271.79" y="873.5" ></text>
+</g>
+<g >
+<title>[bash] (989,231,463 samples, 0.15%)</title><rect x="862.0" y="281" width="6.5" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="864.98" y="293.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,150,422,968 samples, 0.18%)</title><rect x="827.6" y="1741" width="7.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.57" y="1753.5" ></text>
+</g>
+<g >
+<title>__fstat64 (1,322,137,362 samples, 0.21%)</title><rect x="4057.3" y="2401" width="8.7" height="19.0" fill="rgb(224,88,21)" rx="2" ry="2" />
+<text  x="4060.33" y="2413.5" ></text>
+</g>
+<g >
+<title>dispose_command (278,788,607 samples, 0.04%)</title><rect x="840.5" y="361" width="1.8" height="19.0" fill="rgb(248,201,48)" rx="2" ry="2" />
+<text  x="843.48" y="373.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (3,547,991,777 samples, 0.56%)</title><rect x="361.7" y="321" width="23.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="364.70" y="333.5" >e..</text>
+</g>
+<g >
+<title>__printf_buffer_to_file_done (305,871,632 samples, 0.05%)</title><rect x="2106.1" y="2461" width="2.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="2109.13" y="2473.5" ></text>
+</g>
+<g >
+<title>redirection_expand (354,911,948 samples, 0.06%)</title><rect x="840.5" y="741" width="2.3" height="19.0" fill="rgb(218,63,15)" rx="2" ry="2" />
+<text  x="843.48" y="753.5" ></text>
+</g>
+<g >
+<title>redirection_expand (671,069,878 samples, 0.11%)</title><rect x="852.5" y="341" width="4.4" height="19.0" fill="rgb(218,63,15)" rx="2" ry="2" />
+<text  x="855.47" y="353.5" ></text>
+</g>
+<g >
+<title>[bash] (356,134,455 samples, 0.06%)</title><rect x="840.5" y="1661" width="2.3" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="843.47" y="1673.5" ></text>
+</g>
+<g >
+<title>execute_command (512,251,839 samples, 0.08%)</title><rect x="856.9" y="681" width="3.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="859.94" y="693.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (158,744,410 samples, 0.02%)</title><rect x="875.9" y="1181" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="878.93" y="1193.5" ></text>
+</g>
+<g >
+<title>walk_component (247,246,379 samples, 0.04%)</title><rect x="3321.9" y="2241" width="1.6" height="19.0" fill="rgb(247,197,47)" rx="2" ry="2" />
+<text  x="3324.93" y="2253.5" ></text>
+</g>
+<g >
+<title>printf_builtin (179,349,378 samples, 0.03%)</title><rect x="343.3" y="661" width="1.1" height="19.0" fill="rgb(239,159,38)" rx="2" ry="2" />
+<text  x="346.25" y="673.5" ></text>
+</g>
+<g >
+<title>execute_command (595,672,870 samples, 0.09%)</title><rect x="891.4" y="601" width="3.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="894.42" y="613.5" ></text>
+</g>
+<g >
+<title>[bash] (343,498,573 samples, 0.05%)</title><rect x="889.1" y="421" width="2.3" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="892.10" y="433.5" ></text>
+</g>
+<g >
+<title>execute_command (1,833,940,690 samples, 0.29%)</title><rect x="868.6" y="2081" width="12.0" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="871.57" y="2093.5" ></text>
+</g>
+<g >
+<title>execute_command (889,542,281 samples, 0.14%)</title><rect x="851.1" y="1061" width="5.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="854.09" y="1073.5" ></text>
+</g>
+<g >
+<title>execute_command (7,230,386,069 samples, 1.13%)</title><rect x="308.5" y="1121" width="47.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="311.53" y="1133.5" >exec..</text>
+</g>
+<g >
+<title>main (713,521,499 samples, 0.11%)</title><rect x="296.5" y="2561" width="4.6" height="19.0" fill="rgb(243,179,42)" rx="2" ry="2" />
+<text  x="299.45" y="2573.5" ></text>
+</g>
+<g >
+<title>execute_command (4,238,514,019 samples, 0.66%)</title><rect x="360.4" y="461" width="27.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="363.41" y="473.5" >e..</text>
+</g>
+<g >
+<title>execute_command (849,509,116 samples, 0.13%)</title><rect x="895.3" y="2041" width="5.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="898.35" y="2053.5" ></text>
+</g>
+<g >
+<title>read_builtin (246,073,393 samples, 0.04%)</title><rect x="317.4" y="541" width="1.6" height="19.0" fill="rgb(235,139,33)" rx="2" ry="2" />
+<text  x="320.42" y="553.5" ></text>
+</g>
+<g >
+<title>__fstat64 (896,480,334 samples, 0.14%)</title><rect x="3338.2" y="2421" width="5.8" height="19.0" fill="rgb(224,88,21)" rx="2" ry="2" />
+<text  x="3341.18" y="2433.5" ></text>
+</g>
+<g >
+<title>_IO_file_open (2,575,222,280 samples, 0.40%)</title><rect x="1591.3" y="2421" width="16.9" height="19.0" fill="rgb(249,205,49)" rx="2" ry="2" />
+<text  x="1594.33" y="2433.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (6,263,498,205 samples, 0.98%)</title><rect x="309.2" y="821" width="41.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="312.19" y="833.5" >exe..</text>
+</g>
+<g >
+<title>execute_command_internal (483,985,097 samples, 0.08%)</title><rect x="276.9" y="2521" width="3.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="279.92" y="2533.5" ></text>
+</g>
+<g >
+<title>execute_command (1,150,422,968 samples, 0.18%)</title><rect x="827.6" y="1841" width="7.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="830.57" y="1853.5" ></text>
+</g>
+<g >
+<title>[bash] (158,604,378 samples, 0.02%)</title><rect x="855.3" y="201" width="1.1" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="858.33" y="213.5" ></text>
+</g>
+<g >
+<title>selinux_inode_permission (300,719,615 samples, 0.05%)</title><rect x="2130.3" y="2221" width="2.0" height="19.0" fill="rgb(238,156,37)" rx="2" ry="2" />
+<text  x="2133.34" y="2233.5" ></text>
+</g>
+<g >
+<title>_dl_relocate_object (584,716,072 samples, 0.09%)</title><rect x="1581.5" y="2501" width="3.8" height="19.0" fill="rgb(231,120,28)" rx="2" ry="2" />
+<text  x="1584.46" y="2513.5" ></text>
+</g>
+<g >
+<title>[bash] (179,777,548 samples, 0.03%)</title><rect x="878.5" y="761" width="1.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="881.48" y="773.5" ></text>
+</g>
+<g >
+<title>do_filp_open (1,860,785,931 samples, 0.29%)</title><rect x="178.0" y="2301" width="12.2" height="19.0" fill="rgb(217,58,13)" rx="2" ry="2" />
+<text  x="181.00" y="2313.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,150,422,968 samples, 0.18%)</title><rect x="827.6" y="2261" width="7.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.57" y="2273.5" ></text>
+</g>
+<g >
+<title>execute_command (356,134,455 samples, 0.06%)</title><rect x="840.5" y="1541" width="2.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="843.47" y="1553.5" ></text>
+</g>
+<g >
+<title>execute_command (436,055,112 samples, 0.07%)</title><rect x="888.5" y="2321" width="2.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="891.55" y="2333.5" ></text>
+</g>
+<g >
+<title>execute_command (159,710,185 samples, 0.03%)</title><rect x="875.9" y="1601" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="878.92" y="1613.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (269,171,593 samples, 0.04%)</title><rect x="319.9" y="501" width="1.8" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="322.94" y="513.5" ></text>
+</g>
+<g >
+<title>dl_main (664,985,433 samples, 0.10%)</title><rect x="2117.5" y="2521" width="4.4" height="19.0" fill="rgb(236,145,34)" rx="2" ry="2" />
+<text  x="2120.52" y="2533.5" ></text>
+</g>
+<g >
+<title>entry_SYSRETQ_unsafe_stack (290,042,971 samples, 0.05%)</title><rect x="1461.1" y="2401" width="1.9" height="19.0" fill="rgb(213,37,8)" rx="2" ry="2" />
+<text  x="1464.07" y="2413.5" ></text>
+</g>
+<g >
+<title>execute_command (164,209,678 samples, 0.03%)</title><rect x="836.5" y="861" width="1.0" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="839.46" y="873.5" ></text>
+</g>
+<g >
+<title>[bash] (777,639,093 samples, 0.12%)</title><rect x="829.8" y="261" width="5.1" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="832.82" y="273.5" ></text>
+</g>
+<g >
+<title>_dl_relocate_object (400,642,988 samples, 0.06%)</title><rect x="3683.2" y="2501" width="2.6" height="19.0" fill="rgb(231,120,28)" rx="2" ry="2" />
+<text  x="3686.20" y="2513.5" ></text>
+</g>
+<g >
+<title>[bash] (219,358,838 samples, 0.03%)</title><rect x="340.7" y="581" width="1.4" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="343.67" y="593.5" ></text>
+</g>
+<g >
+<title>[bash] (264,647,119 samples, 0.04%)</title><rect x="866.2" y="181" width="1.7" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="869.20" y="193.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (5,906,351,662 samples, 0.92%)</title><rect x="356.1" y="1241" width="38.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="359.06" y="1253.5" >exe..</text>
+</g>
+<g >
+<title>execute_command_internal (598,514,664 samples, 0.09%)</title><rect x="891.4" y="1741" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.40" y="1753.5" ></text>
+</g>
+<g >
+<title>[bash] (278,829,311 samples, 0.04%)</title><rect x="840.5" y="581" width="1.8" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="843.48" y="593.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (354,938,381 samples, 0.06%)</title><rect x="840.5" y="841" width="2.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="843.48" y="853.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,146,830,397 samples, 0.18%)</title><rect x="827.6" y="981" width="7.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.59" y="993.5" ></text>
+</g>
+<g >
+<title>[bash] (550,598,300 samples, 0.09%)</title><rect x="273.3" y="1201" width="3.6" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="276.32" y="1213.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (843,061,254 samples, 0.13%)</title><rect x="895.4" y="1161" width="5.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.39" y="1173.5" ></text>
+</g>
+<g >
+<title>execute_command (190,829,147 samples, 0.03%)</title><rect x="837.6" y="901" width="1.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="840.55" y="913.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (501,349,629 samples, 0.08%)</title><rect x="4152.1" y="2421" width="3.2" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="4155.05" y="2433.5" ></text>
+</g>
+<g >
+<title>[bash] (215,132,849 samples, 0.03%)</title><rect x="842.8" y="741" width="1.4" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="845.81" y="753.5" ></text>
+</g>
+<g >
+<title>vfs_read (2,449,537,006 samples, 0.38%)</title><rect x="1617.3" y="2381" width="16.1" height="19.0" fill="rgb(230,118,28)" rx="2" ry="2" />
+<text  x="1620.33" y="2393.5" ></text>
+</g>
+<g >
+<title>substring (461,786,396 samples, 0.07%)</title><rect x="631.9" y="1281" width="3.0" height="19.0" fill="rgb(248,201,48)" rx="2" ry="2" />
+<text  x="634.89" y="1293.5" ></text>
+</g>
+<g >
+<title>__fstat64 (721,286,477 samples, 0.11%)</title><rect x="1609.8" y="2421" width="4.8" height="19.0" fill="rgb(224,88,21)" rx="2" ry="2" />
+<text  x="1612.85" y="2433.5" ></text>
+</g>
+<g >
+<title>[bash] (601,677,897 samples, 0.09%)</title><rect x="896.8" y="341" width="4.0" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="899.84" y="353.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (164,209,678 samples, 0.03%)</title><rect x="836.5" y="841" width="1.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="839.46" y="853.5" ></text>
+</g>
+<g >
+<title>expand_arith_string (232,514,474 samples, 0.04%)</title><rect x="340.7" y="601" width="1.5" height="19.0" fill="rgb(206,6,1)" rx="2" ry="2" />
+<text  x="343.66" y="613.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (578,068,287 samples, 0.09%)</title><rect x="884.6" y="2201" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="887.62" y="2213.5" ></text>
+</g>
+<g >
+<title>[bash] (156,895,695 samples, 0.02%)</title><rect x="870.9" y="541" width="1.0" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="873.86" y="553.5" ></text>
+</g>
+<g >
+<title>parse_and_execute (156,314,180 samples, 0.02%)</title><rect x="836.5" y="461" width="1.0" height="19.0" fill="rgb(243,178,42)" rx="2" ry="2" />
+<text  x="839.51" y="473.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (2,286,100,543 samples, 0.36%)</title><rect x="835.1" y="2401" width="15.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="838.10" y="2413.5" ></text>
+</g>
+<g >
+<title>[bash] (849,509,116 samples, 0.13%)</title><rect x="895.3" y="2481" width="5.6" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="898.35" y="2493.5" ></text>
+</g>
+<g >
+<title>execute_command (185,523,073 samples, 0.03%)</title><rect x="803.8" y="1521" width="1.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="806.77" y="1533.5" ></text>
+</g>
+<g >
+<title>execute_command (354,998,378 samples, 0.06%)</title><rect x="840.5" y="1381" width="2.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="843.48" y="1393.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (713,462,810 samples, 0.11%)</title><rect x="280.1" y="1021" width="4.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.11" y="1033.5" ></text>
+</g>
+<g >
+<title>execute_command (436,055,112 samples, 0.07%)</title><rect x="888.5" y="2201" width="2.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="891.55" y="2213.5" ></text>
+</g>
+<g >
+<title>execute_command (516,725,798 samples, 0.08%)</title><rect x="856.9" y="2081" width="3.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="859.92" y="2093.5" ></text>
+</g>
+<g >
+<title>vfs_read (2,267,433,736 samples, 0.36%)</title><rect x="1445.8" y="2341" width="14.9" height="19.0" fill="rgb(230,118,28)" rx="2" ry="2" />
+<text  x="1448.83" y="2353.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (3,061,625,676 samples, 0.48%)</title><rect x="3313.5" y="2381" width="20.0" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="3316.49" y="2393.5" ></text>
+</g>
+<g >
+<title>execute_command (1,150,422,968 samples, 0.18%)</title><rect x="827.6" y="2161" width="7.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="830.57" y="2173.5" ></text>
+</g>
+<g >
+<title>execute_command (76,158,944,495 samples, 11.93%)</title><rect x="307.9" y="1901" width="498.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="310.94" y="1913.5" >execute_command</text>
+</g>
+<g >
+<title>[unknown] (156,773,466 samples, 0.02%)</title><rect x="265.2" y="2581" width="1.0" height="19.0" fill="rgb(210,24,5)" rx="2" ry="2" />
+<text  x="268.16" y="2593.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (166,042,857 samples, 0.03%)</title><rect x="836.5" y="1401" width="1.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="839.46" y="1413.5" ></text>
+</g>
+<g >
+<title>__do_sys_newfstatat (174,965,855 samples, 0.03%)</title><rect x="407.7" y="961" width="1.2" height="19.0" fill="rgb(250,207,49)" rx="2" ry="2" />
+<text  x="410.75" y="973.5" ></text>
+</g>
+<g >
+<title>entry_SYSRETQ_unsafe_stack (307,944,851 samples, 0.05%)</title><rect x="1525.5" y="2421" width="2.0" height="19.0" fill="rgb(213,37,8)" rx="2" ry="2" />
+<text  x="1528.47" y="2433.5" ></text>
+</g>
+<g >
+<title>__libc_start_main@@GLIBC_2.34 (416,070,235 samples, 0.07%)</title><rect x="900.9" y="2561" width="2.7" height="19.0" fill="rgb(229,113,27)" rx="2" ry="2" />
+<text  x="903.92" y="2573.5" ></text>
+</g>
+<g >
+<title>execute_command (322,256,264 samples, 0.05%)</title><rect x="868.7" y="1161" width="2.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="871.70" y="1173.5" ></text>
+</g>
+<g >
+<title>[bash] (589,950,484 samples, 0.09%)</title><rect x="302.6" y="181" width="3.9" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="305.65" y="193.5" ></text>
+</g>
+<g >
+<title>execute_command (190,416,277 samples, 0.03%)</title><rect x="895.4" y="241" width="1.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="898.39" y="253.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (578,068,287 samples, 0.09%)</title><rect x="884.6" y="2241" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="887.62" y="2253.5" ></text>
+</g>
+<g >
+<title>execute_command (1,146,830,397 samples, 0.18%)</title><rect x="827.6" y="841" width="7.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="830.59" y="853.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (76,495,467,802 samples, 11.98%)</title><rect x="307.3" y="2321" width="500.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="310.33" y="2333.5" >execute_command_internal</text>
+</g>
+<g >
+<title>__fopen_internal (3,577,889,448 samples, 0.56%)</title><rect x="2542.0" y="2461" width="23.4" height="19.0" fill="rgb(248,197,47)" rx="2" ry="2" />
+<text  x="2544.96" y="2473.5" >_..</text>
+</g>
+<g >
+<title>security_inode_permission (345,130,541 samples, 0.05%)</title><rect x="180.9" y="2241" width="2.3" height="19.0" fill="rgb(215,47,11)" rx="2" ry="2" />
+<text  x="183.91" y="2253.5" ></text>
+</g>
+<g >
+<title>execute_command (598,514,664 samples, 0.09%)</title><rect x="891.4" y="2241" width="3.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="894.40" y="2253.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (195,267,188 samples, 0.03%)</title><rect x="835.2" y="921" width="1.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="838.18" y="933.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (516,725,798 samples, 0.08%)</title><rect x="856.9" y="1941" width="3.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="859.92" y="1953.5" ></text>
+</g>
+<g >
+<title>[bash] (481,813,209 samples, 0.08%)</title><rect x="276.9" y="1301" width="3.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="279.93" y="1313.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (529,082,290 samples, 0.08%)</title><rect x="1551.0" y="2421" width="3.5" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="1554.00" y="2433.5" ></text>
+</g>
+<g >
+<title>do_sys_openat2 (4,160,480,591 samples, 0.65%)</title><rect x="3906.0" y="2341" width="27.2" height="19.0" fill="rgb(209,21,5)" rx="2" ry="2" />
+<text  x="3909.00" y="2353.5" >d..</text>
+</g>
+<g >
+<title>execute_command (1,146,830,397 samples, 0.18%)</title><rect x="827.6" y="801" width="7.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="830.59" y="813.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (166,042,857 samples, 0.03%)</title><rect x="836.5" y="1481" width="1.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="839.46" y="1493.5" ></text>
+</g>
+<g >
+<title>asm_exc_page_fault (198,856,678 samples, 0.03%)</title><rect x="779.4" y="1281" width="1.3" height="19.0" fill="rgb(231,123,29)" rx="2" ry="2" />
+<text  x="782.45" y="1293.5" ></text>
+</g>
+<g >
+<title>execute_command (163,954,022 samples, 0.03%)</title><rect x="870.8" y="1241" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="873.82" y="1253.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (323,026,366 samples, 0.05%)</title><rect x="868.7" y="1561" width="2.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="871.70" y="1573.5" ></text>
+</g>
+<g >
+<title>_int_realloc (344,551,294 samples, 0.05%)</title><rect x="647.9" y="1301" width="2.2" height="19.0" fill="rgb(230,117,28)" rx="2" ry="2" />
+<text  x="650.89" y="1313.5" ></text>
+</g>
+<g >
+<title>execute_command (2,418,202,317 samples, 0.38%)</title><rect x="835.1" y="2541" width="15.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="838.10" y="2553.5" ></text>
+</g>
+<g >
+<title>[bash] (778,379,553 samples, 0.12%)</title><rect x="790.1" y="1381" width="5.1" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="793.08" y="1393.5" ></text>
+</g>
+<g >
+<title>execute_command (192,670,319 samples, 0.03%)</title><rect x="837.6" y="941" width="1.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="840.55" y="953.5" ></text>
+</g>
+<g >
+<title>copy_process (156,624,984 samples, 0.02%)</title><rect x="886.7" y="81" width="1.0" height="19.0" fill="rgb(239,160,38)" rx="2" ry="2" />
+<text  x="889.72" y="93.5" ></text>
+</g>
+<g >
+<title>execute_command (323,026,366 samples, 0.05%)</title><rect x="868.7" y="1281" width="2.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="871.70" y="1293.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (185,604,918 samples, 0.03%)</title><rect x="835.2" y="581" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="838.23" y="593.5" ></text>
+</g>
+<g >
+<title>execute_command (866,614,713 samples, 0.14%)</title><rect x="301.1" y="2201" width="5.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="304.12" y="2213.5" ></text>
+</g>
+<g >
+<title>execute_command (198,062,250 samples, 0.03%)</title><rect x="511.5" y="1361" width="1.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="514.45" y="1373.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (483,985,097 samples, 0.08%)</title><rect x="276.9" y="1921" width="3.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="279.92" y="1933.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (862,395,726 samples, 0.14%)</title><rect x="301.2" y="1321" width="5.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.15" y="1333.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (646,443,974 samples, 0.10%)</title><rect x="3940.0" y="2401" width="4.3" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="3943.04" y="2413.5" ></text>
+</g>
+<g >
+<title>execute_command (16,718,848,160 samples, 2.62%)</title><rect x="399.1" y="1221" width="109.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="402.12" y="1233.5" >execute_command</text>
+</g>
+<g >
+<title>execute_command_internal (704,492,242 samples, 0.11%)</title><rect x="296.5" y="841" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.51" y="853.5" ></text>
+</g>
+<g >
+<title>_IO_file_xsputn@@GLIBC_2.2.5 (161,764,643 samples, 0.03%)</title><rect x="1544.8" y="2401" width="1.0" height="19.0" fill="rgb(242,171,41)" rx="2" ry="2" />
+<text  x="1547.78" y="2413.5" ></text>
+</g>
+<g >
+<title>do_user_addr_fault (1,632,557,691 samples, 0.26%)</title><rect x="764.9" y="1261" width="10.7" height="19.0" fill="rgb(235,138,33)" rx="2" ry="2" />
+<text  x="767.94" y="1273.5" ></text>
+</g>
+<g >
+<title>parse_and_execute (215,126,890 samples, 0.03%)</title><rect x="842.8" y="701" width="1.4" height="19.0" fill="rgb(243,178,42)" rx="2" ry="2" />
+<text  x="845.81" y="713.5" ></text>
+</g>
+<g >
+<title>[bash] (201,247,992 samples, 0.03%)</title><rect x="340.7" y="561" width="1.3" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="343.73" y="573.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (170,489,782 samples, 0.03%)</title><rect x="871.9" y="901" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="874.90" y="913.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (2,156,220,174 samples, 0.34%)</title><rect x="835.1" y="2321" width="14.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="838.10" y="2333.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (849,509,116 samples, 0.13%)</title><rect x="895.3" y="2181" width="5.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.35" y="2193.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (190,829,147 samples, 0.03%)</title><rect x="837.6" y="721" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="840.55" y="733.5" ></text>
+</g>
+<g >
+<title>execute_command (1,925,898,782 samples, 0.30%)</title><rect x="868.6" y="2161" width="12.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="871.57" y="2173.5" ></text>
+</g>
+<g >
+<title>[sha1sum] (3,513,710,776 samples, 0.55%)</title><rect x="2020.9" y="2481" width="23.0" height="19.0" fill="rgb(214,42,10)" rx="2" ry="2" />
+<text  x="2023.86" y="2493.5" >[..</text>
+</g>
+<g >
+<title>execute_command_internal (432,872,015 samples, 0.07%)</title><rect x="888.6" y="1061" width="2.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="891.57" y="1073.5" ></text>
+</g>
+<g >
+<title>redirection_expand (156,895,695 samples, 0.02%)</title><rect x="870.9" y="521" width="1.0" height="19.0" fill="rgb(218,63,15)" rx="2" ry="2" />
+<text  x="873.86" y="533.5" ></text>
+</g>
+<g >
+<title>copy_page_to_iter (3,351,989,006 samples, 0.52%)</title><rect x="4077.9" y="2321" width="22.0" height="19.0" fill="rgb(216,52,12)" rx="2" ry="2" />
+<text  x="4080.92" y="2333.5" >c..</text>
+</g>
+<g >
+<title>__printf_buffer (526,520,642 samples, 0.08%)</title><rect x="1652.9" y="2461" width="3.4" height="19.0" fill="rgb(219,68,16)" rx="2" ry="2" />
+<text  x="1655.88" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command (1,263,560,140 samples, 0.20%)</title><rect x="860.3" y="1981" width="8.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="863.30" y="1993.5" ></text>
+</g>
+<g >
+<title>parse_and_execute (159,600,130 samples, 0.02%)</title><rect x="893.4" y="161" width="1.1" height="19.0" fill="rgb(243,178,42)" rx="2" ry="2" />
+<text  x="896.42" y="173.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,147,316,451 samples, 0.18%)</title><rect x="827.6" y="1341" width="7.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.59" y="1353.5" ></text>
+</g>
+<g >
+<title>[sha1sum] (11,111,701,143 samples, 1.74%)</title><rect x="2020.2" y="2501" width="72.7" height="19.0" fill="rgb(214,42,10)" rx="2" ry="2" />
+<text  x="2023.18" y="2513.5" >[sha1sum]</text>
+</g>
+<g >
+<title>execute_command_internal (195,267,188 samples, 0.03%)</title><rect x="835.2" y="961" width="1.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="838.18" y="973.5" ></text>
+</g>
+<g >
+<title>do_sys_openat2 (3,488,035,858 samples, 0.55%)</title><rect x="4121.8" y="2341" width="22.8" height="19.0" fill="rgb(209,21,5)" rx="2" ry="2" />
+<text  x="4124.78" y="2353.5" >d..</text>
+</g>
+<g >
+<title>lookup_fast (176,917,369 samples, 0.03%)</title><rect x="3031.6" y="2261" width="1.1" height="19.0" fill="rgb(226,97,23)" rx="2" ry="2" />
+<text  x="3034.59" y="2273.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (551,359,579 samples, 0.09%)</title><rect x="273.3" y="1401" width="3.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="276.31" y="1413.5" ></text>
+</g>
+<g >
+<title>execute_command (180,216,075 samples, 0.03%)</title><rect x="878.5" y="1881" width="1.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="881.48" y="1893.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (861,612,432 samples, 0.13%)</title><rect x="301.2" y="541" width="5.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.16" y="553.5" ></text>
+</g>
+<g >
+<title>__d_lookup_rcu (208,913,784 samples, 0.03%)</title><rect x="2031.6" y="2241" width="1.4" height="19.0" fill="rgb(235,139,33)" rx="2" ry="2" />
+<text  x="2034.65" y="2253.5" ></text>
+</g>
+<g >
+<title>execute_command (861,612,432 samples, 0.13%)</title><rect x="301.2" y="561" width="5.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="304.16" y="573.5" ></text>
+</g>
+<g >
+<title>lookup_fast (204,003,591 samples, 0.03%)</title><rect x="2030.3" y="2221" width="1.3" height="19.0" fill="rgb(226,97,23)" rx="2" ry="2" />
+<text  x="2033.29" y="2233.5" ></text>
+</g>
+<g >
+<title>execute_command (575,055,300 samples, 0.09%)</title><rect x="884.6" y="1021" width="3.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="887.64" y="1033.5" ></text>
+</g>
+<g >
+<title>execute_command (891,895,571 samples, 0.14%)</title><rect x="851.1" y="1981" width="5.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="854.08" y="1993.5" ></text>
+</g>
+<g >
+<title>rep_movs_alternative (1,573,733,712 samples, 0.25%)</title><rect x="3052.8" y="2301" width="10.3" height="19.0" fill="rgb(211,31,7)" rx="2" ry="2" />
+<text  x="3055.82" y="2313.5" ></text>
+</g>
+<g >
+<title>entry_SYSRETQ_unsafe_stack (248,570,527 samples, 0.04%)</title><rect x="3898.9" y="2401" width="1.7" height="19.0" fill="rgb(213,37,8)" rx="2" ry="2" />
+<text  x="3901.95" y="2413.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (705,583,873 samples, 0.11%)</title><rect x="296.5" y="1101" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.50" y="1113.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (2,420,545,736 samples, 0.38%)</title><rect x="868.6" y="2501" width="15.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="871.57" y="2513.5" ></text>
+</g>
+<g >
+<title>__fopen_internal (2,738,812,394 samples, 0.43%)</title><rect x="1590.6" y="2461" width="18.0" height="19.0" fill="rgb(248,197,47)" rx="2" ry="2" />
+<text  x="1593.63" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command (689,586,161 samples, 0.11%)</title><rect x="296.5" y="381" width="4.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="299.51" y="393.5" ></text>
+</g>
+<g >
+<title>execute_command (164,072,262 samples, 0.03%)</title><rect x="836.5" y="661" width="1.0" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="839.46" y="673.5" ></text>
+</g>
+<g >
+<title>execute_command (373,582,417 samples, 0.06%)</title><rect x="835.1" y="1701" width="2.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="838.10" y="1713.5" ></text>
+</g>
+<g >
+<title>__irqentry_text_end (330,322,254 samples, 0.05%)</title><rect x="731.4" y="1241" width="2.2" height="19.0" fill="rgb(254,228,54)" rx="2" ry="2" />
+<text  x="734.41" y="1253.5" ></text>
+</g>
+<g >
+<title>redirection_expand (592,111,570 samples, 0.09%)</title><rect x="302.6" y="201" width="3.9" height="19.0" fill="rgb(218,63,15)" rx="2" ry="2" />
+<text  x="305.65" y="213.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (2,587,375,772 samples, 0.41%)</title><rect x="1616.7" y="2421" width="16.9" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="1619.66" y="2433.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (164,209,678 samples, 0.03%)</title><rect x="836.5" y="801" width="1.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="839.46" y="813.5" ></text>
+</g>
+<g >
+<title>execute_command (578,068,287 samples, 0.09%)</title><rect x="884.6" y="2421" width="3.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="887.62" y="2433.5" ></text>
+</g>
+<g >
+<title>[bash] (751,639,212 samples, 0.12%)</title><rect x="375.3" y="141" width="5.0" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="378.33" y="153.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (195,562,201 samples, 0.03%)</title><rect x="511.5" y="1341" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="514.47" y="1353.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (713,987,302 samples, 0.11%)</title><rect x="280.1" y="1241" width="4.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.11" y="1253.5" ></text>
+</g>
+<g >
+<title>[bash] (158,593,817 samples, 0.02%)</title><rect x="875.9" y="621" width="1.1" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="878.93" y="633.5" ></text>
+</g>
+<g >
+<title>[libcrypto.so.3.2.2] (26,153,490,556 samples, 4.10%)</title><rect x="1848.2" y="2581" width="171.2" height="19.0" fill="rgb(244,181,43)" rx="2" ry="2" />
+<text  x="1851.18" y="2593.5" >[libcrypto.so.3.2.2]</text>
+</g>
+<g >
+<title>[bash] (892,089,174 samples, 0.14%)</title><rect x="851.1" y="2541" width="5.8" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="854.08" y="2553.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (158,593,817 samples, 0.02%)</title><rect x="875.9" y="661" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="878.93" y="673.5" ></text>
+</g>
+<g >
+<title>execute_command (710,260,538 samples, 0.11%)</title><rect x="280.1" y="541" width="4.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="283.11" y="553.5" ></text>
+</g>
+<g >
+<title>[bash] (475,200,240 samples, 0.07%)</title><rect x="281.5" y="321" width="3.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="284.54" y="333.5" ></text>
+</g>
+<g >
+<title>may_open (165,289,465 samples, 0.03%)</title><rect x="3325.0" y="2261" width="1.1" height="19.0" fill="rgb(240,162,38)" rx="2" ry="2" />
+<text  x="3328.00" y="2273.5" ></text>
+</g>
+<g >
+<title>zreadc (983,357,083 samples, 0.15%)</title><rect x="501.3" y="1101" width="6.4" height="19.0" fill="rgb(224,89,21)" rx="2" ry="2" />
+<text  x="504.27" y="1113.5" ></text>
+</g>
+<g >
+<title>may_open (239,649,910 samples, 0.04%)</title><rect x="3921.4" y="2281" width="1.5" height="19.0" fill="rgb(240,162,38)" rx="2" ry="2" />
+<text  x="3924.36" y="2293.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (348,489,528 samples, 0.05%)</title><rect x="2146.0" y="2401" width="2.3" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="2149.02" y="2413.5" ></text>
+</g>
+<g >
+<title>execute_command (171,847,094 samples, 0.03%)</title><rect x="871.9" y="1661" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="874.89" y="1673.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (433,500,595 samples, 0.07%)</title><rect x="888.6" y="1181" width="2.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="891.56" y="1193.5" ></text>
+</g>
+<g >
+<title>[bash] (22,089,478,937 samples, 3.46%)</title><rect x="517.5" y="1341" width="144.6" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="520.46" y="1353.5" >[bash]</text>
+</g>
+<g >
+<title>parse_and_execute (197,264,169 samples, 0.03%)</title><rect x="890.0" y="321" width="1.2" height="19.0" fill="rgb(243,178,42)" rx="2" ry="2" />
+<text  x="892.95" y="333.5" ></text>
+</g>
+<g >
+<title>execute_command (166,042,857 samples, 0.03%)</title><rect x="836.5" y="1641" width="1.0" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="839.46" y="1653.5" ></text>
+</g>
+<g >
+<title>filemap_get_entry (222,259,728 samples, 0.03%)</title><rect x="3064.1" y="2321" width="1.4" height="19.0" fill="rgb(253,222,53)" rx="2" ry="2" />
+<text  x="3067.06" y="2333.5" ></text>
+</g>
+<g >
+<title>new_do_write (156,862,057 samples, 0.02%)</title><rect x="4026.7" y="2501" width="1.0" height="19.0" fill="rgb(206,5,1)" rx="2" ry="2" />
+<text  x="4029.70" y="2513.5" ></text>
+</g>
+<g >
+<title>execute_command (432,872,015 samples, 0.07%)</title><rect x="888.6" y="1121" width="2.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="891.57" y="1133.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (13,305,758,244 samples, 2.08%)</title><rect x="307.9" y="1641" width="87.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="310.94" y="1653.5" >execute_co..</text>
+</g>
+<g >
+<title>[bash] (381,708,976 samples, 0.06%)</title><rect x="277.5" y="361" width="2.5" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="280.53" y="373.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (354,911,948 samples, 0.06%)</title><rect x="840.5" y="821" width="2.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="843.48" y="833.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (481,191,724 samples, 0.08%)</title><rect x="276.9" y="1001" width="3.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="279.94" y="1013.5" ></text>
+</g>
+<g >
+<title>llseek@GLIBC_2.2.5 (672,217,582 samples, 0.11%)</title><rect x="2611.1" y="2481" width="4.4" height="19.0" fill="rgb(239,156,37)" rx="2" ry="2" />
+<text  x="2614.06" y="2493.5" ></text>
+</g>
+<g >
+<title>execute_command (891,895,571 samples, 0.14%)</title><rect x="851.1" y="2221" width="5.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="854.08" y="2233.5" ></text>
+</g>
+<g >
+<title>[sha384sum] (2,972,057,322 samples, 0.47%)</title><rect x="3022.6" y="2481" width="19.5" height="19.0" fill="rgb(253,223,53)" rx="2" ry="2" />
+<text  x="3025.62" y="2493.5" ></text>
+</g>
+<g >
+<title>do_sys_openat2 (2,221,657,990 samples, 0.35%)</title><rect x="177.7" y="2321" width="14.5" height="19.0" fill="rgb(209,21,5)" rx="2" ry="2" />
+<text  x="180.66" y="2333.5" ></text>
+</g>
+<g >
+<title>execute_command (192,670,319 samples, 0.03%)</title><rect x="837.6" y="1301" width="1.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="840.55" y="1313.5" ></text>
+</g>
+<g >
+<title>shmem_file_read_iter (2,221,860,839 samples, 0.35%)</title><rect x="3051.4" y="2361" width="14.5" height="19.0" fill="rgb(238,152,36)" rx="2" ry="2" />
+<text  x="3054.35" y="2373.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (179,777,548 samples, 0.03%)</title><rect x="878.5" y="781" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="881.48" y="793.5" ></text>
+</g>
+<g >
+<title>execute_command (356,134,455 samples, 0.06%)</title><rect x="840.5" y="1581" width="2.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="843.47" y="1593.5" ></text>
+</g>
+<g >
+<title>_dl_sysdep_start (1,048,086,300 samples, 0.16%)</title><rect x="1578.8" y="2541" width="6.9" height="19.0" fill="rgb(234,137,32)" rx="2" ry="2" />
+<text  x="1581.83" y="2553.5" ></text>
+</g>
+<g >
+<title>vfs_statx (2,381,102,937 samples, 0.37%)</title><rect x="4165.6" y="2401" width="15.6" height="19.0" fill="rgb(248,201,48)" rx="2" ry="2" />
+<text  x="4168.64" y="2413.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (190,387,243 samples, 0.03%)</title><rect x="895.4" y="221" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.39" y="233.5" ></text>
+</g>
+<g >
+<title>selinux_inode_permission (288,033,311 samples, 0.05%)</title><rect x="3028.1" y="2221" width="1.9" height="19.0" fill="rgb(238,156,37)" rx="2" ry="2" />
+<text  x="3031.13" y="2233.5" ></text>
+</g>
+<g >
+<title>entry_SYSRETQ_unsafe_stack (158,426,411 samples, 0.02%)</title><rect x="2095.7" y="2421" width="1.1" height="19.0" fill="rgb(213,37,8)" rx="2" ry="2" />
+<text  x="2098.72" y="2433.5" ></text>
+</g>
+<g >
+<title>syscall_return_via_sysret (194,222,275 samples, 0.03%)</title><rect x="2091.4" y="2461" width="1.3" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="2094.43" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,251,500,515 samples, 0.20%)</title><rect x="860.3" y="441" width="8.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.32" y="453.5" ></text>
+</g>
+<g >
+<title>shmem_file_read_iter (2,639,857,477 samples, 0.41%)</title><rect x="2154.8" y="2361" width="17.3" height="19.0" fill="rgb(238,152,36)" rx="2" ry="2" />
+<text  x="2157.84" y="2373.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (4,214,928,141 samples, 0.66%)</title><rect x="360.5" y="441" width="27.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="363.54" y="453.5" >e..</text>
+</g>
+<g >
+<title>__close_nocancel (630,782,784 samples, 0.10%)</title><rect x="225.0" y="2461" width="4.2" height="19.0" fill="rgb(228,109,26)" rx="2" ry="2" />
+<text  x="228.03" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command (713,521,499 samples, 0.11%)</title><rect x="296.5" y="1421" width="4.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="299.45" y="1433.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (170,489,782 samples, 0.03%)</title><rect x="871.9" y="941" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="874.90" y="953.5" ></text>
+</g>
+<g >
+<title>[libcrypto.so.3.2.2] (49,258,750,280 samples, 7.71%)</title><rect x="2208.8" y="2561" width="322.5" height="19.0" fill="rgb(244,181,43)" rx="2" ry="2" />
+<text  x="2211.79" y="2573.5" >[libcrypto.so.3.2.2]</text>
+</g>
+<g >
+<title>execute_command (6,274,329,552 samples, 0.98%)</title><rect x="309.1" y="841" width="41.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="312.14" y="853.5" >exe..</text>
+</g>
+<g >
+<title>execute_command (842,511,421 samples, 0.13%)</title><rect x="895.4" y="801" width="5.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="898.39" y="813.5" ></text>
+</g>
+<g >
+<title>execute_command (195,267,188 samples, 0.03%)</title><rect x="835.2" y="1061" width="1.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="838.18" y="1073.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (713,521,499 samples, 0.11%)</title><rect x="296.5" y="2041" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.45" y="2053.5" ></text>
+</g>
+<g >
+<title>[unknown] (30,255,339,231 samples, 4.74%)</title><rect x="3107.0" y="2581" width="198.1" height="19.0" fill="rgb(210,24,5)" rx="2" ry="2" />
+<text  x="3110.04" y="2593.5" >[unknown]</text>
+</g>
+<g >
+<title>execute_command_internal (195,916,485 samples, 0.03%)</title><rect x="835.2" y="1281" width="1.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="838.17" y="1293.5" ></text>
+</g>
+<g >
+<title>execute_command (158,744,410 samples, 0.02%)</title><rect x="875.9" y="1481" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="878.93" y="1493.5" ></text>
+</g>
+<g >
+<title>[bash] (215,132,849 samples, 0.03%)</title><rect x="842.8" y="761" width="1.4" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="845.81" y="773.5" ></text>
+</g>
+<g >
+<title>[bash] (354,900,103 samples, 0.06%)</title><rect x="840.5" y="621" width="2.3" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="843.48" y="633.5" ></text>
+</g>
+<g >
+<title>execute_command (1,147,316,451 samples, 0.18%)</title><rect x="827.6" y="1121" width="7.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="830.59" y="1133.5" ></text>
+</g>
+<g >
+<title>__printf_buffer (198,506,379 samples, 0.03%)</title><rect x="3996.8" y="2441" width="1.3" height="19.0" fill="rgb(219,68,16)" rx="2" ry="2" />
+<text  x="3999.78" y="2453.5" ></text>
+</g>
+<g >
+<title>[bash] (215,132,849 samples, 0.03%)</title><rect x="842.8" y="721" width="1.4" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="845.81" y="733.5" ></text>
+</g>
+<g >
+<title>__printf_chk (1,864,585,452 samples, 0.29%)</title><rect x="2191.7" y="2501" width="12.2" height="19.0" fill="rgb(212,36,8)" rx="2" ry="2" />
+<text  x="2194.74" y="2513.5" ></text>
+</g>
+<g >
+<title>[bash] (686,486,049 samples, 0.11%)</title><rect x="268.8" y="1261" width="4.5" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="271.78" y="1273.5" ></text>
+</g>
+<g >
+<title>execute_command (575,800,354 samples, 0.09%)</title><rect x="884.6" y="1421" width="3.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="887.64" y="1433.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (322,256,264 samples, 0.05%)</title><rect x="868.7" y="941" width="2.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="871.70" y="953.5" ></text>
+</g>
+<g >
+<title>[bash] (277,989,816 samples, 0.04%)</title><rect x="275.1" y="321" width="1.8" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="278.06" y="333.5" ></text>
+</g>
+<g >
+<title>execute_command (598,514,664 samples, 0.09%)</title><rect x="891.4" y="2041" width="3.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="894.40" y="2053.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (737,490,267 samples, 0.12%)</title><rect x="835.1" y="1801" width="4.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="838.10" y="1813.5" ></text>
+</g>
+<g >
+<title>execute_command (320,440,447 samples, 0.05%)</title><rect x="868.7" y="601" width="2.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="871.70" y="613.5" ></text>
+</g>
+<g >
+<title>security_file_open (254,450,186 samples, 0.04%)</title><rect x="3329.0" y="2221" width="1.6" height="19.0" fill="rgb(215,47,11)" rx="2" ry="2" />
+<text  x="3331.97" y="2233.5" ></text>
+</g>
+<g >
+<title>__do_sys_clone (159,753,816 samples, 0.03%)</title><rect x="886.7" y="121" width="1.1" height="19.0" fill="rgb(217,57,13)" rx="2" ry="2" />
+<text  x="889.71" y="133.5" ></text>
+</g>
+<g >
+<title>execute_command (866,614,713 samples, 0.14%)</title><rect x="301.1" y="1961" width="5.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="304.12" y="1973.5" ></text>
+</g>
+<g >
+<title>_dl_sysdep_start (689,490,755 samples, 0.11%)</title><rect x="2117.4" y="2541" width="4.5" height="19.0" fill="rgb(234,137,32)" rx="2" ry="2" />
+<text  x="2120.42" y="2553.5" ></text>
+</g>
+<g >
+<title>dispose_command (278,786,529 samples, 0.04%)</title><rect x="840.5" y="321" width="1.8" height="19.0" fill="rgb(248,201,48)" rx="2" ry="2" />
+<text  x="843.48" y="333.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (849,509,116 samples, 0.13%)</title><rect x="895.3" y="2261" width="5.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.35" y="2273.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (252,576,184 samples, 0.04%)</title><rect x="858.5" y="281" width="1.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="861.51" y="293.5" ></text>
+</g>
+<g >
+<title>path_openat (3,446,437,732 samples, 0.54%)</title><rect x="3907.0" y="2301" width="22.5" height="19.0" fill="rgb(205,2,0)" rx="2" ry="2" />
+<text  x="3909.98" y="2313.5" >p..</text>
+</g>
+<g >
+<title>execute_command (62,848,306,171 samples, 9.84%)</title><rect x="395.1" y="1841" width="411.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="398.07" y="1853.5" >execute_command</text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (237,699,148 samples, 0.04%)</title><rect x="270.0" y="221" width="1.5" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="272.99" y="233.5" ></text>
+</g>
+<g >
+<title>unmap_page_range (458,714,718 samples, 0.07%)</title><rect x="292.9" y="2361" width="3.0" height="19.0" fill="rgb(212,35,8)" rx="2" ry="2" />
+<text  x="295.92" y="2373.5" ></text>
+</g>
+<g >
+<title>execute_command (13,305,059,798 samples, 2.08%)</title><rect x="307.9" y="1621" width="87.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="310.94" y="1633.5" >execute_co..</text>
+</g>
+<g >
+<title>execute_command_internal (713,521,499 samples, 0.11%)</title><rect x="296.5" y="1441" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.45" y="1453.5" ></text>
+</g>
+<g >
+<title>[bash] (276,325,243 samples, 0.04%)</title><rect x="892.8" y="181" width="1.8" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="895.77" y="193.5" ></text>
+</g>
+<g >
+<title>_int_malloc (349,331,937 samples, 0.05%)</title><rect x="644.0" y="1261" width="2.3" height="19.0" fill="rgb(215,47,11)" rx="2" ry="2" />
+<text  x="647.03" y="1273.5" ></text>
+</g>
+<g >
+<title>execute_command (356,134,455 samples, 0.06%)</title><rect x="840.5" y="1841" width="2.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="843.47" y="1853.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (598,514,664 samples, 0.09%)</title><rect x="891.4" y="2401" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.40" y="2413.5" ></text>
+</g>
+<g >
+<title>[bash] (391,165,898 samples, 0.06%)</title><rect x="277.5" y="441" width="2.5" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="280.48" y="453.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (688,813,226 samples, 0.11%)</title><rect x="268.8" y="2521" width="4.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="271.77" y="2533.5" ></text>
+</g>
+<g >
+<title>_start (76,571,701,847 samples, 11.99%)</title><rect x="306.9" y="2581" width="501.2" height="19.0" fill="rgb(245,185,44)" rx="2" ry="2" />
+<text  x="309.86" y="2593.5" >_start</text>
+</g>
+<g >
+<title>execute_command_internal (164,209,678 samples, 0.03%)</title><rect x="836.5" y="761" width="1.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="839.46" y="773.5" ></text>
+</g>
+<g >
+<title>redirection_expand (511,018,812 samples, 0.08%)</title><rect x="885.1" y="421" width="3.3" height="19.0" fill="rgb(218,63,15)" rx="2" ry="2" />
+<text  x="888.05" y="433.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (513,954,307 samples, 0.08%)</title><rect x="856.9" y="1261" width="3.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="859.94" y="1273.5" ></text>
+</g>
+<g >
+<title>execute_command (685,594,707 samples, 0.11%)</title><rect x="268.8" y="681" width="4.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="271.79" y="693.5" ></text>
+</g>
+<g >
+<title>execute_command (159,710,185 samples, 0.03%)</title><rect x="875.9" y="1561" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="878.92" y="1573.5" ></text>
+</g>
+<g >
+<title>new_do_write (522,266,488 samples, 0.08%)</title><rect x="1647.7" y="2461" width="3.4" height="19.0" fill="rgb(206,5,1)" rx="2" ry="2" />
+<text  x="1650.72" y="2473.5" ></text>
+</g>
+<g >
+<title>__fread_unlocked_chk (4,227,890,130 samples, 0.66%)</title><rect x="1502.3" y="2461" width="27.7" height="19.0" fill="rgb(225,94,22)" rx="2" ry="2" />
+<text  x="1505.33" y="2473.5" >_..</text>
+</g>
+<g >
+<title>_dl_sysdep_start (168,022,672 samples, 0.03%)</title><rect x="266.6" y="2541" width="1.1" height="19.0" fill="rgb(234,137,32)" rx="2" ry="2" />
+<text  x="269.63" y="2553.5" ></text>
+</g>
+<g >
+<title>execute_command (862,395,726 samples, 0.14%)</title><rect x="301.2" y="1201" width="5.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="304.15" y="1213.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,263,560,140 samples, 0.20%)</title><rect x="860.3" y="1601" width="8.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.30" y="1613.5" ></text>
+</g>
+<g >
+<title>__printf_buffer (832,043,041 samples, 0.13%)</title><rect x="2194.3" y="2461" width="5.5" height="19.0" fill="rgb(219,68,16)" rx="2" ry="2" />
+<text  x="2197.35" y="2473.5" ></text>
+</g>
+<g >
+<title>path_openat (2,305,638,226 samples, 0.36%)</title><rect x="2544.7" y="2281" width="15.1" height="19.0" fill="rgb(205,2,0)" rx="2" ry="2" />
+<text  x="2547.69" y="2293.5" ></text>
+</g>
+<g >
+<title>bpf_trampoline_6442533562 (160,591,245 samples, 0.03%)</title><rect x="2037.0" y="2181" width="1.1" height="19.0" fill="rgb(221,78,18)" rx="2" ry="2" />
+<text  x="2040.04" y="2193.5" ></text>
+</g>
+<g >
+<title>execute_command (158,744,410 samples, 0.02%)</title><rect x="875.9" y="1241" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="878.93" y="1253.5" ></text>
+</g>
+<g >
+<title>rep_movs_alternative (1,552,354,385 samples, 0.24%)</title><rect x="205.3" y="2281" width="10.1" height="19.0" fill="rgb(211,31,7)" rx="2" ry="2" />
+<text  x="208.28" y="2293.5" ></text>
+</g>
+<g >
+<title>__strlen_evex (305,027,079 samples, 0.05%)</title><rect x="673.7" y="1341" width="2.0" height="19.0" fill="rgb(240,164,39)" rx="2" ry="2" />
+<text  x="676.67" y="1353.5" ></text>
+</g>
+<g >
+<title>entry_SYSRETQ_unsafe_stack (173,030,170 samples, 0.03%)</title><rect x="2562.3" y="2381" width="1.2" height="19.0" fill="rgb(213,37,8)" rx="2" ry="2" />
+<text  x="2565.34" y="2393.5" ></text>
+</g>
+<g >
+<title>do_redirections (547,537,781 samples, 0.09%)</title><rect x="897.2" y="321" width="3.6" height="19.0" fill="rgb(247,193,46)" rx="2" ry="2" />
+<text  x="900.19" y="333.5" ></text>
+</g>
+<g >
+<title>syscall_return_via_sysret (171,805,679 samples, 0.03%)</title><rect x="2149.4" y="2401" width="1.1" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="2152.42" y="2413.5" ></text>
+</g>
+<g >
+<title>[bash] (62,225,668,365 samples, 9.75%)</title><rect x="396.0" y="1521" width="407.3" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="398.96" y="1533.5" >[bash]</text>
+</g>
+<g >
+<title>[bash] (1,147,316,451 samples, 0.18%)</title><rect x="827.6" y="1221" width="7.5" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="830.59" y="1233.5" ></text>
+</g>
+<g >
+<title>_Fork (185,178,919 samples, 0.03%)</title><rect x="273.8" y="341" width="1.3" height="19.0" fill="rgb(252,220,52)" rx="2" ry="2" />
+<text  x="276.84" y="353.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (354,998,378 samples, 0.06%)</title><rect x="840.5" y="1121" width="2.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="843.48" y="1133.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (704,492,242 samples, 0.11%)</title><rect x="296.5" y="801" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.51" y="813.5" ></text>
+</g>
+<g >
+<title>shmem_get_folio_gfp (433,571,386 samples, 0.07%)</title><rect x="2071.9" y="2341" width="2.8" height="19.0" fill="rgb(219,67,16)" rx="2" ry="2" />
+<text  x="2074.89" y="2353.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (203,200,345 samples, 0.03%)</title><rect x="511.4" y="1381" width="1.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="514.42" y="1393.5" ></text>
+</g>
+<g >
+<title>_IO_file_open (2,683,465,061 samples, 0.42%)</title><rect x="176.7" y="2421" width="17.5" height="19.0" fill="rgb(249,205,49)" rx="2" ry="2" />
+<text  x="179.65" y="2433.5" ></text>
+</g>
+<g >
+<title>[bash] (188,263,754 samples, 0.03%)</title><rect x="837.6" y="441" width="1.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="840.57" y="453.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (195,267,188 samples, 0.03%)</title><rect x="835.2" y="841" width="1.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="838.18" y="853.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (598,514,664 samples, 0.09%)</title><rect x="891.4" y="2101" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.40" y="2113.5" ></text>
+</g>
+<g >
+<title>execute_command (163,563,240 samples, 0.03%)</title><rect x="870.8" y="761" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="873.82" y="773.5" ></text>
+</g>
+<g >
+<title>__x64_sys_openat (276,599,738 samples, 0.04%)</title><rect x="345.4" y="581" width="1.8" height="19.0" fill="rgb(208,15,3)" rx="2" ry="2" />
+<text  x="348.42" y="593.5" ></text>
+</g>
+<g >
+<title>do_redirections (1,214,683,984 samples, 0.19%)</title><rect x="374.4" y="221" width="8.0" height="19.0" fill="rgb(247,193,46)" rx="2" ry="2" />
+<text  x="377.44" y="233.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (483,295,144 samples, 0.08%)</title><rect x="3941.1" y="2381" width="3.2" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="3944.11" y="2393.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,147,316,451 samples, 0.18%)</title><rect x="827.6" y="1261" width="7.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.59" y="1273.5" ></text>
+</g>
+<g >
+<title>__strlen_evex (218,643,781 samples, 0.03%)</title><rect x="592.8" y="1321" width="1.4" height="19.0" fill="rgb(240,164,39)" rx="2" ry="2" />
+<text  x="595.81" y="1333.5" ></text>
+</g>
+<g >
+<title>perf_event_alloc (174,390,604 samples, 0.03%)</title><rect x="273.9" y="161" width="1.1" height="19.0" fill="rgb(215,49,11)" rx="2" ry="2" />
+<text  x="276.87" y="173.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (7,231,057,977 samples, 1.13%)</title><rect x="308.5" y="1141" width="47.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="311.53" y="1153.5" >exec..</text>
+</g>
+<g >
+<title>avc_has_perm_noaudit (158,844,928 samples, 0.02%)</title><rect x="2549.8" y="2201" width="1.0" height="19.0" fill="rgb(209,18,4)" rx="2" ry="2" />
+<text  x="2552.81" y="2213.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (7,201,882,543 samples, 1.13%)</title><rect x="308.6" y="961" width="47.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="311.57" y="973.5" >exec..</text>
+</g>
+<g >
+<title>execute_command_internal (595,672,870 samples, 0.09%)</title><rect x="891.4" y="861" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.42" y="873.5" ></text>
+</g>
+<g >
+<title>execute_command (481,191,724 samples, 0.08%)</title><rect x="276.9" y="821" width="3.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="279.94" y="833.5" ></text>
+</g>
+<g >
+<title>syscall_return_via_sysret (356,903,303 samples, 0.06%)</title><rect x="1463.0" y="2401" width="2.3" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="1465.97" y="2413.5" ></text>
+</g>
+<g >
+<title>read_builtin (180,119,748 samples, 0.03%)</title><rect x="329.5" y="501" width="1.2" height="19.0" fill="rgb(235,139,33)" rx="2" ry="2" />
+<text  x="332.52" y="513.5" ></text>
+</g>
+<g >
+<title>[bash] (62,598,531,356 samples, 9.80%)</title><rect x="395.5" y="1601" width="409.7" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="398.45" y="1613.5" >[bash]</text>
+</g>
+<g >
+<title>[bash] (563,179,959 samples, 0.09%)</title><rect x="269.5" y="341" width="3.7" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="272.54" y="353.5" ></text>
+</g>
+<g >
+<title>[bash] (36,664,796,209 samples, 5.74%)</title><rect x="515.1" y="1361" width="240.1" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="518.14" y="1373.5" >[bash]</text>
+</g>
+<g >
+<title>syscall_return_via_sysret (177,670,253 samples, 0.03%)</title><rect x="369.9" y="141" width="1.2" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="372.93" y="153.5" ></text>
+</g>
+<g >
+<title>execute_command (516,725,798 samples, 0.08%)</title><rect x="856.9" y="1681" width="3.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="859.92" y="1693.5" ></text>
+</g>
+<g >
+<title>[bash] (215,132,849 samples, 0.03%)</title><rect x="842.8" y="1521" width="1.4" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="845.81" y="1533.5" ></text>
+</g>
+<g >
+<title>execute_command (5,239,110,076 samples, 0.82%)</title><rect x="359.6" y="661" width="34.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="362.56" y="673.5" >ex..</text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (2,964,154,477 samples, 0.46%)</title><rect x="808.2" y="2581" width="19.4" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="811.16" y="2593.5" ></text>
+</g>
+<g >
+<title>_IO_file_open (5,063,645,429 samples, 0.79%)</title><rect x="3904.1" y="2441" width="33.1" height="19.0" fill="rgb(249,205,49)" rx="2" ry="2" />
+<text  x="3907.06" y="2453.5" >_I..</text>
+</g>
+<g >
+<title>execute_command_internal (688,777,208 samples, 0.11%)</title><rect x="268.8" y="2261" width="4.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="271.77" y="2273.5" ></text>
+</g>
+<g >
+<title>copy_page_range (286,134,447 samples, 0.04%)</title><rect x="863.1" y="61" width="1.9" height="19.0" fill="rgb(221,76,18)" rx="2" ry="2" />
+<text  x="866.08" y="73.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (215,748,926 samples, 0.03%)</title><rect x="842.8" y="1741" width="1.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="845.80" y="1753.5" ></text>
+</g>
+<g >
+<title>_dl_sysdep_start (523,289,703 samples, 0.08%)</title><rect x="3305.7" y="2541" width="3.4" height="19.0" fill="rgb(234,137,32)" rx="2" ry="2" />
+<text  x="3308.67" y="2553.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (891,895,571 samples, 0.14%)</title><rect x="851.1" y="2081" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.08" y="2093.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (348,020,568 samples, 0.05%)</title><rect x="3374.3" y="2421" width="2.3" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="3377.28" y="2433.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (710,260,538 samples, 0.11%)</title><rect x="280.1" y="521" width="4.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.11" y="533.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (5,716,266,174 samples, 0.90%)</title><rect x="356.9" y="841" width="37.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="359.93" y="853.5" >exe..</text>
+</g>
+<g >
+<title>__libc_fork (2,813,635,402 samples, 0.44%)</title><rect x="693.4" y="1321" width="18.5" height="19.0" fill="rgb(220,70,16)" rx="2" ry="2" />
+<text  x="696.44" y="1333.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (179,777,548 samples, 0.03%)</title><rect x="878.5" y="1541" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="881.48" y="1553.5" ></text>
+</g>
+<g >
+<title>read (7,990,346,179 samples, 1.25%)</title><rect x="4066.2" y="2441" width="52.3" height="19.0" fill="rgb(252,216,51)" rx="2" ry="2" />
+<text  x="4069.21" y="2453.5" >read</text>
+</g>
+<g >
+<title>[sha512sum] (17,509,416,850 samples, 2.74%)</title><rect x="3310.1" y="2521" width="114.7" height="19.0" fill="rgb(248,201,48)" rx="2" ry="2" />
+<text  x="3313.14" y="2533.5" >[sha512sum]</text>
+</g>
+<g >
+<title>entry_SYSCALL_64 (276,657,677 samples, 0.04%)</title><rect x="3948.9" y="2441" width="1.8" height="19.0" fill="rgb(245,186,44)" rx="2" ry="2" />
+<text  x="3951.87" y="2453.5" ></text>
+</g>
+<g >
+<title>_IO_file_overflow@@GLIBC_2.2.5 (682,032,978 samples, 0.11%)</title><rect x="2093.6" y="2501" width="4.4" height="19.0" fill="rgb(239,157,37)" rx="2" ry="2" />
+<text  x="2096.57" y="2513.5" ></text>
+</g>
+<g >
+<title>kernel_clone (181,373,291 samples, 0.03%)</title><rect x="273.8" y="261" width="1.2" height="19.0" fill="rgb(248,199,47)" rx="2" ry="2" />
+<text  x="276.84" y="273.5" ></text>
+</g>
+<g >
+<title>execute_command (425,110,343 samples, 0.07%)</title><rect x="888.6" y="561" width="2.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="891.57" y="573.5" ></text>
+</g>
+<g >
+<title>execute_command (717,313,739 samples, 0.11%)</title><rect x="280.1" y="1621" width="4.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="283.09" y="1633.5" ></text>
+</g>
+<g >
+<title>execute_command (171,847,094 samples, 0.03%)</title><rect x="871.9" y="1361" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="874.89" y="1373.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (578,068,287 samples, 0.09%)</title><rect x="884.6" y="1681" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="887.62" y="1693.5" ></text>
+</g>
+<g >
+<title>execute_command (1,693,874,404 samples, 0.27%)</title><rect x="868.6" y="2041" width="11.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="871.57" y="2053.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,988,959,591 samples, 0.31%)</title><rect x="868.6" y="2221" width="13.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="871.57" y="2233.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,150,422,968 samples, 0.18%)</title><rect x="827.6" y="1621" width="7.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.57" y="1633.5" ></text>
+</g>
+<g >
+<title>execute_command (596,118,643 samples, 0.09%)</title><rect x="891.4" y="1241" width="3.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="894.42" y="1253.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (889,542,281 samples, 0.14%)</title><rect x="851.1" y="881" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.09" y="893.5" ></text>
+</g>
+<g >
+<title>[bash] (361,529,372 samples, 0.06%)</title><rect x="892.8" y="221" width="2.3" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="895.77" y="233.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,146,830,397 samples, 0.18%)</title><rect x="827.6" y="821" width="7.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.59" y="833.5" ></text>
+</g>
+<g >
+<title>_IO_doallocbuf (996,267,056 samples, 0.16%)</title><rect x="2566.2" y="2441" width="6.5" height="19.0" fill="rgb(214,45,10)" rx="2" ry="2" />
+<text  x="2569.17" y="2453.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (6,880,497,771 samples, 1.08%)</title><rect x="309.1" y="861" width="45.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="312.08" y="873.5" >exec..</text>
+</g>
+<g >
+<title>execute_command_internal (322,256,264 samples, 0.05%)</title><rect x="868.7" y="1101" width="2.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="871.70" y="1113.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (192,670,319 samples, 0.03%)</title><rect x="837.6" y="921" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="840.55" y="933.5" ></text>
+</g>
+<g >
+<title>_IO_doallocbuf (728,279,237 samples, 0.11%)</title><rect x="1438.2" y="2401" width="4.7" height="19.0" fill="rgb(214,45,10)" rx="2" ry="2" />
+<text  x="1441.16" y="2413.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,146,830,397 samples, 0.18%)</title><rect x="827.6" y="741" width="7.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.59" y="753.5" ></text>
+</g>
+<g >
+<title>parse_and_execute (849,509,116 samples, 0.13%)</title><rect x="895.3" y="2581" width="5.6" height="19.0" fill="rgb(243,178,42)" rx="2" ry="2" />
+<text  x="898.35" y="2593.5" ></text>
+</g>
+<g >
+<title>exc_page_fault (184,185,848 samples, 0.03%)</title><rect x="590.9" y="1281" width="1.2" height="19.0" fill="rgb(219,65,15)" rx="2" ry="2" />
+<text  x="593.89" y="1293.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,142,026,027 samples, 0.18%)</title><rect x="827.6" y="421" width="7.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.59" y="433.5" ></text>
+</g>
+<g >
+<title>[bash] (1,375,575,314 samples, 0.22%)</title><rect x="534.9" y="1181" width="9.0" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="537.90" y="1193.5" ></text>
+</g>
+<g >
+<title>mapfile_builtin (847,979,396 samples, 0.13%)</title><rect x="365.6" y="201" width="5.6" height="19.0" fill="rgb(205,1,0)" rx="2" ry="2" />
+<text  x="368.64" y="213.5" ></text>
+</g>
+<g >
+<title>execute_command (1,150,422,968 samples, 0.18%)</title><rect x="827.6" y="1681" width="7.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="830.57" y="1693.5" ></text>
+</g>
+<g >
+<title>__fput (190,645,609 samples, 0.03%)</title><rect x="2606.5" y="2381" width="1.2" height="19.0" fill="rgb(205,0,0)" rx="2" ry="2" />
+<text  x="2609.47" y="2393.5" ></text>
+</g>
+<g >
+<title>execute_command (215,748,926 samples, 0.03%)</title><rect x="842.8" y="1821" width="1.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="845.80" y="1833.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (5,497,500,922 samples, 0.86%)</title><rect x="3950.7" y="2441" width="36.0" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="3953.68" y="2453.5" >ent..</text>
+</g>
+<g >
+<title>[sha512sum] (17,661,009,092 samples, 2.77%)</title><rect x="3309.9" y="2581" width="115.6" height="19.0" fill="rgb(248,201,48)" rx="2" ry="2" />
+<text  x="3312.89" y="2593.5" >[sha512sum]</text>
+</g>
+<g >
+<title>entry_SYSRETQ_unsafe_stack (166,625,106 samples, 0.03%)</title><rect x="3341.7" y="2401" width="1.0" height="19.0" fill="rgb(213,37,8)" rx="2" ry="2" />
+<text  x="3344.66" y="2413.5" ></text>
+</g>
+<g >
+<title>execute_command (713,521,499 samples, 0.11%)</title><rect x="296.5" y="2301" width="4.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="299.45" y="2313.5" ></text>
+</g>
+<g >
+<title>__x64_sys_openat (262,847,942 samples, 0.04%)</title><rect x="320.0" y="461" width="1.7" height="19.0" fill="rgb(208,15,3)" rx="2" ry="2" />
+<text  x="322.97" y="473.5" ></text>
+</g>
+<g >
+<title>execute_command (891,895,571 samples, 0.14%)</title><rect x="851.1" y="1501" width="5.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="854.08" y="1513.5" ></text>
+</g>
+<g >
+<title>execute_command (354,938,381 samples, 0.06%)</title><rect x="840.5" y="901" width="2.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="843.48" y="913.5" ></text>
+</g>
+<g >
+<title>shmem_file_read_iter (221,109,922 samples, 0.03%)</title><rect x="499.2" y="961" width="1.5" height="19.0" fill="rgb(238,152,36)" rx="2" ry="2" />
+<text  x="502.21" y="973.5" ></text>
+</g>
+<g >
+<title>[sha224sum] (9,605,886,408 samples, 1.50%)</title><rect x="2124.0" y="2501" width="62.9" height="19.0" fill="rgb(248,201,48)" rx="2" ry="2" />
+<text  x="2127.03" y="2513.5" >[sha22..</text>
+</g>
+<g >
+<title>execute_command_internal (717,313,739 samples, 0.11%)</title><rect x="280.1" y="2541" width="4.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.09" y="2553.5" ></text>
+</g>
+<g >
+<title>_IO_file_xsputn@@GLIBC_2.2.5 (287,444,466 samples, 0.05%)</title><rect x="3412.0" y="2421" width="1.9" height="19.0" fill="rgb(242,171,41)" rx="2" ry="2" />
+<text  x="3415.02" y="2433.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (554,006,342 samples, 0.09%)</title><rect x="273.3" y="1721" width="3.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="276.29" y="1733.5" ></text>
+</g>
+<g >
+<title>do_redirections (511,071,965 samples, 0.08%)</title><rect x="885.1" y="461" width="3.3" height="19.0" fill="rgb(247,193,46)" rx="2" ry="2" />
+<text  x="888.05" y="473.5" ></text>
+</g>
+<g >
+<title>do_redirections (354,911,948 samples, 0.06%)</title><rect x="840.5" y="781" width="2.3" height="19.0" fill="rgb(247,193,46)" rx="2" ry="2" />
+<text  x="843.48" y="793.5" ></text>
+</g>
+<g >
+<title>execute_command (700,045,805 samples, 0.11%)</title><rect x="280.1" y="461" width="4.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="283.11" y="473.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,150,422,968 samples, 0.18%)</title><rect x="827.6" y="1461" width="7.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.57" y="1473.5" ></text>
+</g>
+<g >
+<title>flush_tlb_func (201,290,853 samples, 0.03%)</title><rect x="771.1" y="1141" width="1.3" height="19.0" fill="rgb(220,71,17)" rx="2" ry="2" />
+<text  x="774.12" y="1153.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (554,006,342 samples, 0.09%)</title><rect x="273.3" y="1641" width="3.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="276.29" y="1653.5" ></text>
+</g>
+<g >
+<title>error_entry (169,284,813 samples, 0.03%)</title><rect x="740.9" y="1241" width="1.1" height="19.0" fill="rgb(247,193,46)" rx="2" ry="2" />
+<text  x="743.89" y="1253.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (239,498,748 samples, 0.04%)</title><rect x="1439.4" y="2341" width="1.6" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="1442.41" y="2353.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (175,601,700 samples, 0.03%)</title><rect x="860.3" y="321" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.32" y="333.5" ></text>
+</g>
+<g >
+<title>__strchr_evex (233,847,280 samples, 0.04%)</title><rect x="578.7" y="1281" width="1.5" height="19.0" fill="rgb(253,223,53)" rx="2" ry="2" />
+<text  x="581.65" y="1293.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (866,614,713 samples, 0.14%)</title><rect x="301.1" y="2221" width="5.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.12" y="2233.5" ></text>
+</g>
+<g >
+<title>execute_command (275,670,705 samples, 0.04%)</title><rect x="827.6" y="361" width="1.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="830.59" y="373.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,150,422,968 samples, 0.18%)</title><rect x="827.6" y="2061" width="7.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.57" y="2073.5" ></text>
+</g>
+<g >
+<title>redirection_expand (305,535,030 samples, 0.05%)</title><rect x="868.8" y="481" width="2.0" height="19.0" fill="rgb(218,63,15)" rx="2" ry="2" />
+<text  x="871.80" y="493.5" ></text>
+</g>
+<g >
+<title>_int_malloc (808,785,883 samples, 0.13%)</title><rect x="552.6" y="1161" width="5.3" height="19.0" fill="rgb(215,47,11)" rx="2" ry="2" />
+<text  x="555.62" y="1173.5" ></text>
+</g>
+<g >
+<title>perf_try_init_event (173,644,855 samples, 0.03%)</title><rect x="273.9" y="141" width="1.1" height="19.0" fill="rgb(246,191,45)" rx="2" ry="2" />
+<text  x="276.88" y="153.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (550,598,300 samples, 0.09%)</title><rect x="273.3" y="841" width="3.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="276.32" y="853.5" ></text>
+</g>
+<g >
+<title>expand_string_assignment (158,810,219 samples, 0.02%)</title><rect x="334.6" y="461" width="1.0" height="19.0" fill="rgb(235,141,33)" rx="2" ry="2" />
+<text  x="337.57" y="473.5" ></text>
+</g>
+<g >
+<title>execute_command (179,777,548 samples, 0.03%)</title><rect x="878.5" y="1441" width="1.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="881.48" y="1453.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (483,985,097 samples, 0.08%)</title><rect x="276.9" y="1841" width="3.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="279.92" y="1853.5" ></text>
+</g>
+<g >
+<title>execute_command (713,462,810 samples, 0.11%)</title><rect x="280.1" y="741" width="4.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="283.11" y="753.5" ></text>
+</g>
+<g >
+<title>[bash] (159,978,148 samples, 0.03%)</title><rect x="389.3" y="421" width="1.0" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="392.29" y="433.5" ></text>
+</g>
+<g >
+<title>entry_SYSRETQ_unsafe_stack (820,908,242 samples, 0.13%)</title><rect x="4106.7" y="2421" width="5.4" height="19.0" fill="rgb(213,37,8)" rx="2" ry="2" />
+<text  x="4109.72" y="2433.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (685,976,378 samples, 0.11%)</title><rect x="268.8" y="781" width="4.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="271.79" y="793.5" ></text>
+</g>
+<g >
+<title>malloc (412,841,490 samples, 0.06%)</title><rect x="632.2" y="1261" width="2.7" height="19.0" fill="rgb(230,119,28)" rx="2" ry="2" />
+<text  x="635.21" y="1273.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (194,148,063 samples, 0.03%)</title><rect x="837.5" y="1641" width="1.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="840.54" y="1653.5" ></text>
+</g>
+<g >
+<title>_IO_doallocbuf (761,214,797 samples, 0.12%)</title><rect x="1609.6" y="2441" width="5.0" height="19.0" fill="rgb(214,45,10)" rx="2" ry="2" />
+<text  x="1612.61" y="2453.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (596,118,643 samples, 0.09%)</title><rect x="891.4" y="1181" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.42" y="1193.5" ></text>
+</g>
+<g >
+<title>execute_command (866,614,713 samples, 0.14%)</title><rect x="301.1" y="1721" width="5.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="304.12" y="1733.5" ></text>
+</g>
+<g >
+<title>[libcrypto.so.3.2.2] (30,175,882,715 samples, 4.73%)</title><rect x="3107.2" y="2561" width="197.6" height="19.0" fill="rgb(244,181,43)" rx="2" ry="2" />
+<text  x="3110.23" y="2573.5" >[libcrypto.so.3.2.2]</text>
+</g>
+<g >
+<title>execute_command_internal (575,800,354 samples, 0.09%)</title><rect x="884.6" y="1381" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="887.64" y="1393.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (688,777,208 samples, 0.11%)</title><rect x="268.8" y="2341" width="4.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="271.77" y="2353.5" ></text>
+</g>
+<g >
+<title>[bash] (1,504,027,298 samples, 0.24%)</title><rect x="789.6" y="1421" width="9.9" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="792.64" y="1433.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (214,645,250 samples, 0.03%)</title><rect x="1530.7" y="2401" width="1.4" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="1533.73" y="2413.5" ></text>
+</g>
+<g >
+<title>execute_command (512,251,839 samples, 0.08%)</title><rect x="856.9" y="721" width="3.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="859.94" y="733.5" ></text>
+</g>
+<g >
+<title>_IO_file_fopen@@GLIBC_2.2.5 (3,399,134,835 samples, 0.53%)</title><rect x="2021.3" y="2441" width="22.2" height="19.0" fill="rgb(237,148,35)" rx="2" ry="2" />
+<text  x="2024.27" y="2453.5" >_..</text>
+</g>
+<g >
+<title>execute_command_internal (354,998,378 samples, 0.06%)</title><rect x="840.5" y="1241" width="2.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="843.48" y="1253.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (551,359,579 samples, 0.09%)</title><rect x="273.3" y="1581" width="3.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="276.31" y="1593.5" ></text>
+</g>
+<g >
+<title>filemap_get_entry (231,998,608 samples, 0.04%)</title><rect x="216.4" y="2301" width="1.5" height="19.0" fill="rgb(253,222,53)" rx="2" ry="2" />
+<text  x="219.40" y="2313.5" ></text>
+</g>
+<g >
+<title>do_user_addr_fault (521,868,456 samples, 0.08%)</title><rect x="724.6" y="1221" width="3.4" height="19.0" fill="rgb(235,138,33)" rx="2" ry="2" />
+<text  x="727.61" y="1233.5" ></text>
+</g>
+<g >
+<title>execute_command (513,428,353 samples, 0.08%)</title><rect x="856.9" y="1161" width="3.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="859.94" y="1173.5" ></text>
+</g>
+<g >
+<title>rep_movs_alternative (1,510,712,224 samples, 0.24%)</title><rect x="1512.5" y="2281" width="9.8" height="19.0" fill="rgb(211,31,7)" rx="2" ry="2" />
+<text  x="1515.45" y="2293.5" ></text>
+</g>
+<g >
+<title>[bash] (240,043,669 samples, 0.04%)</title><rect x="325.3" y="541" width="1.6" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="328.30" y="553.5" ></text>
+</g>
+<g >
+<title>[bash] (717,313,739 samples, 0.11%)</title><rect x="280.1" y="2381" width="4.7" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="283.09" y="2393.5" ></text>
+</g>
+<g >
+<title>cfree@GLIBC_2.2.5 (510,695,098 samples, 0.08%)</title><rect x="608.8" y="1301" width="3.4" height="19.0" fill="rgb(233,131,31)" rx="2" ry="2" />
+<text  x="611.82" y="1313.5" ></text>
+</g>
+<g >
+<title>alloc_empty_file (160,091,154 samples, 0.03%)</title><rect x="2024.1" y="2261" width="1.1" height="19.0" fill="rgb(215,49,11)" rx="2" ry="2" />
+<text  x="2027.10" y="2273.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (171,847,094 samples, 0.03%)</title><rect x="871.9" y="1581" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="874.89" y="1593.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,261,568,072 samples, 0.20%)</title><rect x="860.3" y="1321" width="8.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.31" y="1333.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (516,725,798 samples, 0.08%)</title><rect x="856.9" y="1981" width="3.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="859.92" y="1993.5" ></text>
+</g>
+<g >
+<title>x86_pmu_event_init (173,644,855 samples, 0.03%)</title><rect x="273.9" y="121" width="1.1" height="19.0" fill="rgb(216,51,12)" rx="2" ry="2" />
+<text  x="276.88" y="133.5" ></text>
+</g>
+<g >
+<title>syscall_return_via_sysret (383,301,279 samples, 0.06%)</title><rect x="3068.3" y="2441" width="2.5" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="3071.31" y="2453.5" ></text>
+</g>
+<g >
+<title>execute_command (513,428,353 samples, 0.08%)</title><rect x="856.9" y="1001" width="3.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="859.94" y="1013.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (554,006,342 samples, 0.09%)</title><rect x="273.3" y="1601" width="3.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="276.29" y="1613.5" ></text>
+</g>
+<g >
+<title>__vfprintf_internal (1,546,399,747 samples, 0.24%)</title><rect x="2100.0" y="2481" width="10.1" height="19.0" fill="rgb(232,125,30)" rx="2" ry="2" />
+<text  x="2102.96" y="2493.5" ></text>
+</g>
+<g >
+<title>[bash] (194,148,063 samples, 0.03%)</title><rect x="837.5" y="1501" width="1.3" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="840.54" y="1513.5" ></text>
+</g>
+<g >
+<title>__GI___execve (1,260,500,822 samples, 0.20%)</title><rect x="288.1" y="2581" width="8.2" height="19.0" fill="rgb(230,117,28)" rx="2" ry="2" />
+<text  x="291.10" y="2593.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (169,122,730 samples, 0.03%)</title><rect x="835.3" y="401" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="838.33" y="413.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (13,306,993,942 samples, 2.08%)</title><rect x="307.9" y="1761" width="87.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="310.94" y="1773.5" >execute_co..</text>
+</g>
+<g >
+<title>[bash] (179,777,548 samples, 0.03%)</title><rect x="878.5" y="741" width="1.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="881.48" y="753.5" ></text>
+</g>
+<g >
+<title>execute_command (7,350,366,841 samples, 1.15%)</title><rect x="307.9" y="1301" width="48.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="310.95" y="1313.5" >exec..</text>
+</g>
+<g >
+<title>execute_command (1,281,803,985 samples, 0.20%)</title><rect x="868.6" y="1921" width="8.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="871.57" y="1933.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (849,509,116 samples, 0.13%)</title><rect x="895.3" y="1461" width="5.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.35" y="1473.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (194,148,063 samples, 0.03%)</title><rect x="837.5" y="1461" width="1.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="840.54" y="1473.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (840,181,758 samples, 0.13%)</title><rect x="895.4" y="541" width="5.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.39" y="553.5" ></text>
+</g>
+<g >
+<title>load_elf_binary (1,260,500,822 samples, 0.20%)</title><rect x="288.1" y="2461" width="8.2" height="19.0" fill="rgb(229,113,27)" rx="2" ry="2" />
+<text  x="291.10" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (354,938,381 samples, 0.06%)</title><rect x="840.5" y="961" width="2.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="843.48" y="973.5" ></text>
+</g>
+<g >
+<title>_dl_relocate_object (285,050,168 samples, 0.04%)</title><rect x="1844.4" y="2501" width="1.9" height="19.0" fill="rgb(231,120,28)" rx="2" ry="2" />
+<text  x="1847.43" y="2513.5" ></text>
+</g>
+<g >
+<title>execute_command (1,119,099,207 samples, 0.18%)</title><rect x="399.9" y="1101" width="7.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="402.91" y="1113.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (17,266,332,715 samples, 2.70%)</title><rect x="398.4" y="1361" width="113.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="401.38" y="1373.5" >execute_comma..</text>
+</g>
+<g >
+<title>__x64_sys_exit_group (2,964,126,674 samples, 0.46%)</title><rect x="808.2" y="2521" width="19.4" height="19.0" fill="rgb(220,72,17)" rx="2" ry="2" />
+<text  x="811.16" y="2533.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (164,731,865 samples, 0.03%)</title><rect x="836.5" y="1041" width="1.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="839.46" y="1053.5" ></text>
+</g>
+<g >
+<title>dispose_command (278,788,607 samples, 0.04%)</title><rect x="840.5" y="381" width="1.8" height="19.0" fill="rgb(248,201,48)" rx="2" ry="2" />
+<text  x="843.48" y="393.5" ></text>
+</g>
+<g >
+<title>__printf_buffer_write (171,036,566 samples, 0.03%)</title><rect x="2631.3" y="2441" width="1.1" height="19.0" fill="rgb(220,73,17)" rx="2" ry="2" />
+<text  x="2634.30" y="2453.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (574,909,828 samples, 0.09%)</title><rect x="884.6" y="641" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="887.64" y="653.5" ></text>
+</g>
+<g >
+<title>[bash] (937,748,185 samples, 0.15%)</title><rect x="651.3" y="1281" width="6.1" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="654.30" y="1293.5" ></text>
+</g>
+<g >
+<title>[bash] (603,874,522 samples, 0.09%)</title><rect x="302.6" y="221" width="3.9" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="305.57" y="233.5" ></text>
+</g>
+<g >
+<title>execute_command (164,808,262 samples, 0.03%)</title><rect x="870.8" y="1321" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="873.81" y="1333.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,261,220,789 samples, 0.20%)</title><rect x="860.3" y="721" width="8.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.32" y="733.5" ></text>
+</g>
+<g >
+<title>kernel_clone (268,202,598 samples, 0.04%)</title><rect x="830.7" y="121" width="1.8" height="19.0" fill="rgb(248,199,47)" rx="2" ry="2" />
+<text  x="833.73" y="133.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (598,514,664 samples, 0.09%)</title><rect x="891.4" y="1941" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.40" y="1953.5" ></text>
+</g>
+<g >
+<title>execute_command (717,313,739 samples, 0.11%)</title><rect x="280.1" y="1541" width="4.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="283.09" y="1553.5" ></text>
+</g>
+<g >
+<title>_IO_doallocbuf (973,775,210 samples, 0.15%)</title><rect x="2044.6" y="2441" width="6.4" height="19.0" fill="rgb(214,45,10)" rx="2" ry="2" />
+<text  x="2047.63" y="2453.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (159,710,185 samples, 0.03%)</title><rect x="875.9" y="1621" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="878.92" y="1633.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (203,048,745 samples, 0.03%)</title><rect x="833.2" y="161" width="1.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="836.18" y="173.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (170,489,782 samples, 0.03%)</title><rect x="871.9" y="981" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="874.90" y="993.5" ></text>
+</g>
+<g >
+<title>list_string (3,820,381,887 samples, 0.60%)</title><rect x="559.4" y="1301" width="25.1" height="19.0" fill="rgb(248,201,48)" rx="2" ry="2" />
+<text  x="562.44" y="1313.5" >l..</text>
+</g>
+<g >
+<title>execute_command_internal (192,670,319 samples, 0.03%)</title><rect x="837.6" y="1201" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="840.55" y="1213.5" ></text>
+</g>
+<g >
+<title>execute_command (891,895,571 samples, 0.14%)</title><rect x="851.1" y="2021" width="5.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="854.08" y="2033.5" ></text>
+</g>
+<g >
+<title>execute_command (549,214,247 samples, 0.09%)</title><rect x="273.3" y="781" width="3.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="276.32" y="793.5" ></text>
+</g>
+<g >
+<title>__vfprintf_internal (494,581,932 samples, 0.08%)</title><rect x="3996.6" y="2461" width="3.3" height="19.0" fill="rgb(232,125,30)" rx="2" ry="2" />
+<text  x="3999.64" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (215,748,926 samples, 0.03%)</title><rect x="842.8" y="1761" width="1.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="845.80" y="1773.5" ></text>
+</g>
+<g >
+<title>syscall_return_via_sysret (444,426,967 samples, 0.07%)</title><rect x="2174.8" y="2441" width="3.0" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="2177.84" y="2453.5" ></text>
+</g>
+<g >
+<title>execute_command (550,598,300 samples, 0.09%)</title><rect x="273.3" y="1141" width="3.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="276.32" y="1153.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (713,521,499 samples, 0.11%)</title><rect x="296.5" y="1521" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.45" y="1533.5" ></text>
+</g>
+<g >
+<title>__x64_sys_close (481,256,005 samples, 0.08%)</title><rect x="1551.1" y="2401" width="3.2" height="19.0" fill="rgb(238,153,36)" rx="2" ry="2" />
+<text  x="1554.15" y="2413.5" ></text>
+</g>
+<g >
+<title>[bash] (278,021,182 samples, 0.04%)</title><rect x="858.4" y="301" width="1.8" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="861.37" y="313.5" ></text>
+</g>
+<g >
+<title>get_arg_page (382,326,578 samples, 0.06%)</title><rect x="667.4" y="1221" width="2.5" height="19.0" fill="rgb(229,111,26)" rx="2" ry="2" />
+<text  x="670.40" y="1233.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (688,777,208 samples, 0.11%)</title><rect x="268.8" y="2061" width="4.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="271.77" y="2073.5" ></text>
+</g>
+<g >
+<title>inherit_event.isra.0 (462,691,420 samples, 0.07%)</title><rect x="703.5" y="1141" width="3.0" height="19.0" fill="rgb(213,38,9)" rx="2" ry="2" />
+<text  x="706.51" y="1153.5" ></text>
+</g>
+<g >
+<title>__x64_sys_pselect6 (207,442,719 samples, 0.03%)</title><rect x="313.1" y="401" width="1.3" height="19.0" fill="rgb(231,120,28)" rx="2" ry="2" />
+<text  x="316.08" y="413.5" ></text>
+</g>
+<g >
+<title>memset_orig (244,755,163 samples, 0.04%)</title><rect x="4142.1" y="2281" width="1.6" height="19.0" fill="rgb(253,224,53)" rx="2" ry="2" />
+<text  x="4145.06" y="2293.5" ></text>
+</g>
+<g >
+<title>llseek@GLIBC_2.2.5 (522,137,006 samples, 0.08%)</title><rect x="1643.5" y="2481" width="3.4" height="19.0" fill="rgb(239,156,37)" rx="2" ry="2" />
+<text  x="1646.53" y="2493.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (436,055,112 samples, 0.07%)</title><rect x="888.5" y="1621" width="2.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="891.55" y="1633.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (575,055,300 samples, 0.09%)</title><rect x="884.6" y="921" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="887.64" y="933.5" ></text>
+</g>
+<g >
+<title>execute_command (1,150,422,968 samples, 0.18%)</title><rect x="827.6" y="1561" width="7.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="830.57" y="1573.5" ></text>
+</g>
+<g >
+<title>do_filp_open (3,500,444,431 samples, 0.55%)</title><rect x="3906.6" y="2321" width="22.9" height="19.0" fill="rgb(217,58,13)" rx="2" ry="2" />
+<text  x="3909.62" y="2333.5" >d..</text>
+</g>
+<g >
+<title>__GI___libc_open (3,240,522,220 samples, 0.51%)</title><rect x="2022.2" y="2401" width="21.2" height="19.0" fill="rgb(249,202,48)" rx="2" ry="2" />
+<text  x="2025.18" y="2413.5" ></text>
+</g>
+<g >
+<title>vfs_read (3,167,964,872 samples, 0.50%)</title><rect x="2054.5" y="2381" width="20.8" height="19.0" fill="rgb(230,118,28)" rx="2" ry="2" />
+<text  x="2057.51" y="2393.5" ></text>
+</g>
+<g >
+<title>syscall_return_via_sysret (527,033,059 samples, 0.08%)</title><rect x="2601.0" y="2441" width="3.5" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="2604.03" y="2453.5" ></text>
+</g>
+<g >
+<title>execute_command (578,068,287 samples, 0.09%)</title><rect x="884.6" y="2221" width="3.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="887.62" y="2233.5" ></text>
+</g>
+<g >
+<title>syscall_return_via_sysret (165,664,027 samples, 0.03%)</title><rect x="2190.1" y="2421" width="1.1" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="2193.15" y="2433.5" ></text>
+</g>
+<g >
+<title>execute_command (195,267,188 samples, 0.03%)</title><rect x="835.2" y="981" width="1.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="838.18" y="993.5" ></text>
+</g>
+<g >
+<title>execute_command (158,599,791 samples, 0.02%)</title><rect x="875.9" y="961" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="878.93" y="973.5" ></text>
+</g>
+<g >
+<title>execute_command (1,261,220,789 samples, 0.20%)</title><rect x="860.3" y="781" width="8.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="863.32" y="793.5" ></text>
+</g>
+<g >
+<title>[bash] (520,910,609 samples, 0.08%)</title><rect x="897.3" y="261" width="3.4" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="900.29" y="273.5" ></text>
+</g>
+<g >
+<title>execute_command (889,118,394 samples, 0.14%)</title><rect x="851.1" y="621" width="5.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="854.09" y="633.5" ></text>
+</g>
+<g >
+<title>execute_command (849,509,116 samples, 0.13%)</title><rect x="895.3" y="1881" width="5.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="898.35" y="1893.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (849,509,116 samples, 0.13%)</title><rect x="895.3" y="2441" width="5.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.35" y="2453.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (268,212,480 samples, 0.04%)</title><rect x="830.7" y="161" width="1.8" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="833.73" y="173.5" ></text>
+</g>
+<g >
+<title>__fread_unlocked_chk (4,359,494,786 samples, 0.68%)</title><rect x="3042.3" y="2481" width="28.5" height="19.0" fill="rgb(225,94,22)" rx="2" ry="2" />
+<text  x="3045.28" y="2493.5" >__..</text>
+</g>
+<g >
+<title>memset_orig (281,103,504 samples, 0.04%)</title><rect x="3930.1" y="2281" width="1.8" height="19.0" fill="rgb(253,224,53)" rx="2" ry="2" />
+<text  x="3933.10" y="2293.5" ></text>
+</g>
+<g >
+<title>execute_command (164,731,865 samples, 0.03%)</title><rect x="836.5" y="1141" width="1.0" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="839.46" y="1153.5" ></text>
+</g>
+<g >
+<title>execute_command (322,256,264 samples, 0.05%)</title><rect x="868.7" y="881" width="2.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="871.70" y="893.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (474,271,348 samples, 0.07%)</title><rect x="276.9" y="481" width="3.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="279.94" y="493.5" ></text>
+</g>
+<g >
+<title>[bash] (62,817,680,020 samples, 9.84%)</title><rect x="395.1" y="1701" width="411.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="398.10" y="1713.5" >[bash]</text>
+</g>
+<g >
+<title>execute_command (685,976,378 samples, 0.11%)</title><rect x="268.8" y="761" width="4.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="271.79" y="773.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (5,310,879,119 samples, 0.83%)</title><rect x="359.1" y="801" width="34.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="362.15" y="813.5" >ex..</text>
+</g>
+<g >
+<title>asm_exc_page_fault (958,935,336 samples, 0.15%)</title><rect x="452.5" y="1021" width="6.3" height="19.0" fill="rgb(231,123,29)" rx="2" ry="2" />
+<text  x="455.53" y="1033.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (688,777,208 samples, 0.11%)</title><rect x="268.8" y="1661" width="4.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="271.77" y="1673.5" ></text>
+</g>
+<g >
+<title>do_redirections (157,778,539 samples, 0.02%)</title><rect x="513.7" y="1401" width="1.0" height="19.0" fill="rgb(247,193,46)" rx="2" ry="2" />
+<text  x="516.68" y="1413.5" ></text>
+</g>
+<g >
+<title>[bash] (164,808,262 samples, 0.03%)</title><rect x="870.8" y="1441" width="1.1" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="873.81" y="1453.5" ></text>
+</g>
+<g >
+<title>execute_command (171,847,094 samples, 0.03%)</title><rect x="871.9" y="1601" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="874.89" y="1613.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,861,037,088 samples, 0.29%)</title><rect x="835.1" y="2081" width="12.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="838.10" y="2093.5" ></text>
+</g>
+<g >
+<title>execute_command (713,521,499 samples, 0.11%)</title><rect x="296.5" y="1701" width="4.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="299.45" y="1713.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (192,670,319 samples, 0.03%)</title><rect x="837.6" y="1001" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="840.55" y="1013.5" ></text>
+</g>
+<g >
+<title>__memmove_evex_unaligned_erms (733,348,850 samples, 0.11%)</title><rect x="588.0" y="1321" width="4.8" height="19.0" fill="rgb(226,100,24)" rx="2" ry="2" />
+<text  x="591.01" y="1333.5" ></text>
+</g>
+<g >
+<title>__GI___libc_open (299,076,356 samples, 0.05%)</title><rect x="345.4" y="641" width="1.9" height="19.0" fill="rgb(249,202,48)" rx="2" ry="2" />
+<text  x="348.35" y="653.5" ></text>
+</g>
+<g >
+<title>execute_command (889,542,281 samples, 0.14%)</title><rect x="851.1" y="821" width="5.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="854.09" y="833.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (323,026,366 samples, 0.05%)</title><rect x="868.7" y="1361" width="2.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="871.70" y="1373.5" ></text>
+</g>
+<g >
+<title>execute_command (549,214,247 samples, 0.09%)</title><rect x="273.3" y="741" width="3.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="276.32" y="753.5" ></text>
+</g>
+<g >
+<title>execute_command (170,489,782 samples, 0.03%)</title><rect x="871.9" y="1041" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="874.90" y="1053.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (433,500,595 samples, 0.07%)</title><rect x="888.6" y="1221" width="2.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="891.56" y="1233.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (436,055,112 samples, 0.07%)</title><rect x="888.5" y="1741" width="2.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="891.55" y="1753.5" ></text>
+</g>
+<g >
+<title>dispose_command (278,740,081 samples, 0.04%)</title><rect x="840.5" y="301" width="1.8" height="19.0" fill="rgb(248,201,48)" rx="2" ry="2" />
+<text  x="843.48" y="313.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (595,672,870 samples, 0.09%)</title><rect x="891.4" y="621" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.42" y="633.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,145,785,833 samples, 0.18%)</title><rect x="827.6" y="581" width="7.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.59" y="593.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (2,512,564,094 samples, 0.39%)</title><rect x="3049.7" y="2421" width="16.4" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="3052.69" y="2433.5" ></text>
+</g>
+<g >
+<title>execute_command (861,612,432 samples, 0.13%)</title><rect x="301.2" y="921" width="5.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="304.16" y="933.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (164,808,262 samples, 0.03%)</title><rect x="870.8" y="1401" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="873.81" y="1413.5" ></text>
+</g>
+<g >
+<title>execute_command (578,068,287 samples, 0.09%)</title><rect x="884.6" y="1901" width="3.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="887.62" y="1913.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (354,998,378 samples, 0.06%)</title><rect x="840.5" y="1201" width="2.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="843.48" y="1213.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (481,191,724 samples, 0.08%)</title><rect x="276.9" y="1081" width="3.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="279.94" y="1093.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (179,777,548 samples, 0.03%)</title><rect x="878.5" y="1181" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="881.48" y="1193.5" ></text>
+</g>
+<g >
+<title>__close_nocancel (802,285,801 samples, 0.13%)</title><rect x="2083.0" y="2461" width="5.3" height="19.0" fill="rgb(228,109,26)" rx="2" ry="2" />
+<text  x="2086.02" y="2473.5" ></text>
+</g>
+<g >
+<title>__fopen_internal (3,713,243,302 samples, 0.58%)</title><rect x="3312.3" y="2461" width="24.3" height="19.0" fill="rgb(248,197,47)" rx="2" ry="2" />
+<text  x="3315.30" y="2473.5" >_..</text>
+</g>
+<g >
+<title>__printf_chk (2,112,287,621 samples, 0.33%)</title><rect x="1534.7" y="2481" width="13.9" height="19.0" fill="rgb(212,36,8)" rx="2" ry="2" />
+<text  x="1537.73" y="2493.5" ></text>
+</g>
+<g >
+<title>zreadc (2,972,436,131 samples, 0.47%)</title><rect x="481.8" y="1081" width="19.5" height="19.0" fill="rgb(224,89,21)" rx="2" ry="2" />
+<text  x="484.81" y="1093.5" ></text>
+</g>
+<g >
+<title>read (659,544,924 samples, 0.10%)</title><rect x="366.8" y="161" width="4.3" height="19.0" fill="rgb(252,216,51)" rx="2" ry="2" />
+<text  x="369.77" y="173.5" ></text>
+</g>
+<g >
+<title>execute_command (554,006,342 samples, 0.09%)</title><rect x="273.3" y="2101" width="3.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="276.29" y="2113.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (862,395,726 samples, 0.14%)</title><rect x="301.2" y="1281" width="5.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.15" y="1293.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (158,744,410 samples, 0.02%)</title><rect x="875.9" y="1421" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="878.93" y="1433.5" ></text>
+</g>
+<g >
+<title>execute_command (195,267,188 samples, 0.03%)</title><rect x="835.2" y="1141" width="1.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="838.18" y="1153.5" ></text>
+</g>
+<g >
+<title>execute_command (354,998,378 samples, 0.06%)</title><rect x="840.5" y="1301" width="2.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="843.48" y="1313.5" ></text>
+</g>
+<g >
+<title>copy_page_range (766,281,559 samples, 0.12%)</title><rect x="697.0" y="1181" width="5.0" height="19.0" fill="rgb(221,76,18)" rx="2" ry="2" />
+<text  x="700.01" y="1193.5" ></text>
+</g>
+<g >
+<title>[bash] (516,944,898 samples, 0.08%)</title><rect x="273.5" y="421" width="3.4" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="276.52" y="433.5" ></text>
+</g>
+<g >
+<title>execute_command (891,895,571 samples, 0.14%)</title><rect x="851.1" y="1781" width="5.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="854.08" y="1793.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (436,055,112 samples, 0.07%)</title><rect x="888.5" y="1781" width="2.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="891.55" y="1793.5" ></text>
+</g>
+<g >
+<title>_dl_sysdep_start (696,170,864 samples, 0.11%)</title><rect x="3681.5" y="2541" width="4.6" height="19.0" fill="rgb(234,137,32)" rx="2" ry="2" />
+<text  x="3684.54" y="2553.5" ></text>
+</g>
+<g >
+<title>parse_and_execute (192,137,391 samples, 0.03%)</title><rect x="282.7" y="181" width="1.3" height="19.0" fill="rgb(243,178,42)" rx="2" ry="2" />
+<text  x="285.73" y="193.5" ></text>
+</g>
+<g >
+<title>may_open (246,975,643 samples, 0.04%)</title><rect x="1485.7" y="2261" width="1.6" height="19.0" fill="rgb(240,162,38)" rx="2" ry="2" />
+<text  x="1488.66" y="2273.5" ></text>
+</g>
+<g >
+<title>execute_command (575,800,354 samples, 0.09%)</title><rect x="884.6" y="1521" width="3.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="887.64" y="1533.5" ></text>
+</g>
+<g >
+<title>__x64_sys_openat (3,522,595,324 samples, 0.55%)</title><rect x="4121.6" y="2361" width="23.0" height="19.0" fill="rgb(208,15,3)" rx="2" ry="2" />
+<text  x="4124.55" y="2373.5" >_..</text>
+</g>
+<g >
+<title>execute_command (595,672,870 samples, 0.09%)</title><rect x="891.4" y="841" width="3.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="894.42" y="853.5" ></text>
+</g>
+<g >
+<title>execute_command (688,777,208 samples, 0.11%)</title><rect x="268.8" y="2001" width="4.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="271.77" y="2013.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (595,672,870 samples, 0.09%)</title><rect x="891.4" y="581" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.42" y="593.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (3,599,918,186 samples, 0.56%)</title><rect x="4121.3" y="2381" width="23.6" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="4124.34" y="2393.5" >d..</text>
+</g>
+<g >
+<title>__x64_sys_openat (4,191,337,254 samples, 0.66%)</title><rect x="3905.8" y="2361" width="27.4" height="19.0" fill="rgb(208,15,3)" rx="2" ry="2" />
+<text  x="3908.80" y="2373.5" >_..</text>
+</g>
+<g >
+<title>execute_command (164,808,262 samples, 0.03%)</title><rect x="870.8" y="1361" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="873.81" y="1373.5" ></text>
+</g>
+<g >
+<title>execute_command (1,259,613,163 samples, 0.20%)</title><rect x="860.3" y="581" width="8.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="863.32" y="593.5" ></text>
+</g>
+<g >
+<title>execute_command (575,800,354 samples, 0.09%)</title><rect x="884.6" y="1261" width="3.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="887.64" y="1273.5" ></text>
+</g>
+<g >
+<title>_int_free (233,111,900 samples, 0.04%)</title><rect x="690.2" y="1301" width="1.5" height="19.0" fill="rgb(247,196,46)" rx="2" ry="2" />
+<text  x="693.16" y="1313.5" ></text>
+</g>
+<g >
+<title>[sum] (51,719,066,479 samples, 8.10%)</title><rect x="3687.1" y="2581" width="338.5" height="19.0" fill="rgb(222,78,18)" rx="2" ry="2" />
+<text  x="3690.08" y="2593.5" >[sum]</text>
+</g>
+<g >
+<title>execute_command (354,998,378 samples, 0.06%)</title><rect x="840.5" y="1341" width="2.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="843.48" y="1353.5" ></text>
+</g>
+<g >
+<title>do_execveat_common.isra.0 (1,609,921,722 samples, 0.25%)</title><rect x="662.1" y="1261" width="10.5" height="19.0" fill="rgb(238,153,36)" rx="2" ry="2" />
+<text  x="665.08" y="1273.5" ></text>
+</g>
+<g >
+<title>__vfprintf_internal (2,466,305,612 samples, 0.39%)</title><rect x="3086.7" y="2481" width="16.1" height="19.0" fill="rgb(232,125,30)" rx="2" ry="2" />
+<text  x="3089.66" y="2493.5" ></text>
+</g>
+<g >
+<title>[bash] (596,118,643 samples, 0.09%)</title><rect x="891.4" y="1141" width="3.9" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="894.42" y="1153.5" ></text>
+</g>
+<g >
+<title>[bash] (155,807,032 samples, 0.02%)</title><rect x="836.5" y="401" width="1.0" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="839.51" y="413.5" ></text>
+</g>
+<g >
+<title>[bash] (305,961,079 samples, 0.05%)</title><rect x="868.8" y="541" width="2.0" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="871.80" y="553.5" ></text>
+</g>
+<g >
+<title>execute_command (13,300,839,577 samples, 2.08%)</title><rect x="307.9" y="1421" width="87.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="310.94" y="1433.5" >execute_co..</text>
+</g>
+<g >
+<title>execute_command_internal (356,134,455 samples, 0.06%)</title><rect x="840.5" y="1801" width="2.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="843.47" y="1813.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (578,068,287 samples, 0.09%)</title><rect x="884.6" y="1801" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="887.62" y="1813.5" ></text>
+</g>
+<g >
+<title>malloc_consolidate (263,893,332 samples, 0.04%)</title><rect x="648.3" y="1261" width="1.8" height="19.0" fill="rgb(239,159,38)" rx="2" ry="2" />
+<text  x="651.33" y="1273.5" ></text>
+</g>
+<g >
+<title>redirection_expand (343,414,451 samples, 0.05%)</title><rect x="889.1" y="401" width="2.3" height="19.0" fill="rgb(218,63,15)" rx="2" ry="2" />
+<text  x="892.10" y="413.5" ></text>
+</g>
+<g >
+<title>execute_command (190,829,147 samples, 0.03%)</title><rect x="837.6" y="781" width="1.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="840.55" y="793.5" ></text>
+</g>
+<g >
+<title>malloc (466,412,394 samples, 0.07%)</title><rect x="575.1" y="1241" width="3.1" height="19.0" fill="rgb(230,119,28)" rx="2" ry="2" />
+<text  x="578.11" y="1253.5" ></text>
+</g>
+<g >
+<title>array_to_word_list (1,514,047,593 samples, 0.24%)</title><rect x="518.7" y="1221" width="9.9" height="19.0" fill="rgb(211,32,7)" rx="2" ry="2" />
+<text  x="521.70" y="1233.5" ></text>
+</g>
+<g >
+<title>read (154,749,791 samples, 0.02%)</title><rect x="405.5" y="981" width="1.0" height="19.0" fill="rgb(252,216,51)" rx="2" ry="2" />
+<text  x="408.50" y="993.5" ></text>
+</g>
+<g >
+<title>[xxhsum] (23,191,387,213 samples, 3.63%)</title><rect x="4033.7" y="2521" width="151.8" height="19.0" fill="rgb(249,206,49)" rx="2" ry="2" />
+<text  x="4036.66" y="2533.5" >[xxhsum]</text>
+</g>
+<g >
+<title>execute_command_internal (513,428,353 samples, 0.08%)</title><rect x="856.9" y="861" width="3.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="859.94" y="873.5" ></text>
+</g>
+<g >
+<title>kmem_cache_alloc_noprof (239,168,701 samples, 0.04%)</title><rect x="3330.9" y="2281" width="1.6" height="19.0" fill="rgb(205,0,0)" rx="2" ry="2" />
+<text  x="3333.94" y="2293.5" ></text>
+</g>
+<g >
+<title>execute_command (516,725,798 samples, 0.08%)</title><rect x="856.9" y="2361" width="3.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="859.92" y="2373.5" ></text>
+</g>
+<g >
+<title>md5sum (39,385,977,143 samples, 6.17%)</title><rect x="1589.5" y="2601" width="257.8" height="19.0" fill="rgb(218,60,14)" rx="2" ry="2" />
+<text  x="1592.47" y="2613.5" >md5sum</text>
+</g>
+<g >
+<title>__pselect (240,302,871 samples, 0.04%)</title><rect x="313.0" y="461" width="1.6" height="19.0" fill="rgb(228,107,25)" rx="2" ry="2" />
+<text  x="316.01" y="473.5" ></text>
+</g>
+<g >
+<title>execute_command (713,987,302 samples, 0.11%)</title><rect x="280.1" y="1361" width="4.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="283.11" y="1373.5" ></text>
+</g>
+<g >
+<title>execute_command (163,954,022 samples, 0.03%)</title><rect x="870.8" y="1201" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="873.82" y="1213.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,263,560,140 samples, 0.20%)</title><rect x="860.3" y="2481" width="8.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.30" y="2493.5" ></text>
+</g>
+<g >
+<title>[bash] (511,047,796 samples, 0.08%)</title><rect x="885.1" y="441" width="3.3" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="888.05" y="453.5" ></text>
+</g>
+<g >
+<title>[bash] (168,762,684 samples, 0.03%)</title><rect x="835.3" y="361" width="1.1" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="838.33" y="373.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (680,229,498 samples, 0.11%)</title><rect x="268.8" y="541" width="4.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="271.79" y="553.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (436,055,112 samples, 0.07%)</title><rect x="888.5" y="2341" width="2.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="891.55" y="2353.5" ></text>
+</g>
+<g >
+<title>__vfprintf_internal (200,389,712 samples, 0.03%)</title><rect x="4054.5" y="2441" width="1.3" height="19.0" fill="rgb(232,125,30)" rx="2" ry="2" />
+<text  x="4057.45" y="2453.5" ></text>
+</g>
+<g >
+<title>shmem_get_folio_gfp (654,788,636 samples, 0.10%)</title><rect x="4100.5" y="2321" width="4.2" height="19.0" fill="rgb(219,67,16)" rx="2" ry="2" />
+<text  x="4103.46" y="2333.5" ></text>
+</g>
+<g >
+<title>execute_command (1,150,422,968 samples, 0.18%)</title><rect x="827.6" y="2361" width="7.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="830.57" y="2373.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (322,256,264 samples, 0.05%)</title><rect x="868.7" y="1061" width="2.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="871.70" y="1073.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (695,772,580 samples, 0.11%)</title><rect x="296.5" y="401" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.51" y="413.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (849,509,116 samples, 0.13%)</title><rect x="895.3" y="2301" width="5.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.35" y="2313.5" ></text>
+</g>
+<g >
+<title>execute_command (713,521,499 samples, 0.11%)</title><rect x="296.5" y="1821" width="4.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="299.45" y="1833.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (704,492,242 samples, 0.11%)</title><rect x="296.5" y="921" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.51" y="933.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (181,373,291 samples, 0.03%)</title><rect x="273.8" y="301" width="1.2" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="276.84" y="313.5" ></text>
+</g>
+<g >
+<title>execute_command (13,305,835,469 samples, 2.08%)</title><rect x="307.9" y="1661" width="87.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="310.94" y="1673.5" >execute_co..</text>
+</g>
+<g >
+<title>execute_command (598,514,664 samples, 0.09%)</title><rect x="891.4" y="1521" width="3.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="894.40" y="1533.5" ></text>
+</g>
+<g >
+<title>get_page_from_freelist (260,593,495 samples, 0.04%)</title><rect x="772.9" y="1101" width="1.7" height="19.0" fill="rgb(208,18,4)" rx="2" ry="2" />
+<text  x="775.89" y="1113.5" ></text>
+</g>
+<g >
+<title>[bash] (1,261,568,072 samples, 0.20%)</title><rect x="860.3" y="1221" width="8.3" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="863.31" y="1233.5" ></text>
+</g>
+<g >
+<title>execute_command (866,614,713 samples, 0.14%)</title><rect x="301.1" y="1401" width="5.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="304.12" y="1413.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (13,256,971,382 samples, 2.08%)</title><rect x="307.9" y="1321" width="86.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="310.95" y="1333.5" >execute_co..</text>
+</g>
+<g >
+<title>execute_command_internal (849,509,116 samples, 0.13%)</title><rect x="895.3" y="1741" width="5.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.35" y="1753.5" ></text>
+</g>
+<g >
+<title>execute_command (1,261,220,789 samples, 0.20%)</title><rect x="860.3" y="661" width="8.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="863.32" y="673.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (977,768,443 samples, 0.15%)</title><rect x="868.6" y="1821" width="6.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="871.57" y="1833.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (891,895,571 samples, 0.14%)</title><rect x="851.1" y="2241" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.08" y="2253.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (62,227,282,912 samples, 9.75%)</title><rect x="396.0" y="1541" width="407.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="398.96" y="1553.5" >execute_command_internal</text>
+</g>
+<g >
+<title>execute_command (483,985,097 samples, 0.08%)</title><rect x="276.9" y="1701" width="3.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="279.92" y="1713.5" ></text>
+</g>
+<g >
+<title>may_open (160,398,085 samples, 0.03%)</title><rect x="2554.2" y="2261" width="1.0" height="19.0" fill="rgb(240,162,38)" rx="2" ry="2" />
+<text  x="2557.19" y="2273.5" ></text>
+</g>
+<g >
+<title>vfs_statx_path (401,957,615 samples, 0.06%)</title><rect x="4178.6" y="2381" width="2.6" height="19.0" fill="rgb(213,41,9)" rx="2" ry="2" />
+<text  x="4181.60" y="2393.5" ></text>
+</g>
+<g >
+<title>do_redirections (566,401,588 samples, 0.09%)</title><rect x="269.5" y="401" width="3.7" height="19.0" fill="rgb(247,193,46)" rx="2" ry="2" />
+<text  x="272.52" y="413.5" ></text>
+</g>
+<g >
+<title>execute_command (581,752,562 samples, 0.09%)</title><rect x="891.4" y="441" width="3.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="894.42" y="453.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (195,267,188 samples, 0.03%)</title><rect x="835.2" y="1081" width="1.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="838.18" y="1093.5" ></text>
+</g>
+<g >
+<title>_int_malloc (1,038,858,699 samples, 0.16%)</title><rect x="419.9" y="1021" width="6.8" height="19.0" fill="rgb(215,47,11)" rx="2" ry="2" />
+<text  x="422.88" y="1033.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (279,224,651 samples, 0.04%)</title><rect x="275.1" y="361" width="1.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="278.06" y="373.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (849,509,116 samples, 0.13%)</title><rect x="895.3" y="2461" width="5.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.35" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command (717,313,739 samples, 0.11%)</title><rect x="280.1" y="1581" width="4.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="283.09" y="1593.5" ></text>
+</g>
+<g >
+<title>dispose_command (278,296,843 samples, 0.04%)</title><rect x="840.5" y="241" width="1.8" height="19.0" fill="rgb(248,201,48)" rx="2" ry="2" />
+<text  x="843.48" y="253.5" ></text>
+</g>
+<g >
+<title>[bash] (445,473,550 samples, 0.07%)</title><rect x="339.6" y="661" width="2.9" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="342.62" y="673.5" ></text>
+</g>
+<g >
+<title>[bash] (889,542,281 samples, 0.14%)</title><rect x="851.1" y="1081" width="5.8" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="854.09" y="1093.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (76,162,814,457 samples, 11.93%)</title><rect x="307.9" y="2001" width="498.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="310.94" y="2013.5" >execute_command_internal</text>
+</g>
+<g >
+<title>_int_malloc (676,752,297 samples, 0.11%)</title><rect x="523.0" y="1161" width="4.4" height="19.0" fill="rgb(215,47,11)" rx="2" ry="2" />
+<text  x="525.99" y="1173.5" ></text>
+</g>
+<g >
+<title>[bash] (215,132,849 samples, 0.03%)</title><rect x="842.8" y="841" width="1.4" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="845.81" y="853.5" ></text>
+</g>
+<g >
+<title>[bash] (159,438,359 samples, 0.02%)</title><rect x="271.8" y="221" width="1.0" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="274.76" y="233.5" ></text>
+</g>
+<g >
+<title>syscall_return_via_sysret (165,058,404 samples, 0.03%)</title><rect x="2185.6" y="2461" width="1.1" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="2188.65" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (713,521,499 samples, 0.11%)</title><rect x="296.5" y="2361" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.45" y="2373.5" ></text>
+</g>
+<g >
+<title>execute_command (215,748,926 samples, 0.03%)</title><rect x="842.8" y="1621" width="1.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="845.80" y="1633.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (170,489,782 samples, 0.03%)</title><rect x="871.9" y="1141" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="874.90" y="1153.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (717,313,739 samples, 0.11%)</title><rect x="280.1" y="1401" width="4.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.09" y="1413.5" ></text>
+</g>
+<g >
+<title>execute_command (843,061,254 samples, 0.13%)</title><rect x="895.4" y="1381" width="5.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="898.39" y="1393.5" ></text>
+</g>
+<g >
+<title>execute_command (215,132,849 samples, 0.03%)</title><rect x="842.8" y="941" width="1.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="845.81" y="953.5" ></text>
+</g>
+<g >
+<title>[bash] (433,500,595 samples, 0.07%)</title><rect x="888.6" y="1321" width="2.8" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="891.56" y="1333.5" ></text>
+</g>
+<g >
+<title>execute_command (597,833,467 samples, 0.09%)</title><rect x="388.8" y="481" width="3.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="391.79" y="493.5" ></text>
+</g>
+<g >
+<title>execute_command (170,489,782 samples, 0.03%)</title><rect x="871.9" y="961" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="874.90" y="973.5" ></text>
+</g>
+<g >
+<title>kernel_clone (256,839,097 samples, 0.04%)</title><rect x="853.2" y="141" width="1.7" height="19.0" fill="rgb(248,199,47)" rx="2" ry="2" />
+<text  x="856.18" y="153.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (356,134,455 samples, 0.06%)</title><rect x="840.5" y="1621" width="2.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="843.47" y="1633.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,989,848,818 samples, 0.31%)</title><rect x="835.1" y="2241" width="13.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="838.10" y="2253.5" ></text>
+</g>
+<g >
+<title>get_user_pages_remote (207,946,404 samples, 0.03%)</title><rect x="668.5" y="1201" width="1.4" height="19.0" fill="rgb(251,214,51)" rx="2" ry="2" />
+<text  x="671.52" y="1213.5" ></text>
+</g>
+<g >
+<title>_IO_do_write@@GLIBC_2.2.5 (655,460,026 samples, 0.10%)</title><rect x="2616.4" y="2481" width="4.3" height="19.0" fill="rgb(238,155,37)" rx="2" ry="2" />
+<text  x="2619.43" y="2493.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (2,966,748,821 samples, 0.46%)</title><rect x="363.7" y="261" width="19.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="366.65" y="273.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (592,850,596 samples, 0.09%)</title><rect x="891.4" y="501" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.42" y="513.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,145,785,833 samples, 0.18%)</title><rect x="827.6" y="621" width="7.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.59" y="633.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (861,612,432 samples, 0.13%)</title><rect x="301.2" y="861" width="5.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.16" y="873.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (180,216,075 samples, 0.03%)</title><rect x="878.5" y="2001" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="881.48" y="2013.5" ></text>
+</g>
+<g >
+<title>execute_command (192,670,319 samples, 0.03%)</title><rect x="837.6" y="981" width="1.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="840.55" y="993.5" ></text>
+</g>
+<g >
+<title>syscall_return_via_sysret (328,866,810 samples, 0.05%)</title><rect x="1499.5" y="2381" width="2.2" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="1502.54" y="2393.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (164,808,262 samples, 0.03%)</title><rect x="870.8" y="1341" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="873.81" y="1353.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (581,752,562 samples, 0.09%)</title><rect x="891.4" y="421" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.42" y="433.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (710,260,538 samples, 0.11%)</title><rect x="280.1" y="561" width="4.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.11" y="573.5" ></text>
+</g>
+<g >
+<title>openaux (196,267,314 samples, 0.03%)</title><rect x="3015.9" y="2461" width="1.3" height="19.0" fill="rgb(252,217,52)" rx="2" ry="2" />
+<text  x="3018.87" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (717,313,739 samples, 0.11%)</title><rect x="280.1" y="1721" width="4.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.09" y="1733.5" ></text>
+</g>
+<g >
+<title>__fput (154,449,811 samples, 0.02%)</title><rect x="2179.4" y="2381" width="1.0" height="19.0" fill="rgb(205,0,0)" rx="2" ry="2" />
+<text  x="2182.36" y="2393.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (862,395,726 samples, 0.14%)</title><rect x="301.2" y="1221" width="5.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.15" y="1233.5" ></text>
+</g>
+<g >
+<title>execute_command (866,614,713 samples, 0.14%)</title><rect x="301.1" y="1361" width="5.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="304.12" y="1373.5" ></text>
+</g>
+<g >
+<title>allocate_fake_cpuc (193,903,600 samples, 0.03%)</title><rect x="704.8" y="1061" width="1.2" height="19.0" fill="rgb(248,198,47)" rx="2" ry="2" />
+<text  x="707.77" y="1073.5" ></text>
+</g>
+<g >
+<title>execute_command (76,161,613,125 samples, 11.93%)</title><rect x="307.9" y="1981" width="498.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="310.94" y="1993.5" >execute_command</text>
+</g>
+<g >
+<title>execute_command_internal (223,596,592 samples, 0.04%)</title><rect x="383.4" y="261" width="1.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="386.43" y="273.5" ></text>
+</g>
+<g >
+<title>[bash] (278,197,208 samples, 0.04%)</title><rect x="337.0" y="521" width="1.8" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="340.01" y="533.5" ></text>
+</g>
+<g >
+<title>execute_command (158,744,410 samples, 0.02%)</title><rect x="875.9" y="1321" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="878.93" y="1333.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (578,068,287 samples, 0.09%)</title><rect x="884.6" y="1761" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="887.62" y="1773.5" ></text>
+</g>
+<g >
+<title>[bash] (345,617,435 samples, 0.05%)</title><rect x="336.9" y="641" width="2.3" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="339.92" y="653.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (891,895,571 samples, 0.14%)</title><rect x="851.1" y="1961" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.08" y="1973.5" ></text>
+</g>
+<g >
+<title>execute_command (889,118,394 samples, 0.14%)</title><rect x="851.1" y="581" width="5.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="854.09" y="593.5" ></text>
+</g>
+<g >
+<title>[bash] (713,462,810 samples, 0.11%)</title><rect x="280.1" y="1001" width="4.7" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="283.11" y="1013.5" ></text>
+</g>
+<g >
+<title>execute_command (554,006,342 samples, 0.09%)</title><rect x="273.3" y="1981" width="3.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="276.29" y="1993.5" ></text>
+</g>
+<g >
+<title>execute_command (862,395,726 samples, 0.14%)</title><rect x="301.2" y="1301" width="5.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="304.15" y="1313.5" ></text>
+</g>
+<g >
+<title>kmem_cache_alloc_noprof (278,981,607 samples, 0.04%)</title><rect x="4141.8" y="2301" width="1.9" height="19.0" fill="rgb(205,0,0)" rx="2" ry="2" />
+<text  x="4144.84" y="2313.5" ></text>
+</g>
+<g >
+<title>execute_command (713,987,302 samples, 0.11%)</title><rect x="280.1" y="1101" width="4.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="283.11" y="1113.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (526,941,991 samples, 0.08%)</title><rect x="297.5" y="301" width="3.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="300.54" y="313.5" ></text>
+</g>
+<g >
+<title>posix_fadvise (534,545,886 samples, 0.08%)</title><rect x="1659.1" y="2501" width="3.5" height="19.0" fill="rgb(245,186,44)" rx="2" ry="2" />
+<text  x="1662.14" y="2513.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (511,991,718 samples, 0.08%)</title><rect x="856.9" y="621" width="3.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="859.94" y="633.5" ></text>
+</g>
+<g >
+<title>_IO_file_fopen@@GLIBC_2.2.5 (5,294,214,199 samples, 0.83%)</title><rect x="1467.3" y="2441" width="34.6" height="19.0" fill="rgb(237,148,35)" rx="2" ry="2" />
+<text  x="1470.27" y="2453.5" >_I..</text>
+</g>
+<g >
+<title>security_inode_permission (358,286,771 samples, 0.06%)</title><rect x="2130.0" y="2241" width="2.3" height="19.0" fill="rgb(215,47,11)" rx="2" ry="2" />
+<text  x="2132.97" y="2253.5" ></text>
+</g>
+<g >
+<title>execute_command (1,263,560,140 samples, 0.20%)</title><rect x="860.3" y="1941" width="8.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="863.30" y="1953.5" ></text>
+</g>
+<g >
+<title>exit_mmap (193,711,105 samples, 0.03%)</title><rect x="1585.8" y="2441" width="1.3" height="19.0" fill="rgb(242,173,41)" rx="2" ry="2" />
+<text  x="1588.83" y="2453.5" ></text>
+</g>
+<g >
+<title>execute_command (432,872,015 samples, 0.07%)</title><rect x="888.6" y="961" width="2.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="891.57" y="973.5" ></text>
+</g>
+<g >
+<title>__do_sys_newfstat (211,882,921 samples, 0.03%)</title><rect x="1439.5" y="2321" width="1.4" height="19.0" fill="rgb(225,96,23)" rx="2" ry="2" />
+<text  x="1442.48" y="2333.5" ></text>
+</g>
+<g >
+<title>syscall_return_via_sysret (299,354,993 samples, 0.05%)</title><rect x="4016.6" y="2481" width="2.0" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="4019.62" y="2493.5" ></text>
+</g>
+<g >
+<title>execute_command (483,985,097 samples, 0.08%)</title><rect x="276.9" y="1661" width="3.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="279.92" y="1673.5" ></text>
+</g>
+<g >
+<title>__fopen_internal (2,849,268,047 samples, 0.45%)</title><rect x="176.0" y="2461" width="18.6" height="19.0" fill="rgb(248,197,47)" rx="2" ry="2" />
+<text  x="179.00" y="2473.5" ></text>
+</g>
+<g >
+<title>_IO_file_open (3,373,582,542 samples, 0.53%)</title><rect x="2542.8" y="2421" width="22.1" height="19.0" fill="rgb(249,205,49)" rx="2" ry="2" />
+<text  x="2545.83" y="2433.5" >_..</text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (297,325,093 samples, 0.05%)</title><rect x="498.7" y="1041" width="2.0" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="501.74" y="1053.5" ></text>
+</g>
+<g >
+<title>entry_SYSRETQ_unsafe_stack (160,979,402 samples, 0.03%)</title><rect x="2086.0" y="2441" width="1.0" height="19.0" fill="rgb(213,37,8)" rx="2" ry="2" />
+<text  x="2088.96" y="2453.5" ></text>
+</g>
+<g >
+<title>execute_command (823,963,614 samples, 0.13%)</title><rect x="895.4" y="441" width="5.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="898.39" y="453.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (688,777,208 samples, 0.11%)</title><rect x="268.8" y="2461" width="4.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="271.77" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command (179,777,548 samples, 0.03%)</title><rect x="878.5" y="1241" width="1.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="881.48" y="1253.5" ></text>
+</g>
+<g >
+<title>execute_command (322,256,264 samples, 0.05%)</title><rect x="868.7" y="1041" width="2.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="871.70" y="1053.5" ></text>
+</g>
+<g >
+<title>execute_command (169,651,850 samples, 0.03%)</title><rect x="871.9" y="841" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="874.90" y="853.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (483,985,097 samples, 0.08%)</title><rect x="276.9" y="2121" width="3.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="279.92" y="2133.5" ></text>
+</g>
+<g >
+<title>execute_command (483,985,097 samples, 0.08%)</title><rect x="276.9" y="2101" width="3.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="279.92" y="2113.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (179,777,548 samples, 0.03%)</title><rect x="878.5" y="1641" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="881.48" y="1653.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (195,916,485 samples, 0.03%)</title><rect x="835.2" y="1381" width="1.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="838.17" y="1393.5" ></text>
+</g>
+<g >
+<title>do_filp_open (254,834,066 samples, 0.04%)</title><rect x="345.5" y="541" width="1.6" height="19.0" fill="rgb(217,58,13)" rx="2" ry="2" />
+<text  x="348.45" y="553.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (158,599,791 samples, 0.02%)</title><rect x="875.9" y="901" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="878.93" y="913.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (182,342,236 samples, 0.03%)</title><rect x="407.7" y="1001" width="1.2" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="410.72" y="1013.5" ></text>
+</g>
+<g >
+<title>execute_command (195,267,188 samples, 0.03%)</title><rect x="835.2" y="1221" width="1.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="838.18" y="1233.5" ></text>
+</g>
+<g >
+<title>execute_command (1,261,220,789 samples, 0.20%)</title><rect x="860.3" y="941" width="8.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="863.32" y="953.5" ></text>
+</g>
+<g >
+<title>execute_command (483,985,097 samples, 0.08%)</title><rect x="276.9" y="1741" width="3.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="279.92" y="1753.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (691,786,819 samples, 0.11%)</title><rect x="1549.9" y="2441" width="4.6" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="1552.94" y="2453.5" ></text>
+</g>
+<g >
+<title>[bash] (156,837,648 samples, 0.02%)</title><rect x="870.9" y="481" width="1.0" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="873.86" y="493.5" ></text>
+</g>
+<g >
+<title>[bash] (244,490,010 samples, 0.04%)</title><rect x="351.7" y="541" width="1.6" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="354.71" y="553.5" ></text>
+</g>
+<g >
+<title>execute_command (849,509,116 samples, 0.13%)</title><rect x="895.3" y="1801" width="5.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="898.35" y="1813.5" ></text>
+</g>
+<g >
+<title>execute_command (866,614,713 samples, 0.14%)</title><rect x="301.1" y="1441" width="5.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="304.12" y="1453.5" ></text>
+</g>
+<g >
+<title>_dl_catch_exception (197,443,611 samples, 0.03%)</title><rect x="2117.9" y="2481" width="1.3" height="19.0" fill="rgb(253,223,53)" rx="2" ry="2" />
+<text  x="2120.88" y="2493.5" ></text>
+</g>
+<g >
+<title>walk_component (266,920,775 samples, 0.04%)</title><rect x="4132.4" y="2261" width="1.8" height="19.0" fill="rgb(247,197,47)" rx="2" ry="2" />
+<text  x="4135.43" y="2273.5" ></text>
+</g>
+<g >
+<title>vfs_read (2,364,741,912 samples, 0.37%)</title><rect x="202.8" y="2361" width="15.5" height="19.0" fill="rgb(230,118,28)" rx="2" ry="2" />
+<text  x="205.84" y="2373.5" ></text>
+</g>
+<g >
+<title>_dl_sysdep_start (554,783,690 samples, 0.09%)</title><rect x="2534.9" y="2541" width="3.6" height="19.0" fill="rgb(234,137,32)" rx="2" ry="2" />
+<text  x="2537.91" y="2553.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (866,614,713 samples, 0.14%)</title><rect x="301.1" y="2481" width="5.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.12" y="2493.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (889,118,394 samples, 0.14%)</title><rect x="851.1" y="601" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.09" y="613.5" ></text>
+</g>
+<g >
+<title>[bash] (517,010,579 samples, 0.08%)</title><rect x="273.5" y="441" width="3.4" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="276.52" y="453.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (853,210,202 samples, 0.13%)</title><rect x="301.2" y="501" width="5.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.16" y="513.5" ></text>
+</g>
+<g >
+<title>_dl_map_object (284,332,197 samples, 0.04%)</title><rect x="1579.5" y="2441" width="1.9" height="19.0" fill="rgb(248,199,47)" rx="2" ry="2" />
+<text  x="1582.52" y="2453.5" ></text>
+</g>
+<g >
+<title>strvec_from_word_list (4,115,636,003 samples, 0.64%)</title><rect x="715.2" y="1341" width="26.9" height="19.0" fill="rgb(236,145,34)" rx="2" ry="2" />
+<text  x="718.16" y="1353.5" >s..</text>
+</g>
+<g >
+<title>execute_command (680,229,498 samples, 0.11%)</title><rect x="268.8" y="561" width="4.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="271.79" y="573.5" ></text>
+</g>
+<g >
+<title>security_file_post_open (197,541,032 samples, 0.03%)</title><rect x="3923.5" y="2281" width="1.3" height="19.0" fill="rgb(218,63,15)" rx="2" ry="2" />
+<text  x="3926.47" y="2293.5" ></text>
+</g>
+<g >
+<title>execute_command (354,938,381 samples, 0.06%)</title><rect x="840.5" y="861" width="2.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="843.48" y="873.5" ></text>
+</g>
+<g >
+<title>execute_command (554,006,342 samples, 0.09%)</title><rect x="273.3" y="1621" width="3.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="276.29" y="1633.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (284,220,718 samples, 0.04%)</title><rect x="2093.9" y="2421" width="1.8" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="2096.86" y="2433.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (717,313,739 samples, 0.11%)</title><rect x="280.1" y="2081" width="4.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.09" y="2093.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,150,422,968 samples, 0.18%)</title><rect x="827.6" y="1701" width="7.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.57" y="1713.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (843,061,254 samples, 0.13%)</title><rect x="895.4" y="1261" width="5.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.39" y="1273.5" ></text>
+</g>
+<g >
+<title>__x64_sys_openat (2,238,259,998 samples, 0.35%)</title><rect x="177.6" y="2341" width="14.6" height="19.0" fill="rgb(208,15,3)" rx="2" ry="2" />
+<text  x="180.55" y="2353.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,511,703,140 samples, 0.24%)</title><rect x="835.1" y="1961" width="9.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="838.10" y="1973.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (163,954,022 samples, 0.03%)</title><rect x="870.8" y="1181" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="873.82" y="1193.5" ></text>
+</g>
+<g >
+<title>builtin_find_indexed_array (4,954,030,113 samples, 0.78%)</title><rect x="430.0" y="1101" width="32.5" height="19.0" fill="rgb(206,9,2)" rx="2" ry="2" />
+<text  x="433.03" y="1113.5" >bu..</text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (3,247,695,412 samples, 0.51%)</title><rect x="3345.0" y="2441" width="21.2" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="3347.96" y="2453.5" >e..</text>
+</g>
+<g >
+<title>__d_lookup_rcu (154,681,670 samples, 0.02%)</title><rect x="183.6" y="2201" width="1.1" height="19.0" fill="rgb(235,139,33)" rx="2" ry="2" />
+<text  x="186.65" y="2213.5" ></text>
+</g>
+<g >
+<title>execute_command (704,492,242 samples, 0.11%)</title><rect x="296.5" y="661" width="4.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="299.51" y="673.5" ></text>
+</g>
+<g >
+<title>do_redirections (468,029,659 samples, 0.07%)</title><rect x="857.2" y="481" width="3.1" height="19.0" fill="rgb(247,193,46)" rx="2" ry="2" />
+<text  x="860.22" y="493.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (891,895,571 samples, 0.14%)</title><rect x="851.1" y="2041" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.08" y="2053.5" ></text>
+</g>
+<g >
+<title>copy_page_to_iter (1,709,979,725 samples, 0.27%)</title><rect x="1619.2" y="2341" width="11.2" height="19.0" fill="rgb(216,52,12)" rx="2" ry="2" />
+<text  x="1622.22" y="2353.5" ></text>
+</g>
+<g >
+<title>[bash] (166,908,019 samples, 0.03%)</title><rect x="871.9" y="501" width="1.1" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="874.92" y="513.5" ></text>
+</g>
+<g >
+<title>execute_command (320,852,930 samples, 0.05%)</title><rect x="868.7" y="721" width="2.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="871.70" y="733.5" ></text>
+</g>
+<g >
+<title>redirection_expand (991,176,701 samples, 0.16%)</title><rect x="862.0" y="301" width="6.5" height="19.0" fill="rgb(218,63,15)" rx="2" ry="2" />
+<text  x="864.98" y="313.5" ></text>
+</g>
+<g >
+<title>__libc_start_main@@GLIBC_2.34 (76,571,631,469 samples, 11.99%)</title><rect x="306.9" y="2561" width="501.2" height="19.0" fill="rgb(229,113,27)" rx="2" ry="2" />
+<text  x="309.86" y="2573.5" >__libc_start_main@@GLIBC_2.34</text>
+</g>
+<g >
+<title>malloc (160,267,011 samples, 0.03%)</title><rect x="527.5" y="1201" width="1.1" height="19.0" fill="rgb(230,119,28)" rx="2" ry="2" />
+<text  x="530.51" y="1213.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64 (342,214,012 samples, 0.05%)</title><rect x="4066.7" y="2421" width="2.2" height="19.0" fill="rgb(245,186,44)" rx="2" ry="2" />
+<text  x="4069.69" y="2433.5" ></text>
+</g>
+<g >
+<title>_IO_file_overflow@@GLIBC_2.2.5 (539,007,809 samples, 0.08%)</title><rect x="1647.6" y="2501" width="3.5" height="19.0" fill="rgb(239,157,37)" rx="2" ry="2" />
+<text  x="1650.62" y="2513.5" ></text>
+</g>
+<g >
+<title>selinux_inode_permission (540,801,780 samples, 0.08%)</title><rect x="4128.4" y="2241" width="3.5" height="19.0" fill="rgb(238,156,37)" rx="2" ry="2" />
+<text  x="4131.39" y="2253.5" ></text>
+</g>
+<g >
+<title>[unknown] (38,989,140,812 samples, 6.11%)</title><rect x="3425.5" y="2581" width="255.2" height="19.0" fill="rgb(210,24,5)" rx="2" ry="2" />
+<text  x="3428.50" y="2593.5" >[unknown]</text>
+</g>
+<g >
+<title>execute_command_internal (432,726,851 samples, 0.07%)</title><rect x="888.6" y="701" width="2.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="891.57" y="713.5" ></text>
+</g>
+<g >
+<title>[bash] (788,209,064 samples, 0.12%)</title><rect x="829.8" y="281" width="5.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="832.82" y="293.5" ></text>
+</g>
+<g >
+<title>execute_command (1,261,220,789 samples, 0.20%)</title><rect x="860.3" y="741" width="8.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="863.32" y="753.5" ></text>
+</g>
+<g >
+<title>[bash] (76,556,548,766 samples, 11.99%)</title><rect x="306.9" y="2401" width="501.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="309.94" y="2413.5" >[bash]</text>
+</g>
+<g >
+<title>execute_command (889,542,281 samples, 0.14%)</title><rect x="851.1" y="861" width="5.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="854.09" y="873.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (713,521,499 samples, 0.11%)</title><rect x="296.5" y="2461" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.45" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (170,489,782 samples, 0.03%)</title><rect x="871.9" y="1021" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="874.90" y="1033.5" ></text>
+</g>
+<g >
+<title>execute_command (1,261,220,789 samples, 0.20%)</title><rect x="860.3" y="861" width="8.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="863.32" y="873.5" ></text>
+</g>
+<g >
+<title>execute_command (1,263,560,140 samples, 0.20%)</title><rect x="860.3" y="1501" width="8.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="863.30" y="1513.5" ></text>
+</g>
+<g >
+<title>_IO_file_open (3,502,854,147 samples, 0.55%)</title><rect x="3313.2" y="2421" width="22.9" height="19.0" fill="rgb(249,205,49)" rx="2" ry="2" />
+<text  x="3316.16" y="2433.5" >_..</text>
+</g>
+<g >
+<title>execute_command (704,492,242 samples, 0.11%)</title><rect x="296.5" y="901" width="4.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="299.51" y="913.5" ></text>
+</g>
+<g >
+<title>__libc_start_main@@GLIBC_2.34 (11,235,887,811 samples, 1.76%)</title><rect x="1589.5" y="2561" width="73.5" height="19.0" fill="rgb(229,113,27)" rx="2" ry="2" />
+<text  x="1592.47" y="2573.5" >__libc_s..</text>
+</g>
+<g >
+<title>anon_vma_clone (186,517,021 samples, 0.03%)</title><rect x="695.1" y="1161" width="1.3" height="19.0" fill="rgb(217,57,13)" rx="2" ry="2" />
+<text  x="698.15" y="1173.5" ></text>
+</g>
+<g >
+<title>execute_command (166,042,857 samples, 0.03%)</title><rect x="836.5" y="1381" width="1.0" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="839.46" y="1393.5" ></text>
+</g>
+<g >
+<title>execute_command (596,118,643 samples, 0.09%)</title><rect x="891.4" y="1341" width="3.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="894.42" y="1353.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (688,777,208 samples, 0.11%)</title><rect x="268.8" y="2021" width="4.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="271.77" y="2033.5" ></text>
+</g>
+<g >
+<title>execute_command (686,486,049 samples, 0.11%)</title><rect x="268.8" y="1161" width="4.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="271.78" y="1173.5" ></text>
+</g>
+<g >
+<title>_Fork (313,544,771 samples, 0.05%)</title><rect x="853.1" y="221" width="2.1" height="19.0" fill="rgb(252,220,52)" rx="2" ry="2" />
+<text  x="856.11" y="233.5" ></text>
+</g>
+<g >
+<title>execute_command (481,191,724 samples, 0.08%)</title><rect x="276.9" y="941" width="3.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="279.94" y="953.5" ></text>
+</g>
+<g >
+<title>execute_command (481,191,724 samples, 0.08%)</title><rect x="276.9" y="861" width="3.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="279.94" y="873.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (849,636,646 samples, 0.13%)</title><rect x="301.2" y="381" width="5.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.16" y="393.5" ></text>
+</g>
+<g >
+<title>read (4,716,861,848 samples, 0.74%)</title><rect x="2051.2" y="2461" width="30.8" height="19.0" fill="rgb(252,216,51)" rx="2" ry="2" />
+<text  x="2054.15" y="2473.5" >read</text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (237,692,984 samples, 0.04%)</title><rect x="367.3" y="141" width="1.6" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="370.33" y="153.5" ></text>
+</g>
+<g >
+<title>syscall_return_via_sysret (399,691,334 samples, 0.06%)</title><rect x="1635.9" y="2441" width="2.6" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="1638.85" y="2453.5" ></text>
+</g>
+<g >
+<title>do_redirections (158,643,683 samples, 0.02%)</title><rect x="836.5" y="581" width="1.0" height="19.0" fill="rgb(247,193,46)" rx="2" ry="2" />
+<text  x="839.50" y="593.5" ></text>
+</g>
+<g >
+<title>redirection_expand (215,132,849 samples, 0.03%)</title><rect x="842.8" y="781" width="1.4" height="19.0" fill="rgb(218,63,15)" rx="2" ry="2" />
+<text  x="845.81" y="793.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (237,699,148 samples, 0.04%)</title><rect x="270.0" y="201" width="1.5" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="272.99" y="213.5" ></text>
+</g>
+<g >
+<title>_IO_file_xsgetn (784,403,090 samples, 0.12%)</title><rect x="195.1" y="2441" width="5.2" height="19.0" fill="rgb(207,11,2)" rx="2" ry="2" />
+<text  x="198.12" y="2453.5" ></text>
+</g>
+<g >
+<title>dispose_command (254,706,159 samples, 0.04%)</title><rect x="840.6" y="101" width="1.7" height="19.0" fill="rgb(248,201,48)" rx="2" ry="2" />
+<text  x="843.58" y="113.5" ></text>
+</g>
+<g >
+<title>execute_command (1,471,146,555 samples, 0.23%)</title><rect x="327.3" y="661" width="9.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="330.27" y="673.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (62,112,025,004 samples, 9.73%)</title><rect x="396.6" y="1481" width="406.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="399.61" y="1493.5" >execute_command_internal</text>
+</g>
+<g >
+<title>_IO_do_write@@GLIBC_2.2.5 (667,990,137 samples, 0.10%)</title><rect x="2093.7" y="2481" width="4.3" height="19.0" fill="rgb(238,155,37)" rx="2" ry="2" />
+<text  x="2096.66" y="2493.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (436,055,112 samples, 0.07%)</title><rect x="888.5" y="2421" width="2.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="891.55" y="2433.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (354,998,378 samples, 0.06%)</title><rect x="840.5" y="1281" width="2.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="843.48" y="1293.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (436,055,112 samples, 0.07%)</title><rect x="888.5" y="1661" width="2.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="891.55" y="1673.5" ></text>
+</g>
+<g >
+<title>[sum] (47,946,395,288 samples, 7.51%)</title><rect x="3687.6" y="2501" width="313.8" height="19.0" fill="rgb(222,78,18)" rx="2" ry="2" />
+<text  x="3690.56" y="2513.5" >[sum]</text>
+</g>
+<g >
+<title>execute_command (513,428,353 samples, 0.08%)</title><rect x="856.9" y="1121" width="3.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="859.94" y="1133.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (7,228,654,403 samples, 1.13%)</title><rect x="308.5" y="1061" width="47.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="311.54" y="1073.5" >exec..</text>
+</g>
+<g >
+<title>entry_SYSRETQ_unsafe_stack (172,440,725 samples, 0.03%)</title><rect x="3333.5" y="2381" width="1.2" height="19.0" fill="rgb(213,37,8)" rx="2" ry="2" />
+<text  x="3336.53" y="2393.5" ></text>
+</g>
+<g >
+<title>execute_command (866,614,713 samples, 0.14%)</title><rect x="301.1" y="1921" width="5.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="304.12" y="1933.5" ></text>
+</g>
+<g >
+<title>execute_command (713,462,810 samples, 0.11%)</title><rect x="280.1" y="621" width="4.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="283.11" y="633.5" ></text>
+</g>
+<g >
+<title>__close_nocancel (157,537,316 samples, 0.02%)</title><rect x="4025.7" y="2521" width="1.0" height="19.0" fill="rgb(228,109,26)" rx="2" ry="2" />
+<text  x="4028.67" y="2533.5" ></text>
+</g>
+<g >
+<title>__GI___libc_open (2,558,923,003 samples, 0.40%)</title><rect x="1591.4" y="2401" width="16.8" height="19.0" fill="rgb(249,202,48)" rx="2" ry="2" />
+<text  x="1594.43" y="2413.5" ></text>
+</g>
+<g >
+<title>execute_command (688,777,208 samples, 0.11%)</title><rect x="268.8" y="1561" width="4.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="271.77" y="1573.5" ></text>
+</g>
+<g >
+<title>[bash] (373,203,907 samples, 0.06%)</title><rect x="282.1" y="241" width="2.5" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="285.11" y="253.5" ></text>
+</g>
+<g >
+<title>[bash] (686,486,049 samples, 0.11%)</title><rect x="268.8" y="1281" width="4.5" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="271.78" y="1293.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (483,985,097 samples, 0.08%)</title><rect x="276.9" y="1801" width="3.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="279.92" y="1813.5" ></text>
+</g>
+<g >
+<title>dispose_command (278,788,607 samples, 0.04%)</title><rect x="840.5" y="561" width="1.8" height="19.0" fill="rgb(248,201,48)" rx="2" ry="2" />
+<text  x="843.48" y="573.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (849,509,116 samples, 0.13%)</title><rect x="895.3" y="1981" width="5.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.35" y="1993.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (598,514,664 samples, 0.09%)</title><rect x="891.4" y="1981" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.40" y="1993.5" ></text>
+</g>
+<g >
+<title>execute_command (513,954,307 samples, 0.08%)</title><rect x="856.9" y="1441" width="3.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="859.94" y="1453.5" ></text>
+</g>
+<g >
+<title>run_exit_trap (268,599,000 samples, 0.04%)</title><rect x="803.3" y="1581" width="1.8" height="19.0" fill="rgb(242,171,40)" rx="2" ry="2" />
+<text  x="806.34" y="1593.5" ></text>
+</g>
+<g >
+<title>execute_command (281,921,411 samples, 0.04%)</title><rect x="827.6" y="401" width="1.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="830.59" y="413.5" ></text>
+</g>
+<g >
+<title>[bash] (262,805,585 samples, 0.04%)</title><rect x="337.0" y="501" width="1.8" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="340.03" y="513.5" ></text>
+</g>
+<g >
+<title>__GI___libc_open (5,034,882,096 samples, 0.79%)</title><rect x="3904.2" y="2421" width="33.0" height="19.0" fill="rgb(249,202,48)" rx="2" ry="2" />
+<text  x="3907.24" y="2433.5" >__..</text>
+</g>
+<g >
+<title>[bash] (179,777,548 samples, 0.03%)</title><rect x="878.5" y="901" width="1.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="881.48" y="913.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (356,134,455 samples, 0.06%)</title><rect x="840.5" y="1821" width="2.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="843.47" y="1833.5" ></text>
+</g>
+<g >
+<title>execute_command (704,492,242 samples, 0.11%)</title><rect x="296.5" y="741" width="4.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="299.51" y="753.5" ></text>
+</g>
+<g >
+<title>entry_SYSRETQ_unsafe_stack (154,727,418 samples, 0.02%)</title><rect x="2148.4" y="2401" width="1.0" height="19.0" fill="rgb(213,37,8)" rx="2" ry="2" />
+<text  x="2151.40" y="2413.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (356,134,455 samples, 0.06%)</title><rect x="840.5" y="1861" width="2.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="843.47" y="1873.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (688,777,208 samples, 0.11%)</title><rect x="268.8" y="2381" width="4.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="271.77" y="2393.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (354,938,381 samples, 0.06%)</title><rect x="840.5" y="921" width="2.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="843.48" y="933.5" ></text>
+</g>
+<g >
+<title>execute_command (432,872,015 samples, 0.07%)</title><rect x="888.6" y="841" width="2.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="891.57" y="853.5" ></text>
+</g>
+<g >
+<title>execute_command (516,725,798 samples, 0.08%)</title><rect x="856.9" y="2041" width="3.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="859.92" y="2053.5" ></text>
+</g>
+<g >
+<title>[bash] (6,115,706,951 samples, 0.96%)</title><rect x="518.6" y="1301" width="40.0" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="521.58" y="1313.5" >[ba..</text>
+</g>
+<g >
+<title>do_filp_open (2,412,993,495 samples, 0.38%)</title><rect x="3314.9" y="2301" width="15.8" height="19.0" fill="rgb(217,58,13)" rx="2" ry="2" />
+<text  x="3317.93" y="2313.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (262,648,516 samples, 0.04%)</title><rect x="1639.9" y="2421" width="1.7" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="1642.90" y="2433.5" ></text>
+</g>
+<g >
+<title>[bash] (866,614,713 samples, 0.14%)</title><rect x="301.1" y="2321" width="5.7" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="304.12" y="2333.5" ></text>
+</g>
+<g >
+<title>execute_command (1,511,703,140 samples, 0.24%)</title><rect x="835.1" y="1981" width="9.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="838.10" y="1993.5" ></text>
+</g>
+<g >
+<title>__d_lookup_rcu (170,356,582 samples, 0.03%)</title><rect x="1598.9" y="2241" width="1.1" height="19.0" fill="rgb(235,139,33)" rx="2" ry="2" />
+<text  x="1601.90" y="2253.5" ></text>
+</g>
+<g >
+<title>execute_command (1,381,857,513 samples, 0.22%)</title><rect x="868.6" y="1961" width="9.0" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="871.57" y="1973.5" ></text>
+</g>
+<g >
+<title>__d_lookup_rcu (331,210,119 samples, 0.05%)</title><rect x="3919.2" y="2261" width="2.2" height="19.0" fill="rgb(235,139,33)" rx="2" ry="2" />
+<text  x="3922.19" y="2273.5" ></text>
+</g>
+<g >
+<title>execute_command (1,150,422,968 samples, 0.18%)</title><rect x="827.6" y="2281" width="7.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="830.57" y="2293.5" ></text>
+</g>
+<g >
+<title>execute_command (179,777,548 samples, 0.03%)</title><rect x="878.5" y="1121" width="1.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="881.48" y="1133.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (861,612,432 samples, 0.13%)</title><rect x="301.2" y="781" width="5.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.16" y="793.5" ></text>
+</g>
+<g >
+<title>execute_command (164,731,865 samples, 0.03%)</title><rect x="836.5" y="901" width="1.0" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="839.46" y="913.5" ></text>
+</g>
+<g >
+<title>execute_command (354,938,381 samples, 0.06%)</title><rect x="840.5" y="941" width="2.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="843.48" y="953.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (483,985,097 samples, 0.08%)</title><rect x="276.9" y="2481" width="3.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="279.92" y="2493.5" ></text>
+</g>
+<g >
+<title>execute_command (159,710,185 samples, 0.03%)</title><rect x="875.9" y="1801" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="878.92" y="1813.5" ></text>
+</g>
+<g >
+<title>[bash] (521,440,969 samples, 0.08%)</title><rect x="302.6" y="141" width="3.5" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="305.65" y="153.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (194,148,063 samples, 0.03%)</title><rect x="837.5" y="1361" width="1.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="840.54" y="1373.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (354,998,378 samples, 0.06%)</title><rect x="840.5" y="1081" width="2.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="843.48" y="1093.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (171,847,094 samples, 0.03%)</title><rect x="871.9" y="1501" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="874.89" y="1513.5" ></text>
+</g>
+<g >
+<title>execute_command (483,985,097 samples, 0.08%)</title><rect x="276.9" y="1781" width="3.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="279.92" y="1793.5" ></text>
+</g>
+<g >
+<title>execute_command (193,846,806 samples, 0.03%)</title><rect x="835.2" y="701" width="1.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="838.18" y="713.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (2,954,961,180 samples, 0.46%)</title><rect x="3314.2" y="2361" width="19.3" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="3317.19" y="2373.5" ></text>
+</g>
+<g >
+<title>execute_command (1,147,316,451 samples, 0.18%)</title><rect x="827.6" y="1421" width="7.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="830.59" y="1433.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (550,598,300 samples, 0.09%)</title><rect x="273.3" y="1221" width="3.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="276.32" y="1233.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (598,514,664 samples, 0.09%)</title><rect x="891.4" y="1861" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.40" y="1873.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (354,900,103 samples, 0.06%)</title><rect x="840.5" y="641" width="2.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="843.48" y="653.5" ></text>
+</g>
+<g >
+<title>security_file_open (200,882,767 samples, 0.03%)</title><rect x="2138.4" y="2221" width="1.4" height="19.0" fill="rgb(215,47,11)" rx="2" ry="2" />
+<text  x="2141.44" y="2233.5" ></text>
+</g>
+<g >
+<title>_IO_do_write@@GLIBC_2.2.5 (156,862,057 samples, 0.02%)</title><rect x="4026.7" y="2521" width="1.0" height="19.0" fill="rgb(238,155,37)" rx="2" ry="2" />
+<text  x="4029.70" y="2533.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (305,961,079 samples, 0.05%)</title><rect x="868.8" y="561" width="2.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="871.80" y="573.5" ></text>
+</g>
+<g >
+<title>execute_command (215,132,849 samples, 0.03%)</title><rect x="842.8" y="1101" width="1.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="845.81" y="1113.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (550,598,300 samples, 0.09%)</title><rect x="273.3" y="1121" width="3.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="276.32" y="1133.5" ></text>
+</g>
+<g >
+<title>alloc_word_desc (541,184,653 samples, 0.08%)</title><rect x="639.1" y="1301" width="3.6" height="19.0" fill="rgb(208,16,3)" rx="2" ry="2" />
+<text  x="642.11" y="1313.5" ></text>
+</g>
+<g >
+<title>__printf_buffer_to_file_done (422,513,141 samples, 0.07%)</title><rect x="2632.7" y="2461" width="2.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="2635.68" y="2473.5" ></text>
+</g>
+<g >
+<title>_Fork (252,864,373 samples, 0.04%)</title><rect x="270.0" y="241" width="1.6" height="19.0" fill="rgb(252,220,52)" rx="2" ry="2" />
+<text  x="272.97" y="253.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (699,290,297 samples, 0.11%)</title><rect x="296.5" y="481" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.51" y="493.5" ></text>
+</g>
+<g >
+<title>[bash] (171,747,862 samples, 0.03%)</title><rect x="855.3" y="221" width="1.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="858.33" y="233.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (891,984,310 samples, 0.14%)</title><rect x="851.1" y="2521" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.08" y="2533.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (7,320,320,919 samples, 1.15%)</title><rect x="307.9" y="1241" width="48.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="310.95" y="1253.5" >exec..</text>
+</g>
+<g >
+<title>execute_command_internal (180,216,075 samples, 0.03%)</title><rect x="878.5" y="1741" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="881.48" y="1753.5" ></text>
+</g>
+<g >
+<title>[sha384sum] (13,125,362,431 samples, 2.06%)</title><rect x="3021.1" y="2581" width="85.9" height="19.0" fill="rgb(253,223,53)" rx="2" ry="2" />
+<text  x="3024.12" y="2593.5" >[sha384sum]</text>
+</g>
+<g >
+<title>[bash] (466,972,019 samples, 0.07%)</title><rect x="892.1" y="301" width="3.1" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="895.13" y="313.5" ></text>
+</g>
+<g >
+<title>execute_command (598,514,664 samples, 0.09%)</title><rect x="891.4" y="2121" width="3.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="894.40" y="2133.5" ></text>
+</g>
+<g >
+<title>execute_command (575,055,300 samples, 0.09%)</title><rect x="884.6" y="861" width="3.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="887.64" y="873.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (575,055,300 samples, 0.09%)</title><rect x="884.6" y="801" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="887.64" y="813.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (713,462,810 samples, 0.11%)</title><rect x="280.1" y="801" width="4.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.11" y="813.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (163,954,022 samples, 0.03%)</title><rect x="870.8" y="941" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="873.82" y="953.5" ></text>
+</g>
+<g >
+<title>getname_flags.part.0 (456,205,811 samples, 0.07%)</title><rect x="4162.4" y="2401" width="3.0" height="19.0" fill="rgb(213,39,9)" rx="2" ry="2" />
+<text  x="4165.42" y="2413.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (866,614,713 samples, 0.14%)</title><rect x="301.1" y="1901" width="5.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.12" y="1913.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (198,588,585 samples, 0.03%)</title><rect x="866.5" y="141" width="1.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="869.54" y="153.5" ></text>
+</g>
+<g >
+<title>execute_command (866,614,713 samples, 0.14%)</title><rect x="301.1" y="1601" width="5.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="304.12" y="1613.5" ></text>
+</g>
+<g >
+<title>execute_command (513,428,353 samples, 0.08%)</title><rect x="856.9" y="961" width="3.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="859.94" y="973.5" ></text>
+</g>
+<g >
+<title>alloc_empty_file (164,522,697 samples, 0.03%)</title><rect x="2544.9" y="2261" width="1.1" height="19.0" fill="rgb(215,49,11)" rx="2" ry="2" />
+<text  x="2547.88" y="2273.5" ></text>
+</g>
+<g >
+<title>dequote_string (1,570,753,093 samples, 0.25%)</title><rect x="678.2" y="1341" width="10.2" height="19.0" fill="rgb(213,40,9)" rx="2" ry="2" />
+<text  x="681.16" y="1353.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (704,492,242 samples, 0.11%)</title><rect x="296.5" y="601" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.51" y="613.5" ></text>
+</g>
+<g >
+<title>[bash] (206,692,273 samples, 0.03%)</title><rect x="869.4" y="341" width="1.4" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="872.43" y="353.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (862,395,726 samples, 0.14%)</title><rect x="301.2" y="1021" width="5.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.15" y="1033.5" ></text>
+</g>
+<g >
+<title>execute_command (713,521,499 samples, 0.11%)</title><rect x="296.5" y="1781" width="4.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="299.45" y="1793.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (435,069,062 samples, 0.07%)</title><rect x="2083.1" y="2441" width="2.9" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="2086.11" y="2453.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (4,419,675,253 samples, 0.69%)</title><rect x="3904.5" y="2401" width="29.0" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="3907.53" y="2413.5" >en..</text>
+</g>
+<g >
+<title>execute_command (512,251,839 samples, 0.08%)</title><rect x="856.9" y="761" width="3.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="859.94" y="773.5" ></text>
+</g>
+<g >
+<title>__GI___libc_write (547,965,933 samples, 0.09%)</title><rect x="2187.6" y="2441" width="3.6" height="19.0" fill="rgb(217,57,13)" rx="2" ry="2" />
+<text  x="2190.64" y="2453.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (480,699,859 samples, 0.08%)</title><rect x="276.9" y="641" width="3.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="279.94" y="653.5" ></text>
+</g>
+<g >
+<title>execute_command (200,901,327 samples, 0.03%)</title><rect x="280.1" y="301" width="1.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="283.11" y="313.5" ></text>
+</g>
+<g >
+<title>[bash] (7,201,720,807 samples, 1.13%)</title><rect x="308.6" y="941" width="47.1" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="311.57" y="953.5" >[bash]</text>
+</g>
+<g >
+<title>execute_command (598,514,664 samples, 0.09%)</title><rect x="891.4" y="1601" width="3.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="894.40" y="1613.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (575,800,354 samples, 0.09%)</title><rect x="884.6" y="1541" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="887.64" y="1553.5" ></text>
+</g>
+<g >
+<title>execute_command (1,147,316,451 samples, 0.18%)</title><rect x="827.6" y="1361" width="7.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="830.59" y="1373.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (436,055,112 samples, 0.07%)</title><rect x="888.5" y="1861" width="2.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="891.55" y="1873.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (171,847,094 samples, 0.03%)</title><rect x="871.9" y="1421" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="874.89" y="1433.5" ></text>
+</g>
+<g >
+<title>execute_command (179,777,548 samples, 0.03%)</title><rect x="878.5" y="1281" width="1.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="881.48" y="1293.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,261,220,789 samples, 0.20%)</title><rect x="860.3" y="961" width="8.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.32" y="973.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,147,316,451 samples, 0.18%)</title><rect x="827.6" y="1441" width="7.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.59" y="1453.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (516,725,798 samples, 0.08%)</title><rect x="856.9" y="2501" width="3.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="859.92" y="2513.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (866,614,713 samples, 0.14%)</title><rect x="301.1" y="2181" width="5.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.12" y="2193.5" ></text>
+</g>
+<g >
+<title>path_openat (1,924,511,857 samples, 0.30%)</title><rect x="2127.2" y="2281" width="12.6" height="19.0" fill="rgb(205,2,0)" rx="2" ry="2" />
+<text  x="2130.23" y="2293.5" ></text>
+</g>
+<g >
+<title>execute_command (1,150,422,968 samples, 0.18%)</title><rect x="827.6" y="1881" width="7.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="830.57" y="1893.5" ></text>
+</g>
+<g >
+<title>parse_and_execute (169,780,177 samples, 0.03%)</title><rect x="835.3" y="421" width="1.1" height="19.0" fill="rgb(243,178,42)" rx="2" ry="2" />
+<text  x="838.33" y="433.5" ></text>
+</g>
+<g >
+<title>execute_command (717,313,739 samples, 0.11%)</title><rect x="280.1" y="2521" width="4.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="283.09" y="2533.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (481,813,209 samples, 0.08%)</title><rect x="276.9" y="1201" width="3.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="279.93" y="1213.5" ></text>
+</g>
+<g >
+<title>[cksum] (95,558,657,645 samples, 14.97%)</title><rect x="904.8" y="2481" width="625.6" height="19.0" fill="rgb(241,167,40)" rx="2" ry="2" />
+<text  x="907.82" y="2493.5" >[cksum]</text>
+</g>
+<g >
+<title>execute_command_internal (62,280,472,878 samples, 9.75%)</title><rect x="395.6" y="1561" width="407.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="398.61" y="1573.5" >execute_command_internal</text>
+</g>
+<g >
+<title>do_syscall_64 (270,626,950 samples, 0.04%)</title><rect x="225.6" y="2421" width="1.8" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="228.61" y="2433.5" ></text>
+</g>
+<g >
+<title>execute_command (866,614,713 samples, 0.14%)</title><rect x="301.1" y="1521" width="5.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="304.12" y="1533.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (164,808,262 samples, 0.03%)</title><rect x="870.8" y="1501" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="873.81" y="1513.5" ></text>
+</g>
+<g >
+<title>execute_command (842,511,421 samples, 0.13%)</title><rect x="895.4" y="721" width="5.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="898.39" y="733.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (76,161,574,756 samples, 11.93%)</title><rect x="307.9" y="1961" width="498.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="310.94" y="1973.5" >execute_command_internal</text>
+</g>
+<g >
+<title>execute_command_internal (195,916,485 samples, 0.03%)</title><rect x="835.2" y="1461" width="1.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="838.17" y="1473.5" ></text>
+</g>
+<g >
+<title>execute_command (704,492,242 samples, 0.11%)</title><rect x="296.5" y="941" width="4.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="299.51" y="953.5" ></text>
+</g>
+<g >
+<title>execute_command (889,542,281 samples, 0.14%)</title><rect x="851.1" y="741" width="5.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="854.09" y="753.5" ></text>
+</g>
+<g >
+<title>execute_command (862,395,726 samples, 0.14%)</title><rect x="301.2" y="1241" width="5.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="304.15" y="1253.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (596,118,643 samples, 0.09%)</title><rect x="891.4" y="1101" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.42" y="1113.5" ></text>
+</g>
+<g >
+<title>execute_command (578,068,287 samples, 0.09%)</title><rect x="884.6" y="2501" width="3.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="887.62" y="2513.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (428,723,209 samples, 0.07%)</title><rect x="2567.1" y="2401" width="2.8" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="2570.14" y="2413.5" ></text>
+</g>
+<g >
+<title>execute_command (688,777,208 samples, 0.11%)</title><rect x="268.8" y="2161" width="4.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="271.77" y="2173.5" ></text>
+</g>
+<g >
+<title>execute_command (704,492,242 samples, 0.11%)</title><rect x="296.5" y="781" width="4.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="299.51" y="793.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,263,560,140 samples, 0.20%)</title><rect x="860.3" y="2401" width="8.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.30" y="2413.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (436,055,112 samples, 0.07%)</title><rect x="888.5" y="2501" width="2.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="891.55" y="2513.5" ></text>
+</g>
+<g >
+<title>ret_from_fork_asm (327,043,580 samples, 0.05%)</title><rect x="708.3" y="1281" width="2.1" height="19.0" fill="rgb(247,193,46)" rx="2" ry="2" />
+<text  x="711.28" y="1293.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (171,847,094 samples, 0.03%)</title><rect x="871.9" y="1621" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="874.89" y="1633.5" ></text>
+</g>
+<g >
+<title>__libc_start_call_main (38,976,167,927 samples, 6.10%)</title><rect x="10.0" y="2541" width="255.2" height="19.0" fill="rgb(210,26,6)" rx="2" ry="2" />
+<text  x="13.00" y="2553.5" >__libc_start_call_main</text>
+</g>
+<g >
+<title>execute_command_internal (164,731,865 samples, 0.03%)</title><rect x="836.5" y="1081" width="1.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="839.46" y="1093.5" ></text>
+</g>
+<g >
+<title>do_redirections (1,006,427,291 samples, 0.16%)</title><rect x="861.9" y="341" width="6.6" height="19.0" fill="rgb(247,193,46)" rx="2" ry="2" />
+<text  x="864.91" y="353.5" ></text>
+</g>
+<g >
+<title>_IO_file_fopen@@GLIBC_2.2.5 (2,821,200,312 samples, 0.44%)</title><rect x="3022.9" y="2441" width="18.5" height="19.0" fill="rgb(237,148,35)" rx="2" ry="2" />
+<text  x="3025.92" y="2453.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (713,987,302 samples, 0.11%)</title><rect x="280.1" y="1381" width="4.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.11" y="1393.5" ></text>
+</g>
+<g >
+<title>posix_fadvise (529,875,400 samples, 0.08%)</title><rect x="3103.1" y="2501" width="3.4" height="19.0" fill="rgb(245,186,44)" rx="2" ry="2" />
+<text  x="3106.05" y="2513.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (212,497,329 samples, 0.03%)</title><rect x="827.6" y="181" width="1.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.59" y="193.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (550,598,300 samples, 0.09%)</title><rect x="273.3" y="961" width="3.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="276.32" y="973.5" ></text>
+</g>
+<g >
+<title>make_child (270,026,741 samples, 0.04%)</title><rect x="270.0" y="281" width="1.7" height="19.0" fill="rgb(242,170,40)" rx="2" ry="2" />
+<text  x="272.97" y="293.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (516,725,798 samples, 0.08%)</title><rect x="856.9" y="1701" width="3.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="859.92" y="1713.5" ></text>
+</g>
+<g >
+<title>execute_command (7,231,852,508 samples, 1.13%)</title><rect x="308.5" y="1201" width="47.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="311.53" y="1213.5" >exec..</text>
+</g>
+<g >
+<title>execute_command (164,731,865 samples, 0.03%)</title><rect x="836.5" y="1221" width="1.0" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="839.46" y="1233.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (354,998,378 samples, 0.06%)</title><rect x="840.5" y="1401" width="2.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="843.48" y="1413.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (164,808,262 samples, 0.03%)</title><rect x="870.8" y="1461" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="873.81" y="1473.5" ></text>
+</g>
+<g >
+<title>[bash] (212,076,909 samples, 0.03%)</title><rect x="334.5" y="561" width="1.4" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="337.49" y="573.5" ></text>
+</g>
+<g >
+<title>[bash] (179,777,548 samples, 0.03%)</title><rect x="878.5" y="841" width="1.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="881.48" y="853.5" ></text>
+</g>
+<g >
+<title>parse_and_execute (165,315,838 samples, 0.03%)</title><rect x="871.9" y="481" width="1.1" height="19.0" fill="rgb(243,178,42)" rx="2" ry="2" />
+<text  x="874.92" y="493.5" ></text>
+</g>
+<g >
+<title>__x64_sys_openat (2,121,550,539 samples, 0.33%)</title><rect x="1592.2" y="2341" width="13.9" height="19.0" fill="rgb(208,15,3)" rx="2" ry="2" />
+<text  x="1595.21" y="2353.5" ></text>
+</g>
+<g >
+<title>do_sys_openat2 (274,872,352 samples, 0.04%)</title><rect x="345.4" y="561" width="1.8" height="19.0" fill="rgb(209,21,5)" rx="2" ry="2" />
+<text  x="348.43" y="573.5" ></text>
+</g>
+<g >
+<title>execute_command (163,954,022 samples, 0.03%)</title><rect x="870.8" y="1001" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="873.82" y="1013.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (171,847,094 samples, 0.03%)</title><rect x="871.9" y="1381" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="874.89" y="1393.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (158,599,791 samples, 0.02%)</title><rect x="875.9" y="861" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="878.93" y="873.5" ></text>
+</g>
+<g >
+<title>execute_command (215,132,849 samples, 0.03%)</title><rect x="842.8" y="1501" width="1.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="845.81" y="1513.5" ></text>
+</g>
+<g >
+<title>shmem_get_folio_gfp (307,828,323 samples, 0.05%)</title><rect x="1458.3" y="2301" width="2.1" height="19.0" fill="rgb(219,67,16)" rx="2" ry="2" />
+<text  x="1461.34" y="2313.5" ></text>
+</g>
+<g >
+<title>execute_command (1,263,560,140 samples, 0.20%)</title><rect x="860.3" y="1661" width="8.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="863.30" y="1673.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (842,511,421 samples, 0.13%)</title><rect x="895.4" y="901" width="5.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.39" y="913.5" ></text>
+</g>
+<g >
+<title>execute_command (483,985,097 samples, 0.08%)</title><rect x="276.9" y="1981" width="3.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="279.92" y="1993.5" ></text>
+</g>
+<g >
+<title>[bash] (713,521,499 samples, 0.11%)</title><rect x="296.5" y="2421" width="4.6" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="299.45" y="2433.5" ></text>
+</g>
+<g >
+<title>[bash] (326,968,908 samples, 0.05%)</title><rect x="336.9" y="621" width="2.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="339.94" y="633.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,263,560,140 samples, 0.20%)</title><rect x="860.3" y="1641" width="8.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.30" y="1653.5" ></text>
+</g>
+<g >
+<title>parse_and_execute (281,945,248 samples, 0.04%)</title><rect x="275.1" y="381" width="1.8" height="19.0" fill="rgb(243,178,42)" rx="2" ry="2" />
+<text  x="278.05" y="393.5" ></text>
+</g>
+<g >
+<title>execute_command (578,068,287 samples, 0.09%)</title><rect x="884.6" y="2381" width="3.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="887.62" y="2393.5" ></text>
+</g>
+<g >
+<title>[bash] (323,026,366 samples, 0.05%)</title><rect x="868.7" y="1401" width="2.1" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="871.70" y="1413.5" ></text>
+</g>
+<g >
+<title>[b2sum] (24,767,148,019 samples, 3.88%)</title><rect x="13.7" y="2441" width="162.2" height="19.0" fill="rgb(216,50,12)" rx="2" ry="2" />
+<text  x="16.72" y="2453.5" >[b2sum]</text>
+</g>
+<g >
+<title>execute_command (891,895,571 samples, 0.14%)</title><rect x="851.1" y="2141" width="5.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="854.08" y="2153.5" ></text>
+</g>
+<g >
+<title>redirection_expand (467,938,705 samples, 0.07%)</title><rect x="857.2" y="441" width="3.1" height="19.0" fill="rgb(218,63,15)" rx="2" ry="2" />
+<text  x="860.22" y="453.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (259,914,992 samples, 0.04%)</title><rect x="2146.6" y="2381" width="1.7" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="2149.60" y="2393.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (842,511,421 samples, 0.13%)</title><rect x="895.4" y="941" width="5.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.39" y="953.5" ></text>
+</g>
+<g >
+<title>__GI___libc_open (286,925,888 samples, 0.04%)</title><rect x="319.9" y="521" width="1.9" height="19.0" fill="rgb(249,202,48)" rx="2" ry="2" />
+<text  x="322.91" y="533.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (281,921,411 samples, 0.04%)</title><rect x="827.6" y="381" width="1.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.59" y="393.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (513,428,353 samples, 0.08%)</title><rect x="856.9" y="1021" width="3.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="859.94" y="1033.5" ></text>
+</g>
+<g >
+<title>execute_command (436,055,112 samples, 0.07%)</title><rect x="888.5" y="1721" width="2.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="891.55" y="1733.5" ></text>
+</g>
+<g >
+<title>_IO_file_open (5,076,944,665 samples, 0.80%)</title><rect x="1468.5" y="2421" width="33.2" height="19.0" fill="rgb(249,205,49)" rx="2" ry="2" />
+<text  x="1471.46" y="2433.5" >_I..</text>
+</g>
+<g >
+<title>syscall_return_via_sysret (197,744,385 samples, 0.03%)</title><rect x="2614.2" y="2461" width="1.3" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="2617.17" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (513,954,307 samples, 0.08%)</title><rect x="856.9" y="1561" width="3.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="859.94" y="1573.5" ></text>
+</g>
+<g >
+<title>execute_command (554,006,342 samples, 0.09%)</title><rect x="273.3" y="1741" width="3.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="276.29" y="1753.5" ></text>
+</g>
+<g >
+<title>new_do_write (515,419,034 samples, 0.08%)</title><rect x="1530.6" y="2441" width="3.3" height="19.0" fill="rgb(206,5,1)" rx="2" ry="2" />
+<text  x="1533.56" y="2453.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (164,731,865 samples, 0.03%)</title><rect x="836.5" y="1161" width="1.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="839.46" y="1173.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (481,191,724 samples, 0.08%)</title><rect x="276.9" y="841" width="3.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="279.94" y="853.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (551,359,579 samples, 0.09%)</title><rect x="273.3" y="1441" width="3.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="276.31" y="1453.5" ></text>
+</g>
+<g >
+<title>execute_command (163,415,529 samples, 0.03%)</title><rect x="870.8" y="681" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="873.82" y="693.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (6,047,892,104 samples, 0.95%)</title><rect x="309.8" y="781" width="39.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="312.81" y="793.5" >exe..</text>
+</g>
+<g >
+<title>execute_command (705,583,873 samples, 0.11%)</title><rect x="296.5" y="1321" width="4.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="299.50" y="1333.5" ></text>
+</g>
+<g >
+<title>link_path_walk.part.0.constprop.0 (972,234,658 samples, 0.15%)</title><rect x="2546.3" y="2261" width="6.4" height="19.0" fill="rgb(254,229,54)" rx="2" ry="2" />
+<text  x="2549.31" y="2273.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (6,159,910,382 samples, 0.96%)</title><rect x="851.1" y="2581" width="40.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.08" y="2593.5" >exe..</text>
+</g>
+<g >
+<title>execute_command (1,263,560,140 samples, 0.20%)</title><rect x="860.3" y="2061" width="8.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="863.30" y="2073.5" ></text>
+</g>
+<g >
+<title>[bash] (467,815,482 samples, 0.07%)</title><rect x="857.2" y="401" width="3.1" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="860.22" y="413.5" ></text>
+</g>
+<g >
+<title>vfs_open (446,515,814 samples, 0.07%)</title><rect x="2035.5" y="2261" width="2.9" height="19.0" fill="rgb(238,154,37)" rx="2" ry="2" />
+<text  x="2038.51" y="2273.5" ></text>
+</g>
+<g >
+<title>lookup_fast (335,169,583 samples, 0.05%)</title><rect x="3919.2" y="2281" width="2.2" height="19.0" fill="rgb(226,97,23)" rx="2" ry="2" />
+<text  x="3922.16" y="2293.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (5,776,141,249 samples, 0.90%)</title><rect x="356.6" y="881" width="37.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="359.57" y="893.5" >exe..</text>
+</g>
+<g >
+<title>entry_SYSRETQ_unsafe_stack (170,145,239 samples, 0.03%)</title><rect x="2112.4" y="2481" width="1.1" height="19.0" fill="rgb(213,37,8)" rx="2" ry="2" />
+<text  x="2115.37" y="2493.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,459,778,173 samples, 0.23%)</title><rect x="327.3" y="641" width="9.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="330.33" y="653.5" ></text>
+</g>
+<g >
+<title>getname_flags.part.0 (258,000,723 samples, 0.04%)</title><rect x="3037.3" y="2301" width="1.7" height="19.0" fill="rgb(213,39,9)" rx="2" ry="2" />
+<text  x="3040.27" y="2313.5" ></text>
+</g>
+<g >
+<title>__check_object_size (155,967,522 samples, 0.02%)</title><rect x="664.9" y="1221" width="1.0" height="19.0" fill="rgb(232,127,30)" rx="2" ry="2" />
+<text  x="667.88" y="1233.5" ></text>
+</g>
+<g >
+<title>shmem_write_begin (225,672,831 samples, 0.04%)</title><rect x="901.2" y="2361" width="1.5" height="19.0" fill="rgb(242,171,40)" rx="2" ry="2" />
+<text  x="904.19" y="2373.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (592,880,892 samples, 0.09%)</title><rect x="891.4" y="541" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.42" y="553.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (2,964,154,477 samples, 0.46%)</title><rect x="808.2" y="2561" width="19.4" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="811.16" y="2573.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (861,612,432 samples, 0.13%)</title><rect x="301.2" y="661" width="5.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.16" y="673.5" ></text>
+</g>
+<g >
+<title>execute_command (554,006,342 samples, 0.09%)</title><rect x="273.3" y="2381" width="3.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="276.29" y="2393.5" ></text>
+</g>
+<g >
+<title>[unknown] (49,769,174,491 samples, 7.79%)</title><rect x="2208.3" y="2581" width="325.8" height="19.0" fill="rgb(210,24,5)" rx="2" ry="2" />
+<text  x="2211.31" y="2593.5" >[unknown]</text>
+</g>
+<g >
+<title>[bash] (596,118,643 samples, 0.09%)</title><rect x="891.4" y="1161" width="3.9" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="894.42" y="1173.5" ></text>
+</g>
+<g >
+<title>execute_command (595,672,870 samples, 0.09%)</title><rect x="891.4" y="641" width="3.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="894.42" y="653.5" ></text>
+</g>
+<g >
+<title>[bash] (164,808,262 samples, 0.03%)</title><rect x="870.8" y="1421" width="1.1" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="873.81" y="1433.5" ></text>
+</g>
+<g >
+<title>do_filp_open (1,870,424,891 samples, 0.29%)</title><rect x="3024.9" y="2301" width="12.2" height="19.0" fill="rgb(217,58,13)" rx="2" ry="2" />
+<text  x="3027.90" y="2313.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (717,313,739 samples, 0.11%)</title><rect x="280.1" y="1441" width="4.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.09" y="1453.5" ></text>
+</g>
+<g >
+<title>_IO_doallocbuf (821,293,940 samples, 0.13%)</title><rect x="2145.2" y="2441" width="5.4" height="19.0" fill="rgb(214,45,10)" rx="2" ry="2" />
+<text  x="2148.20" y="2453.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (484,042,732 samples, 0.08%)</title><rect x="276.9" y="2541" width="3.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="279.92" y="2553.5" ></text>
+</g>
+<g >
+<title>bpf_trampoline_6442533562 (175,752,052 samples, 0.03%)</title><rect x="3329.2" y="2181" width="1.1" height="19.0" fill="rgb(221,78,18)" rx="2" ry="2" />
+<text  x="3332.18" y="2193.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (481,813,209 samples, 0.08%)</title><rect x="276.9" y="1461" width="3.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="279.93" y="1473.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (688,813,226 samples, 0.11%)</title><rect x="268.8" y="2541" width="4.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="271.77" y="2553.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (320,852,930 samples, 0.05%)</title><rect x="868.7" y="781" width="2.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="871.70" y="793.5" ></text>
+</g>
+<g >
+<title>parse_and_execute (598,514,664 samples, 0.09%)</title><rect x="891.4" y="2541" width="3.9" height="19.0" fill="rgb(243,178,42)" rx="2" ry="2" />
+<text  x="894.40" y="2553.5" ></text>
+</g>
+<g >
+<title>free_pages_and_swap_cache (399,069,106 samples, 0.06%)</title><rect x="290.2" y="2341" width="2.6" height="19.0" fill="rgb(229,112,26)" rx="2" ry="2" />
+<text  x="293.17" y="2353.5" ></text>
+</g>
+<g >
+<title>execute_command (516,725,798 samples, 0.08%)</title><rect x="856.9" y="2281" width="3.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="859.92" y="2293.5" ></text>
+</g>
+<g >
+<title>__do_sys_newfstatat (3,014,455,885 samples, 0.47%)</title><rect x="4161.5" y="2441" width="19.7" height="19.0" fill="rgb(250,207,49)" rx="2" ry="2" />
+<text  x="4164.50" y="2453.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (575,055,300 samples, 0.09%)</title><rect x="884.6" y="1181" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="887.64" y="1193.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,263,560,140 samples, 0.20%)</title><rect x="860.3" y="2321" width="8.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.30" y="2333.5" ></text>
+</g>
+<g >
+<title>execute_command (713,521,499 samples, 0.11%)</title><rect x="296.5" y="1461" width="4.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="299.45" y="1473.5" ></text>
+</g>
+<g >
+<title>execute_command (436,055,112 samples, 0.07%)</title><rect x="888.5" y="1801" width="2.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="891.55" y="1813.5" ></text>
+</g>
+<g >
+<title>execute_command (511,672,691 samples, 0.08%)</title><rect x="856.9" y="601" width="3.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="859.94" y="613.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (164,808,262 samples, 0.03%)</title><rect x="870.8" y="1601" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="873.81" y="1613.5" ></text>
+</g>
+<g >
+<title>[bash] (432,872,015 samples, 0.07%)</title><rect x="888.6" y="1141" width="2.8" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="891.57" y="1153.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (866,614,713 samples, 0.14%)</title><rect x="301.1" y="1661" width="5.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.12" y="1673.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (483,985,097 samples, 0.08%)</title><rect x="276.9" y="1641" width="3.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="279.92" y="1653.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (595,672,870 samples, 0.09%)</title><rect x="891.4" y="741" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.42" y="753.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (578,543,670 samples, 0.09%)</title><rect x="269.4" y="441" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="272.44" y="453.5" ></text>
+</g>
+<g >
+<title>execute_command (575,055,300 samples, 0.09%)</title><rect x="884.6" y="1141" width="3.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="887.64" y="1153.5" ></text>
+</g>
+<g >
+<title>[bash] (862,395,726 samples, 0.14%)</title><rect x="301.2" y="1121" width="5.6" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="304.15" y="1133.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (164,731,865 samples, 0.03%)</title><rect x="836.5" y="1201" width="1.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="839.46" y="1213.5" ></text>
+</g>
+<g >
+<title>__libc_start_main@@GLIBC_2.34 (51,718,519,384 samples, 8.10%)</title><rect x="3687.1" y="2561" width="338.5" height="19.0" fill="rgb(229,113,27)" rx="2" ry="2" />
+<text  x="3690.08" y="2573.5" >__libc_start_main@@GLIBC_2.34</text>
+</g>
+<g >
+<title>execute_command (813,926,528 samples, 0.13%)</title><rect x="868.6" y="1761" width="5.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="871.57" y="1773.5" ></text>
+</g>
+<g >
+<title>execute_command (1,150,422,968 samples, 0.18%)</title><rect x="827.6" y="2321" width="7.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="830.57" y="2333.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (166,042,857 samples, 0.03%)</title><rect x="836.5" y="1601" width="1.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="839.46" y="1613.5" ></text>
+</g>
+<g >
+<title>rep_movs_alternative (3,150,582,035 samples, 0.49%)</title><rect x="4079.2" y="2281" width="20.7" height="19.0" fill="rgb(211,31,7)" rx="2" ry="2" />
+<text  x="4082.24" y="2293.5" ></text>
+</g>
+<g >
+<title>b2sum (39,437,216,244 samples, 6.18%)</title><rect x="10.0" y="2601" width="258.2" height="19.0" fill="rgb(254,228,54)" rx="2" ry="2" />
+<text  x="13.00" y="2613.5" >b2sum</text>
+</g>
+<g >
+<title>execute_command (2,336,163,397 samples, 0.37%)</title><rect x="835.1" y="2461" width="15.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="838.10" y="2473.5" ></text>
+</g>
+<g >
+<title>[bash] (158,609,286 samples, 0.02%)</title><rect x="836.5" y="481" width="1.0" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="839.50" y="493.5" ></text>
+</g>
+<g >
+<title>[bash] (346,100,708 samples, 0.05%)</title><rect x="886.0" y="281" width="2.3" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="889.05" y="293.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (179,777,548 samples, 0.03%)</title><rect x="878.5" y="961" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="881.48" y="973.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (688,777,208 samples, 0.11%)</title><rect x="268.8" y="1501" width="4.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="271.77" y="1513.5" ></text>
+</g>
+<g >
+<title>[bash] (1,147,316,451 samples, 0.18%)</title><rect x="827.6" y="1241" width="7.5" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="830.59" y="1253.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (861,612,432 samples, 0.13%)</title><rect x="301.2" y="701" width="5.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.16" y="713.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (215,748,926 samples, 0.03%)</title><rect x="842.8" y="1561" width="1.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="845.80" y="1573.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (688,777,208 samples, 0.11%)</title><rect x="268.8" y="2501" width="4.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="271.77" y="2513.5" ></text>
+</g>
+<g >
+<title>[bash] (1,150,422,968 samples, 0.18%)</title><rect x="827.6" y="2521" width="7.5" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="830.57" y="2533.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (513,954,307 samples, 0.08%)</title><rect x="856.9" y="1461" width="3.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="859.94" y="1473.5" ></text>
+</g>
+<g >
+<title>__libc_fork (185,363,592 samples, 0.03%)</title><rect x="273.8" y="361" width="1.3" height="19.0" fill="rgb(220,70,16)" rx="2" ry="2" />
+<text  x="276.84" y="373.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (866,614,713 samples, 0.14%)</title><rect x="301.1" y="1981" width="5.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.12" y="1993.5" ></text>
+</g>
+<g >
+<title>execute_command (163,954,022 samples, 0.03%)</title><rect x="870.8" y="881" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="873.82" y="893.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (163,922,807 samples, 0.03%)</title><rect x="331.4" y="461" width="1.1" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="334.45" y="473.5" ></text>
+</g>
+<g >
+<title>execute_command (164,808,262 samples, 0.03%)</title><rect x="870.8" y="1521" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="873.81" y="1533.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (548,788,616 samples, 0.09%)</title><rect x="273.3" y="561" width="3.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="276.32" y="573.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (688,777,208 samples, 0.11%)</title><rect x="268.8" y="1541" width="4.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="271.77" y="1553.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (179,777,548 samples, 0.03%)</title><rect x="878.5" y="981" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="881.48" y="993.5" ></text>
+</g>
+<g >
+<title>execute_command (688,777,208 samples, 0.11%)</title><rect x="268.8" y="2121" width="4.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="271.77" y="2133.5" ></text>
+</g>
+<g >
+<title>[bash] (405,753,984 samples, 0.06%)</title><rect x="791.9" y="1281" width="2.6" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="794.87" y="1293.5" ></text>
+</g>
+<g >
+<title>__GI___libc_open (163,233,630 samples, 0.03%)</title><rect x="3903.0" y="2421" width="1.0" height="19.0" fill="rgb(249,202,48)" rx="2" ry="2" />
+<text  x="3905.96" y="2433.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (475,933,992 samples, 0.07%)</title><rect x="281.5" y="341" width="3.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="284.54" y="353.5" ></text>
+</g>
+<g >
+<title>execute_command (483,985,097 samples, 0.08%)</title><rect x="276.9" y="1901" width="3.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="279.92" y="1913.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (156,545,099 samples, 0.02%)</title><rect x="2183.6" y="2461" width="1.0" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="2186.60" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (158,744,410 samples, 0.02%)</title><rect x="875.9" y="1141" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="878.93" y="1153.5" ></text>
+</g>
+<g >
+<title>execute_command (578,068,287 samples, 0.09%)</title><rect x="884.6" y="2021" width="3.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="887.62" y="2033.5" ></text>
+</g>
+<g >
+<title>execute_command (1,263,560,140 samples, 0.20%)</title><rect x="860.3" y="1701" width="8.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="863.30" y="1713.5" ></text>
+</g>
+<g >
+<title>entry_SYSRETQ_unsafe_stack (179,425,959 samples, 0.03%)</title><rect x="2640.6" y="2481" width="1.1" height="19.0" fill="rgb(213,37,8)" rx="2" ry="2" />
+<text  x="2643.57" y="2493.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (5,215,891,029 samples, 0.82%)</title><rect x="359.7" y="641" width="34.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="362.66" y="653.5" >ex..</text>
+</g>
+<g >
+<title>execute_command_internal (483,985,097 samples, 0.08%)</title><rect x="276.9" y="1721" width="3.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="279.92" y="1733.5" ></text>
+</g>
+<g >
+<title>execute_command (179,777,548 samples, 0.03%)</title><rect x="878.5" y="1201" width="1.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="881.48" y="1213.5" ></text>
+</g>
+<g >
+<title>syscall_return_via_sysret (301,087,197 samples, 0.05%)</title><rect x="4009.7" y="2461" width="1.9" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="4012.66" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command (163,563,240 samples, 0.03%)</title><rect x="870.8" y="801" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="873.82" y="813.5" ></text>
+</g>
+<g >
+<title>execute_command (166,042,857 samples, 0.03%)</title><rect x="836.5" y="1581" width="1.0" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="839.46" y="1593.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (356,134,455 samples, 0.06%)</title><rect x="840.5" y="1721" width="2.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="843.47" y="1733.5" ></text>
+</g>
+<g >
+<title>openaux (176,255,369 samples, 0.03%)</title><rect x="3682.0" y="2461" width="1.1" height="19.0" fill="rgb(252,217,52)" rx="2" ry="2" />
+<text  x="3685.00" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (483,985,097 samples, 0.08%)</title><rect x="276.9" y="2161" width="3.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="279.92" y="2173.5" ></text>
+</g>
+<g >
+<title>execute_command (179,777,548 samples, 0.03%)</title><rect x="878.5" y="1401" width="1.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="881.48" y="1413.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (314,810,831 samples, 0.05%)</title><rect x="1503.4" y="2381" width="2.0" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="1506.38" y="2393.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (179,777,548 samples, 0.03%)</title><rect x="878.5" y="1021" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="881.48" y="1033.5" ></text>
+</g>
+<g >
+<title>execute_command (179,777,548 samples, 0.03%)</title><rect x="878.5" y="1321" width="1.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="881.48" y="1333.5" ></text>
+</g>
+<g >
+<title>[bash] (180,216,075 samples, 0.03%)</title><rect x="878.5" y="1781" width="1.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="881.48" y="1793.5" ></text>
+</g>
+<g >
+<title>[bash] (158,643,683 samples, 0.02%)</title><rect x="836.5" y="521" width="1.0" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="839.50" y="533.5" ></text>
+</g>
+<g >
+<title>execute_command (598,514,664 samples, 0.09%)</title><rect x="891.4" y="1721" width="3.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="894.40" y="1733.5" ></text>
+</g>
+<g >
+<title>execute_command (704,492,242 samples, 0.11%)</title><rect x="296.5" y="821" width="4.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="299.51" y="833.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (578,068,287 samples, 0.09%)</title><rect x="884.6" y="1841" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="887.62" y="1853.5" ></text>
+</g>
+<g >
+<title>execute_command (483,985,097 samples, 0.08%)</title><rect x="276.9" y="2221" width="3.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="279.92" y="2233.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (890,006,400 samples, 0.14%)</title><rect x="851.1" y="1421" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.09" y="1433.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (598,514,664 samples, 0.09%)</title><rect x="891.4" y="1901" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.40" y="1913.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,150,422,968 samples, 0.18%)</title><rect x="827.6" y="1501" width="7.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.57" y="1513.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (866,614,713 samples, 0.14%)</title><rect x="301.1" y="1421" width="5.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.12" y="1433.5" ></text>
+</g>
+<g >
+<title>_IO_do_write@@GLIBC_2.2.5 (563,112,272 samples, 0.09%)</title><rect x="2187.5" y="2481" width="3.7" height="19.0" fill="rgb(238,155,37)" rx="2" ry="2" />
+<text  x="2190.54" y="2493.5" ></text>
+</g>
+<g >
+<title>execute_command (849,509,116 samples, 0.13%)</title><rect x="895.3" y="1561" width="5.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="898.35" y="1573.5" ></text>
+</g>
+<g >
+<title>exit_mmap (1,174,104,533 samples, 0.18%)</title><rect x="288.3" y="2401" width="7.7" height="19.0" fill="rgb(242,173,41)" rx="2" ry="2" />
+<text  x="291.27" y="2413.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (169,343,373 samples, 0.03%)</title><rect x="280.1" y="241" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.11" y="253.5" ></text>
+</g>
+<g >
+<title>__do_sys_newfstat (226,841,595 samples, 0.04%)</title><rect x="2146.7" y="2361" width="1.5" height="19.0" fill="rgb(225,96,23)" rx="2" ry="2" />
+<text  x="2149.68" y="2373.5" ></text>
+</g>
+<g >
+<title>execute_command (551,359,579 samples, 0.09%)</title><rect x="273.3" y="1561" width="3.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="276.31" y="1573.5" ></text>
+</g>
+<g >
+<title>[bash] (459,215,281 samples, 0.07%)</title><rect x="403.6" y="1021" width="3.0" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="406.58" y="1033.5" ></text>
+</g>
+<g >
+<title>execute_command (575,055,300 samples, 0.09%)</title><rect x="884.6" y="1061" width="3.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="887.64" y="1073.5" ></text>
+</g>
+<g >
+<title>_IO_fflush (155,281,976 samples, 0.02%)</title><rect x="371.3" y="221" width="1.0" height="19.0" fill="rgb(218,60,14)" rx="2" ry="2" />
+<text  x="374.26" y="233.5" ></text>
+</g>
+<g >
+<title>__strlen_evex (328,661,342 samples, 0.05%)</title><rect x="549.7" y="1201" width="2.1" height="19.0" fill="rgb(240,164,39)" rx="2" ry="2" />
+<text  x="552.65" y="1213.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (425,110,343 samples, 0.07%)</title><rect x="888.6" y="541" width="2.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="891.57" y="553.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,145,759,953 samples, 0.18%)</title><rect x="827.6" y="541" width="7.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.59" y="553.5" ></text>
+</g>
+<g >
+<title>execute_command (688,777,208 samples, 0.11%)</title><rect x="268.8" y="2361" width="4.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="271.77" y="2373.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (442,577,833 samples, 0.07%)</title><rect x="862.9" y="141" width="2.9" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="865.91" y="153.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (2,796,040,524 samples, 0.44%)</title><rect x="1615.3" y="2441" width="18.3" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="1618.29" y="2453.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (2,568,153,354 samples, 0.40%)</title><rect x="1444.1" y="2401" width="16.8" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="1447.07" y="2413.5" ></text>
+</g>
+<g >
+<title>execute_command (574,909,828 samples, 0.09%)</title><rect x="884.6" y="741" width="3.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="887.64" y="753.5" ></text>
+</g>
+<g >
+<title>__page_cache_release.part.0 (159,467,915 samples, 0.02%)</title><rect x="815.1" y="2341" width="1.0" height="19.0" fill="rgb(216,51,12)" rx="2" ry="2" />
+<text  x="818.08" y="2353.5" ></text>
+</g>
+<g >
+<title>execute_command (578,068,287 samples, 0.09%)</title><rect x="884.6" y="2181" width="3.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="887.62" y="2193.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (221,877,244 samples, 0.03%)</title><rect x="313.1" y="441" width="1.4" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="316.06" y="453.5" ></text>
+</g>
+<g >
+<title>__x64_sys_close (246,368,034 samples, 0.04%)</title><rect x="225.7" y="2401" width="1.6" height="19.0" fill="rgb(238,153,36)" rx="2" ry="2" />
+<text  x="228.69" y="2413.5" ></text>
+</g>
+<g >
+<title>_dl_sysdep_start (380,388,354 samples, 0.06%)</title><rect x="4186.5" y="2541" width="2.5" height="19.0" fill="rgb(234,137,32)" rx="2" ry="2" />
+<text  x="4189.49" y="2553.5" ></text>
+</g>
+<g >
+<title>walk_component (350,749,245 samples, 0.05%)</title><rect x="3916.9" y="2261" width="2.3" height="19.0" fill="rgb(247,197,47)" rx="2" ry="2" />
+<text  x="3919.87" y="2273.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,261,568,072 samples, 0.20%)</title><rect x="860.3" y="1281" width="8.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.31" y="1293.5" ></text>
+</g>
+<g >
+<title>execute_command (166,042,857 samples, 0.03%)</title><rect x="836.5" y="1341" width="1.0" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="839.46" y="1353.5" ></text>
+</g>
+<g >
+<title>do_wp_page (632,795,332 samples, 0.10%)</title><rect x="735.4" y="1141" width="4.2" height="19.0" fill="rgb(219,66,15)" rx="2" ry="2" />
+<text  x="738.42" y="1153.5" ></text>
+</g>
+<g >
+<title>ksys_read (3,364,156,490 samples, 0.53%)</title><rect x="2575.8" y="2401" width="22.0" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="2578.76" y="2413.5" >k..</text>
+</g>
+<g >
+<title>execute_command_internal (4,043,050,486 samples, 0.63%)</title><rect x="360.8" y="401" width="26.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="363.77" y="413.5" >e..</text>
+</g>
+<g >
+<title>_Fork (2,582,545,622 samples, 0.40%)</title><rect x="693.5" y="1301" width="17.0" height="19.0" fill="rgb(252,220,52)" rx="2" ry="2" />
+<text  x="696.55" y="1313.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (3,612,468,013 samples, 0.57%)</title><rect x="2051.9" y="2441" width="23.7" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="2054.92" y="2453.5" >e..</text>
+</g>
+<g >
+<title>execute_command (193,994,695 samples, 0.03%)</title><rect x="835.2" y="821" width="1.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="838.18" y="833.5" ></text>
+</g>
+<g >
+<title>parse_and_execute (713,521,499 samples, 0.11%)</title><rect x="296.5" y="2521" width="4.6" height="19.0" fill="rgb(243,178,42)" rx="2" ry="2" />
+<text  x="299.45" y="2533.5" ></text>
+</g>
+<g >
+<title>[bash] (1,150,422,968 samples, 0.18%)</title><rect x="827.6" y="2441" width="7.5" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="830.57" y="2453.5" ></text>
+</g>
+<g >
+<title>execute_command (717,313,739 samples, 0.11%)</title><rect x="280.1" y="2221" width="4.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="283.09" y="2233.5" ></text>
+</g>
+<g >
+<title>_copy_to_iter (1,642,343,029 samples, 0.26%)</title><rect x="3052.4" y="2321" width="10.7" height="19.0" fill="rgb(234,134,32)" rx="2" ry="2" />
+<text  x="3055.37" y="2333.5" ></text>
+</g>
+<g >
+<title>execute_command (158,599,791 samples, 0.02%)</title><rect x="875.9" y="881" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="878.93" y="893.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (76,163,354,412 samples, 11.93%)</title><rect x="307.9" y="2081" width="498.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="310.93" y="2093.5" >execute_command_internal</text>
+</g>
+<g >
+<title>execute_command (1,147,316,451 samples, 0.18%)</title><rect x="827.6" y="1161" width="7.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="830.59" y="1173.5" ></text>
+</g>
+<g >
+<title>[bash] (511,018,812 samples, 0.08%)</title><rect x="885.1" y="401" width="3.3" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="888.05" y="413.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (3,457,187,266 samples, 0.54%)</title><rect x="2575.5" y="2421" width="22.6" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="2578.46" y="2433.5" >d..</text>
+</g>
+<g >
+<title>[sum] (319,086,676 samples, 0.05%)</title><rect x="4025.6" y="2561" width="2.1" height="19.0" fill="rgb(222,78,18)" rx="2" ry="2" />
+<text  x="4028.64" y="2573.5" ></text>
+</g>
+<g >
+<title>vfs_read (2,372,204,683 samples, 0.37%)</title><rect x="3050.4" y="2381" width="15.5" height="19.0" fill="rgb(230,118,28)" rx="2" ry="2" />
+<text  x="3053.37" y="2393.5" ></text>
+</g>
+<g >
+<title>execute_command (598,514,664 samples, 0.09%)</title><rect x="891.4" y="1441" width="3.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="894.40" y="1453.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (849,509,116 samples, 0.13%)</title><rect x="895.3" y="2101" width="5.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.35" y="2113.5" ></text>
+</g>
+<g >
+<title>shmem_get_folio_gfp (346,011,033 samples, 0.05%)</title><rect x="1630.7" y="2341" width="2.3" height="19.0" fill="rgb(219,67,16)" rx="2" ry="2" />
+<text  x="1633.71" y="2353.5" ></text>
+</g>
+<g >
+<title>flush_tlb_mm_range (226,877,264 samples, 0.04%)</title><rect x="770.9" y="1161" width="1.5" height="19.0" fill="rgb(222,78,18)" rx="2" ry="2" />
+<text  x="773.95" y="1173.5" ></text>
+</g>
+<g >
+<title>execute_command (2,384,496,415 samples, 0.37%)</title><rect x="835.1" y="2501" width="15.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="838.10" y="2513.5" ></text>
+</g>
+<g >
+<title>[unknown] (27,416,081,008 samples, 4.29%)</title><rect x="1663.0" y="2581" width="179.5" height="19.0" fill="rgb(210,24,5)" rx="2" ry="2" />
+<text  x="1666.02" y="2593.5" >[unknown]</text>
+</g>
+<g >
+<title>read (385,016,502 samples, 0.06%)</title><rect x="498.7" y="1061" width="2.5" height="19.0" fill="rgb(252,216,51)" rx="2" ry="2" />
+<text  x="501.71" y="1073.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (889,118,394 samples, 0.14%)</title><rect x="851.1" y="641" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.09" y="653.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (221,811,528 samples, 0.03%)</title><rect x="803.5" y="1541" width="1.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="806.54" y="1553.5" ></text>
+</g>
+<g >
+<title>execute_command (322,256,264 samples, 0.05%)</title><rect x="868.7" y="961" width="2.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="871.70" y="973.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (323,026,366 samples, 0.05%)</title><rect x="868.7" y="1341" width="2.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="871.70" y="1353.5" ></text>
+</g>
+<g >
+<title>[bash] (517,533,844 samples, 0.08%)</title><rect x="273.5" y="521" width="3.4" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="276.52" y="533.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (551,359,579 samples, 0.09%)</title><rect x="273.3" y="1341" width="3.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="276.31" y="1353.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (3,591,512,198 samples, 0.56%)</title><rect x="827.6" y="2561" width="23.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.57" y="2573.5" >e..</text>
+</g>
+<g >
+<title>execute_command_internal (436,055,112 samples, 0.07%)</title><rect x="888.5" y="2381" width="2.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="891.55" y="2393.5" ></text>
+</g>
+<g >
+<title>execute_command (76,160,644,766 samples, 11.93%)</title><rect x="307.9" y="1941" width="498.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="310.94" y="1953.5" >execute_command</text>
+</g>
+<g >
+<title>_int_free_merge_chunk (163,600,575 samples, 0.03%)</title><rect x="460.8" y="1041" width="1.1" height="19.0" fill="rgb(240,163,39)" rx="2" ry="2" />
+<text  x="463.84" y="1053.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (200,901,327 samples, 0.03%)</title><rect x="280.1" y="281" width="1.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.11" y="293.5" ></text>
+</g>
+<g >
+<title>rep_movs_alternative (3,152,859,586 samples, 0.49%)</title><rect x="3959.8" y="2301" width="20.7" height="19.0" fill="rgb(211,31,7)" rx="2" ry="2" />
+<text  x="3962.84" y="2313.5" ></text>
+</g>
+<g >
+<title>rep_movs_alternative (1,611,494,304 samples, 0.25%)</title><rect x="1619.9" y="2301" width="10.5" height="19.0" fill="rgb(211,31,7)" rx="2" ry="2" />
+<text  x="1622.86" y="2313.5" ></text>
+</g>
+<g >
+<title>execute_command (1,263,560,140 samples, 0.20%)</title><rect x="860.3" y="1901" width="8.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="863.30" y="1913.5" ></text>
+</g>
+<g >
+<title>vfs_open (385,230,635 samples, 0.06%)</title><rect x="2137.3" y="2261" width="2.5" height="19.0" fill="rgb(238,154,37)" rx="2" ry="2" />
+<text  x="2140.31" y="2273.5" ></text>
+</g>
+<g >
+<title>do_redirections (810,232,576 samples, 0.13%)</title><rect x="829.8" y="361" width="5.3" height="19.0" fill="rgb(247,193,46)" rx="2" ry="2" />
+<text  x="832.76" y="373.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (717,313,739 samples, 0.11%)</title><rect x="280.1" y="2041" width="4.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.09" y="2053.5" ></text>
+</g>
+<g >
+<title>avc_has_perm_noaudit (234,593,452 samples, 0.04%)</title><rect x="3914.8" y="2221" width="1.6" height="19.0" fill="rgb(209,18,4)" rx="2" ry="2" />
+<text  x="3917.81" y="2233.5" ></text>
+</g>
+<g >
+<title>execute_command (432,872,015 samples, 0.07%)</title><rect x="888.6" y="801" width="2.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="891.57" y="813.5" ></text>
+</g>
+<g >
+<title>execute_command (685,976,378 samples, 0.11%)</title><rect x="268.8" y="1041" width="4.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="271.79" y="1053.5" ></text>
+</g>
+<g >
+<title>execute_command (1,261,220,789 samples, 0.20%)</title><rect x="860.3" y="701" width="8.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="863.32" y="713.5" ></text>
+</g>
+<g >
+<title>execute_command (710,260,538 samples, 0.11%)</title><rect x="280.1" y="581" width="4.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="283.11" y="593.5" ></text>
+</g>
+<g >
+<title>__GI___libc_write (500,353,559 samples, 0.08%)</title><rect x="1565.1" y="2441" width="3.3" height="19.0" fill="rgb(217,57,13)" rx="2" ry="2" />
+<text  x="1568.12" y="2453.5" ></text>
+</g>
+<g >
+<title>[bash] (195,916,485 samples, 0.03%)</title><rect x="835.2" y="1401" width="1.3" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="838.17" y="1413.5" ></text>
+</g>
+<g >
+<title>[bash] (598,514,664 samples, 0.09%)</title><rect x="891.4" y="2461" width="3.9" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="894.40" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (717,313,739 samples, 0.11%)</title><rect x="280.1" y="2281" width="4.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.09" y="2293.5" ></text>
+</g>
+<g >
+<title>execute_command (717,313,739 samples, 0.11%)</title><rect x="280.1" y="1701" width="4.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="283.09" y="1713.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (4,417,755,415 samples, 0.69%)</title><rect x="1468.9" y="2381" width="29.0" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="1471.93" y="2393.5" >en..</text>
+</g>
+<g >
+<title>execute_command (849,509,116 samples, 0.13%)</title><rect x="895.3" y="2201" width="5.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="898.35" y="2213.5" ></text>
+</g>
+<g >
+<title>execute_command (717,313,739 samples, 0.11%)</title><rect x="280.1" y="1901" width="4.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="283.09" y="1913.5" ></text>
+</g>
+<g >
+<title>__printf_buffer_to_file_done (633,797,660 samples, 0.10%)</title><rect x="252.6" y="2461" width="4.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="255.55" y="2473.5" ></text>
+</g>
+<g >
+<title>_IO_do_write@@GLIBC_2.2.5 (540,563,163 samples, 0.08%)</title><rect x="232.6" y="2481" width="3.6" height="19.0" fill="rgb(238,155,37)" rx="2" ry="2" />
+<text  x="235.64" y="2493.5" ></text>
+</g>
+<g >
+<title>__do_sys_newfstat (211,831,291 samples, 0.03%)</title><rect x="196.7" y="2341" width="1.4" height="19.0" fill="rgb(225,96,23)" rx="2" ry="2" />
+<text  x="199.69" y="2353.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (354,938,381 samples, 0.06%)</title><rect x="840.5" y="881" width="2.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="843.48" y="893.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (2,118,773,782 samples, 0.33%)</title><rect x="868.6" y="2301" width="13.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="871.57" y="2313.5" ></text>
+</g>
+<g >
+<title>execute_command (1,150,422,968 samples, 0.18%)</title><rect x="827.6" y="1721" width="7.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="830.57" y="1733.5" ></text>
+</g>
+<g >
+<title>execute_command (849,509,116 samples, 0.13%)</title><rect x="895.3" y="2001" width="5.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="898.35" y="2013.5" ></text>
+</g>
+<g >
+<title>[bash] (713,521,499 samples, 0.11%)</title><rect x="296.5" y="2441" width="4.6" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="299.45" y="2453.5" ></text>
+</g>
+<g >
+<title>execute_command (598,514,664 samples, 0.09%)</title><rect x="891.4" y="1921" width="3.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="894.40" y="1933.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (598,514,664 samples, 0.09%)</title><rect x="891.4" y="2301" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.40" y="2313.5" ></text>
+</g>
+<g >
+<title>redirection_expand (563,908,884 samples, 0.09%)</title><rect x="269.5" y="361" width="3.7" height="19.0" fill="rgb(218,63,15)" rx="2" ry="2" />
+<text  x="272.54" y="373.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (192,670,319 samples, 0.03%)</title><rect x="837.6" y="1241" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="840.55" y="1253.5" ></text>
+</g>
+<g >
+<title>syscall_return_via_sysret (158,772,670 samples, 0.02%)</title><rect x="199.1" y="2381" width="1.1" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="202.13" y="2393.5" ></text>
+</g>
+<g >
+<title>[bash] (354,911,948 samples, 0.06%)</title><rect x="840.5" y="701" width="2.3" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="843.48" y="713.5" ></text>
+</g>
+<g >
+<title>execute_command (554,006,342 samples, 0.09%)</title><rect x="273.3" y="1941" width="3.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="276.29" y="1953.5" ></text>
+</g>
+<g >
+<title>syscall_return_via_sysret (533,501,991 samples, 0.08%)</title><rect x="2078.5" y="2441" width="3.5" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="2081.54" y="2453.5" ></text>
+</g>
+<g >
+<title>execute_command (550,598,300 samples, 0.09%)</title><rect x="273.3" y="821" width="3.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="276.32" y="833.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (849,509,116 samples, 0.13%)</title><rect x="895.3" y="2561" width="5.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.35" y="2573.5" ></text>
+</g>
+<g >
+<title>__fopen_internal (2,869,372,156 samples, 0.45%)</title><rect x="3022.9" y="2461" width="18.7" height="19.0" fill="rgb(248,197,47)" rx="2" ry="2" />
+<text  x="3025.86" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (275,670,705 samples, 0.04%)</title><rect x="827.6" y="341" width="1.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.59" y="353.5" ></text>
+</g>
+<g >
+<title>[bash] (598,514,664 samples, 0.09%)</title><rect x="891.4" y="2361" width="3.9" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="894.40" y="2373.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (513,428,353 samples, 0.08%)</title><rect x="856.9" y="1101" width="3.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="859.94" y="1113.5" ></text>
+</g>
+<g >
+<title>execute_command (215,132,849 samples, 0.03%)</title><rect x="842.8" y="1381" width="1.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="845.81" y="1393.5" ></text>
+</g>
+<g >
+<title>shmem_get_folio_gfp (455,429,681 samples, 0.07%)</title><rect x="2594.3" y="2341" width="3.0" height="19.0" fill="rgb(219,67,16)" rx="2" ry="2" />
+<text  x="2597.31" y="2353.5" ></text>
+</g>
+<g >
+<title>_IO_file_overflow@@GLIBC_2.2.5 (1,030,938,464 samples, 0.16%)</title><rect x="3895.8" y="2481" width="6.8" height="19.0" fill="rgb(239,157,37)" rx="2" ry="2" />
+<text  x="3898.83" y="2493.5" ></text>
+</g>
+<g >
+<title>path_openat (1,843,346,401 samples, 0.29%)</title><rect x="3025.1" y="2281" width="12.0" height="19.0" fill="rgb(205,2,0)" rx="2" ry="2" />
+<text  x="3028.07" y="2293.5" ></text>
+</g>
+<g >
+<title>parse_and_execute (866,614,713 samples, 0.14%)</title><rect x="301.1" y="2501" width="5.7" height="19.0" fill="rgb(243,178,42)" rx="2" ry="2" />
+<text  x="304.12" y="2513.5" ></text>
+</g>
+<g >
+<title>execute_command (238,090,729 samples, 0.04%)</title><rect x="827.6" y="241" width="1.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="830.59" y="253.5" ></text>
+</g>
+<g >
+<title>execute_command (481,813,209 samples, 0.08%)</title><rect x="276.9" y="1181" width="3.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="279.93" y="1193.5" ></text>
+</g>
+<g >
+<title>execute_command (516,725,798 samples, 0.08%)</title><rect x="856.9" y="2401" width="3.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="859.92" y="2413.5" ></text>
+</g>
+<g >
+<title>execute_command (432,872,015 samples, 0.07%)</title><rect x="888.6" y="1001" width="2.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="891.57" y="1013.5" ></text>
+</g>
+<g >
+<title>expand_arith_string (503,797,546 samples, 0.08%)</title><rect x="791.7" y="1361" width="3.3" height="19.0" fill="rgb(206,6,1)" rx="2" ry="2" />
+<text  x="794.73" y="1373.5" ></text>
+</g>
+<g >
+<title>execute_command (170,489,782 samples, 0.03%)</title><rect x="871.9" y="1281" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="874.90" y="1293.5" ></text>
+</g>
+<g >
+<title>posix_fadvise (506,715,292 samples, 0.08%)</title><rect x="261.2" y="2501" width="3.3" height="19.0" fill="rgb(245,186,44)" rx="2" ry="2" />
+<text  x="264.16" y="2513.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (159,710,185 samples, 0.03%)</title><rect x="875.9" y="1821" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="878.92" y="1833.5" ></text>
+</g>
+<g >
+<title>[bash] (282,266,064 samples, 0.04%)</title><rect x="410.4" y="1081" width="1.8" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="413.38" y="1093.5" ></text>
+</g>
+<g >
+<title>walk_component (225,302,683 samples, 0.04%)</title><rect x="2551.2" y="2241" width="1.5" height="19.0" fill="rgb(247,197,47)" rx="2" ry="2" />
+<text  x="2554.20" y="2253.5" ></text>
+</g>
+<g >
+<title>ksys_read (3,255,423,275 samples, 0.51%)</title><rect x="2053.9" y="2401" width="21.4" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="2056.94" y="2413.5" >k..</text>
+</g>
+<g >
+<title>__libc_start_main@@GLIBC_2.34 (13,124,157,425 samples, 2.06%)</title><rect x="3021.1" y="2561" width="85.9" height="19.0" fill="rgb(229,113,27)" rx="2" ry="2" />
+<text  x="3024.12" y="2573.5" >__libc_sta..</text>
+</g>
+<g >
+<title>execute_command_internal (181,979,024 samples, 0.03%)</title><rect x="282.8" y="161" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="285.76" y="173.5" ></text>
+</g>
+<g >
+<title>[bash] (158,599,791 samples, 0.02%)</title><rect x="875.9" y="821" width="1.1" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="878.93" y="833.5" ></text>
+</g>
+<g >
+<title>copy_process (243,248,532 samples, 0.04%)</title><rect x="853.2" y="121" width="1.6" height="19.0" fill="rgb(239,160,38)" rx="2" ry="2" />
+<text  x="856.18" y="133.5" ></text>
+</g>
+<g >
+<title>[unknown] (321,801,843 samples, 0.05%)</title><rect x="4025.6" y="2581" width="2.1" height="19.0" fill="rgb(210,24,5)" rx="2" ry="2" />
+<text  x="4028.64" y="2593.5" ></text>
+</g>
+<g >
+<title>vfs_fstat (183,387,983 samples, 0.03%)</title><rect x="2568.6" y="2341" width="1.2" height="19.0" fill="rgb(215,46,11)" rx="2" ry="2" />
+<text  x="2571.58" y="2353.5" ></text>
+</g>
+<g >
+<title>zgetline (5,868,887,060 samples, 0.92%)</title><rect x="462.9" y="1101" width="38.4" height="19.0" fill="rgb(219,65,15)" rx="2" ry="2" />
+<text  x="465.85" y="1113.5" >zge..</text>
+</g>
+<g >
+<title>execute_command (2,044,048,453 samples, 0.32%)</title><rect x="835.1" y="2301" width="13.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="838.10" y="2313.5" ></text>
+</g>
+<g >
+<title>execute_command (264,100,248 samples, 0.04%)</title><rect x="827.6" y="321" width="1.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="830.59" y="333.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (704,492,242 samples, 0.11%)</title><rect x="296.5" y="761" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.51" y="773.5" ></text>
+</g>
+<g >
+<title>[bash] (525,367,149 samples, 0.08%)</title><rect x="297.5" y="281" width="3.5" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="300.54" y="293.5" ></text>
+</g>
+<g >
+<title>entry_SYSRETQ_unsafe_stack (257,667,426 samples, 0.04%)</title><rect x="1497.9" y="2381" width="1.6" height="19.0" fill="rgb(213,37,8)" rx="2" ry="2" />
+<text  x="1500.85" y="2393.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (866,614,713 samples, 0.14%)</title><rect x="301.1" y="1581" width="5.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.12" y="1593.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (713,987,302 samples, 0.11%)</title><rect x="280.1" y="1081" width="4.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.11" y="1093.5" ></text>
+</g>
+<g >
+<title>shtimer_select (245,008,750 samples, 0.04%)</title><rect x="313.0" y="481" width="1.6" height="19.0" fill="rgb(230,115,27)" rx="2" ry="2" />
+<text  x="315.98" y="493.5" ></text>
+</g>
+<g >
+<title>_dl_start (401,548,305 samples, 0.06%)</title><rect x="4028.7" y="2561" width="2.7" height="19.0" fill="rgb(237,151,36)" rx="2" ry="2" />
+<text  x="4031.74" y="2573.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (833,057,547 samples, 0.13%)</title><rect x="301.2" y="301" width="5.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.16" y="313.5" ></text>
+</g>
+<g >
+<title>dispose_command (278,788,607 samples, 0.04%)</title><rect x="840.5" y="501" width="1.8" height="19.0" fill="rgb(248,201,48)" rx="2" ry="2" />
+<text  x="843.48" y="513.5" ></text>
+</g>
+<g >
+<title>[bash] (717,313,739 samples, 0.11%)</title><rect x="280.1" y="2461" width="4.7" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="283.09" y="2473.5" ></text>
+</g>
+<g >
+<title>syscall_return_via_sysret (194,091,919 samples, 0.03%)</title><rect x="2609.7" y="2441" width="1.3" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="2612.71" y="2453.5" ></text>
+</g>
+<g >
+<title>security_inode_permission (431,916,312 samples, 0.07%)</title><rect x="2548.0" y="2241" width="2.8" height="19.0" fill="rgb(215,47,11)" rx="2" ry="2" />
+<text  x="2551.02" y="2253.5" ></text>
+</g>
+<g >
+<title>vfs_open (352,543,603 samples, 0.06%)</title><rect x="1601.9" y="2261" width="2.4" height="19.0" fill="rgb(238,154,37)" rx="2" ry="2" />
+<text  x="1604.95" y="2273.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (862,395,726 samples, 0.14%)</title><rect x="301.2" y="1081" width="5.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.15" y="1093.5" ></text>
+</g>
+<g >
+<title>execute_command (303,630,575 samples, 0.05%)</title><rect x="351.7" y="621" width="1.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="354.66" y="633.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (704,492,242 samples, 0.11%)</title><rect x="296.5" y="681" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.51" y="693.5" ></text>
+</g>
+<g >
+<title>substring (515,603,788 samples, 0.08%)</title><rect x="574.8" y="1261" width="3.4" height="19.0" fill="rgb(248,201,48)" rx="2" ry="2" />
+<text  x="577.79" y="1273.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (279,153,512 samples, 0.04%)</title><rect x="345.4" y="601" width="1.8" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="348.41" y="613.5" ></text>
+</g>
+<g >
+<title>copy_mc_enhanced_fast_string (214,557,889 samples, 0.03%)</title><rect x="768.8" y="1181" width="1.4" height="19.0" fill="rgb(239,157,37)" rx="2" ry="2" />
+<text  x="771.83" y="1193.5" ></text>
+</g>
+<g >
+<title>[bash] (170,489,782 samples, 0.03%)</title><rect x="871.9" y="1301" width="1.1" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="874.90" y="1313.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (550,598,300 samples, 0.09%)</title><rect x="273.3" y="1081" width="3.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="276.32" y="1093.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (432,872,015 samples, 0.07%)</title><rect x="888.6" y="1161" width="2.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="891.57" y="1173.5" ></text>
+</g>
+<g >
+<title>path_openat (3,443,816,768 samples, 0.54%)</title><rect x="1471.4" y="2281" width="22.5" height="19.0" fill="rgb(205,2,0)" rx="2" ry="2" />
+<text  x="1474.36" y="2293.5" >p..</text>
+</g>
+<g >
+<title>__x64_sys_close (451,848,103 samples, 0.07%)</title><rect x="4152.2" y="2401" width="3.0" height="19.0" fill="rgb(238,153,36)" rx="2" ry="2" />
+<text  x="4155.21" y="2413.5" ></text>
+</g>
+<g >
+<title>execute_command (354,998,378 samples, 0.06%)</title><rect x="840.5" y="1101" width="2.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="843.48" y="1113.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (891,895,571 samples, 0.14%)</title><rect x="851.1" y="2201" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.08" y="2213.5" ></text>
+</g>
+<g >
+<title>ksys_read (2,433,125,097 samples, 0.38%)</title><rect x="202.4" y="2381" width="15.9" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="205.39" y="2393.5" ></text>
+</g>
+<g >
+<title>execute_command (717,313,739 samples, 0.11%)</title><rect x="280.1" y="1781" width="4.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="283.09" y="1793.5" ></text>
+</g>
+<g >
+<title>__d_lookup_rcu (230,265,818 samples, 0.04%)</title><rect x="2552.7" y="2241" width="1.5" height="19.0" fill="rgb(235,139,33)" rx="2" ry="2" />
+<text  x="2555.68" y="2253.5" ></text>
+</g>
+<g >
+<title>__do_sys_newfstat (283,168,119 samples, 0.04%)</title><rect x="2567.9" y="2361" width="1.9" height="19.0" fill="rgb(225,96,23)" rx="2" ry="2" />
+<text  x="2570.93" y="2373.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (323,887,280 samples, 0.05%)</title><rect x="2567.8" y="2381" width="2.1" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="2570.83" y="2393.5" ></text>
+</g>
+<g >
+<title>new_do_write (538,113,123 samples, 0.08%)</title><rect x="232.7" y="2461" width="3.5" height="19.0" fill="rgb(206,5,1)" rx="2" ry="2" />
+<text  x="235.66" y="2473.5" ></text>
+</g>
+<g >
+<title>do_redirections (711,821,479 samples, 0.11%)</title><rect x="319.3" y="561" width="4.6" height="19.0" fill="rgb(247,193,46)" rx="2" ry="2" />
+<text  x="322.28" y="573.5" ></text>
+</g>
+<g >
+<title>__x64_sys_close (236,547,497 samples, 0.04%)</title><rect x="1640.0" y="2401" width="1.5" height="19.0" fill="rgb(238,153,36)" rx="2" ry="2" />
+<text  x="1642.98" y="2413.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (436,055,112 samples, 0.07%)</title><rect x="888.5" y="2181" width="2.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="891.55" y="2193.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (513,428,353 samples, 0.08%)</title><rect x="856.9" y="901" width="3.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="859.94" y="913.5" ></text>
+</g>
+<g >
+<title>execute_command (688,777,208 samples, 0.11%)</title><rect x="268.8" y="1761" width="4.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="271.77" y="1773.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (578,068,287 samples, 0.09%)</title><rect x="884.6" y="1921" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="887.62" y="1933.5" ></text>
+</g>
+<g >
+<title>__close_nocancel (911,595,757 samples, 0.14%)</title><rect x="3373.0" y="2461" width="5.9" height="19.0" fill="rgb(228,109,26)" rx="2" ry="2" />
+<text  x="3375.98" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command (891,895,571 samples, 0.14%)</title><rect x="851.1" y="1701" width="5.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="854.08" y="1713.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (578,068,287 samples, 0.09%)</title><rect x="884.6" y="2481" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="887.62" y="2493.5" ></text>
+</g>
+<g >
+<title>kmem_cache_alloc_noprof (206,072,993 samples, 0.03%)</title><rect x="2560.0" y="2281" width="1.4" height="19.0" fill="rgb(205,0,0)" rx="2" ry="2" />
+<text  x="2563.00" y="2293.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,150,422,968 samples, 0.18%)</title><rect x="827.6" y="1981" width="7.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.57" y="1993.5" ></text>
+</g>
+<g >
+<title>[bash] (6,013,594,508 samples, 0.94%)</title><rect x="518.6" y="1281" width="39.4" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="521.64" y="1293.5" >[ba..</text>
+</g>
+<g >
+<title>shmem_file_read_iter (2,296,344,475 samples, 0.36%)</title><rect x="1618.3" y="2361" width="15.1" height="19.0" fill="rgb(238,152,36)" rx="2" ry="2" />
+<text  x="1621.33" y="2373.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (483,985,097 samples, 0.08%)</title><rect x="276.9" y="2401" width="3.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="279.92" y="2413.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (2,213,511,194 samples, 0.35%)</title><rect x="868.6" y="2341" width="14.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="871.57" y="2353.5" ></text>
+</g>
+<g >
+<title>[bash] (200,376,563 samples, 0.03%)</title><rect x="325.4" y="481" width="1.3" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="328.37" y="493.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (193,994,695 samples, 0.03%)</title><rect x="835.2" y="761" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="838.18" y="773.5" ></text>
+</g>
+<g >
+<title>malloc_consolidate (3,311,355,826 samples, 0.52%)</title><rect x="720.3" y="1281" width="21.7" height="19.0" fill="rgb(239,159,38)" rx="2" ry="2" />
+<text  x="723.33" y="1293.5" >m..</text>
+</g>
+<g >
+<title>execute_command (390,374,659 samples, 0.06%)</title><rect x="407.5" y="1081" width="2.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="410.48" y="1093.5" ></text>
+</g>
+<g >
+<title>execute_command (192,670,319 samples, 0.03%)</title><rect x="837.6" y="1141" width="1.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="840.55" y="1153.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (163,954,022 samples, 0.03%)</title><rect x="870.8" y="981" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="873.82" y="993.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (159,710,185 samples, 0.03%)</title><rect x="875.9" y="1541" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="878.92" y="1553.5" ></text>
+</g>
+<g >
+<title>posix_fadvise (1,020,562,648 samples, 0.16%)</title><rect x="4019.0" y="2521" width="6.6" height="19.0" fill="rgb(245,186,44)" rx="2" ry="2" />
+<text  x="4021.96" y="2533.5" ></text>
+</g>
+<g >
+<title>__fstat64 (925,081,949 samples, 0.14%)</title><rect x="2044.9" y="2421" width="6.1" height="19.0" fill="rgb(224,88,21)" rx="2" ry="2" />
+<text  x="2047.91" y="2433.5" ></text>
+</g>
+<g >
+<title>[bash] (866,614,713 samples, 0.14%)</title><rect x="301.1" y="2401" width="5.7" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="304.12" y="2413.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (3,346,531,691 samples, 0.52%)</title><rect x="2053.7" y="2421" width="21.9" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="2056.66" y="2433.5" >d..</text>
+</g>
+<g >
+<title>bpf_trampoline_6442533562 (245,643,938 samples, 0.04%)</title><rect x="1491.8" y="2181" width="1.6" height="19.0" fill="rgb(221,78,18)" rx="2" ry="2" />
+<text  x="1494.76" y="2193.5" ></text>
+</g>
+<g >
+<title>[unknown] (56,663,574,537 samples, 8.87%)</title><rect x="2643.7" y="2581" width="370.9" height="19.0" fill="rgb(210,24,5)" rx="2" ry="2" />
+<text  x="2646.67" y="2593.5" >[unknown]</text>
+</g>
+<g >
+<title>do_sys_openat2 (2,769,381,081 samples, 0.43%)</title><rect x="2544.1" y="2321" width="18.1" height="19.0" fill="rgb(209,21,5)" rx="2" ry="2" />
+<text  x="2547.06" y="2333.5" ></text>
+</g>
+<g >
+<title>__do_sys_clone (237,687,289 samples, 0.04%)</title><rect x="270.0" y="181" width="1.5" height="19.0" fill="rgb(217,57,13)" rx="2" ry="2" />
+<text  x="272.99" y="193.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (164,731,865 samples, 0.03%)</title><rect x="836.5" y="1121" width="1.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="839.46" y="1133.5" ></text>
+</g>
+<g >
+<title>execute_command (717,313,739 samples, 0.11%)</title><rect x="280.1" y="2181" width="4.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="283.09" y="2193.5" ></text>
+</g>
+<g >
+<title>generic_perform_write (271,972,761 samples, 0.04%)</title><rect x="901.0" y="2381" width="1.7" height="19.0" fill="rgb(243,176,42)" rx="2" ry="2" />
+<text  x="903.97" y="2393.5" ></text>
+</g>
+<g >
+<title>fclose@@GLIBC_2.2.5 (914,014,910 samples, 0.14%)</title><rect x="2082.4" y="2481" width="6.0" height="19.0" fill="rgb(251,213,51)" rx="2" ry="2" />
+<text  x="2085.37" y="2493.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,263,560,140 samples, 0.20%)</title><rect x="860.3" y="2041" width="8.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.30" y="2053.5" ></text>
+</g>
+<g >
+<title>execute_command (713,521,499 samples, 0.11%)</title><rect x="296.5" y="2101" width="4.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="299.45" y="2113.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (550,598,300 samples, 0.09%)</title><rect x="273.3" y="881" width="3.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="276.32" y="893.5" ></text>
+</g>
+<g >
+<title>read (4,245,684,186 samples, 0.66%)</title><rect x="3344.2" y="2461" width="27.8" height="19.0" fill="rgb(252,216,51)" rx="2" ry="2" />
+<text  x="3347.20" y="2473.5" >r..</text>
+</g>
+<g >
+<title>execute_command_internal (1,974,567,416 samples, 0.31%)</title><rect x="399.5" y="1161" width="12.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="402.51" y="1173.5" ></text>
+</g>
+<g >
+<title>_IO_file_open (2,703,200,401 samples, 0.42%)</title><rect x="3023.6" y="2421" width="17.7" height="19.0" fill="rgb(249,205,49)" rx="2" ry="2" />
+<text  x="3026.56" y="2433.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (265,574,122 samples, 0.04%)</title><rect x="320.0" y="481" width="1.7" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="322.97" y="493.5" ></text>
+</g>
+<g >
+<title>ksys_read (5,021,339,025 samples, 0.79%)</title><rect x="4072.8" y="2381" width="32.9" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="4075.81" y="2393.5" >ks..</text>
+</g>
+<g >
+<title>make_word_list (301,567,248 samples, 0.05%)</title><rect x="581.9" y="1281" width="2.0" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="584.89" y="1293.5" ></text>
+</g>
+<g >
+<title>execute_command (3,591,512,198 samples, 0.56%)</title><rect x="827.6" y="2581" width="23.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="830.57" y="2593.5" >e..</text>
+</g>
+<g >
+<title>execute_command (1,392,938,192 samples, 0.22%)</title><rect x="835.1" y="1941" width="9.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="838.10" y="1953.5" ></text>
+</g>
+<g >
+<title>security_inode_permission (342,981,556 samples, 0.05%)</title><rect x="3027.8" y="2241" width="2.2" height="19.0" fill="rgb(215,47,11)" rx="2" ry="2" />
+<text  x="3030.77" y="2253.5" ></text>
+</g>
+<g >
+<title>[cat] (416,070,235 samples, 0.07%)</title><rect x="900.9" y="2581" width="2.7" height="19.0" fill="rgb(209,20,4)" rx="2" ry="2" />
+<text  x="903.92" y="2593.5" ></text>
+</g>
+<g >
+<title>entry_SYSRETQ_unsafe_stack (258,426,924 samples, 0.04%)</title><rect x="3944.5" y="2401" width="1.6" height="19.0" fill="rgb(213,37,8)" rx="2" ry="2" />
+<text  x="3947.46" y="2413.5" ></text>
+</g>
+<g >
+<title>_dl_start (529,053,195 samples, 0.08%)</title><rect x="1843.1" y="2561" width="3.5" height="19.0" fill="rgb(237,151,36)" rx="2" ry="2" />
+<text  x="1846.09" y="2573.5" ></text>
+</g>
+<g >
+<title>execute_command (13,302,856,463 samples, 2.08%)</title><rect x="307.9" y="1501" width="87.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="310.94" y="1513.5" >execute_co..</text>
+</g>
+<g >
+<title>execute_command (159,710,185 samples, 0.03%)</title><rect x="875.9" y="1761" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="878.92" y="1773.5" ></text>
+</g>
+<g >
+<title>source_file (62,818,262,051 samples, 9.84%)</title><rect x="395.1" y="1721" width="411.2" height="19.0" fill="rgb(218,61,14)" rx="2" ry="2" />
+<text  x="398.10" y="1733.5" >source_file</text>
+</g>
+<g >
+<title>syscall_return_via_sysret (185,385,016 samples, 0.03%)</title><rect x="2142.9" y="2381" width="1.2" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="2145.93" y="2393.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (481,191,724 samples, 0.08%)</title><rect x="276.9" y="761" width="3.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="279.94" y="773.5" ></text>
+</g>
+<g >
+<title>redirection_expand (517,010,579 samples, 0.08%)</title><rect x="273.5" y="461" width="3.4" height="19.0" fill="rgb(218,63,15)" rx="2" ry="2" />
+<text  x="276.52" y="473.5" ></text>
+</g>
+<g >
+<title>execute_command (1,259,613,163 samples, 0.20%)</title><rect x="860.3" y="541" width="8.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="863.32" y="553.5" ></text>
+</g>
+<g >
+<title>execute_command (598,514,664 samples, 0.09%)</title><rect x="891.4" y="1841" width="3.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="894.40" y="1853.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (16,862,305,082 samples, 2.64%)</title><rect x="399.0" y="1241" width="110.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="402.04" y="1253.5" >execute_comma..</text>
+</g>
+<g >
+<title>execute_command (598,514,664 samples, 0.09%)</title><rect x="891.4" y="1801" width="3.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="894.40" y="1813.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (710,231,675 samples, 0.11%)</title><rect x="280.1" y="481" width="4.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.11" y="493.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (516,725,798 samples, 0.08%)</title><rect x="856.9" y="2341" width="3.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="859.92" y="2353.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (433,500,595 samples, 0.07%)</title><rect x="888.6" y="1481" width="2.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="891.56" y="1493.5" ></text>
+</g>
+<g >
+<title>__libc_start_call_main (713,521,499 samples, 0.11%)</title><rect x="296.5" y="2581" width="4.6" height="19.0" fill="rgb(210,26,6)" rx="2" ry="2" />
+<text  x="299.45" y="2593.5" ></text>
+</g>
+<g >
+<title>execute_command (163,415,529 samples, 0.03%)</title><rect x="870.8" y="721" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="873.82" y="733.5" ></text>
+</g>
+<g >
+<title>execute_command (882,569,034 samples, 0.14%)</title><rect x="851.1" y="461" width="5.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="854.09" y="473.5" ></text>
+</g>
+<g >
+<title>security_inode_permission (657,895,039 samples, 0.10%)</title><rect x="1476.3" y="2241" width="4.3" height="19.0" fill="rgb(215,47,11)" rx="2" ry="2" />
+<text  x="1479.33" y="2253.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (164,731,865 samples, 0.03%)</title><rect x="836.5" y="1301" width="1.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="839.46" y="1313.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (195,267,188 samples, 0.03%)</title><rect x="835.2" y="1201" width="1.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="838.18" y="1213.5" ></text>
+</g>
+<g >
+<title>allocate_fake_cpuc (164,445,623 samples, 0.03%)</title><rect x="273.9" y="101" width="1.1" height="19.0" fill="rgb(248,198,47)" rx="2" ry="2" />
+<text  x="276.88" y="113.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (891,895,571 samples, 0.14%)</title><rect x="851.1" y="1641" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.08" y="1653.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (947,062,583 samples, 0.15%)</title><rect x="310.0" y="661" width="6.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="312.98" y="673.5" ></text>
+</g>
+<g >
+<title>read (4,131,308,571 samples, 0.65%)</title><rect x="2150.7" y="2461" width="27.1" height="19.0" fill="rgb(252,216,51)" rx="2" ry="2" />
+<text  x="2153.71" y="2473.5" >r..</text>
+</g>
+<g >
+<title>execute_command_internal (481,191,724 samples, 0.08%)</title><rect x="276.9" y="921" width="3.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="279.94" y="933.5" ></text>
+</g>
+<g >
+<title>execute_command (218,392,535 samples, 0.03%)</title><rect x="280.1" y="341" width="1.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="283.11" y="353.5" ></text>
+</g>
+<g >
+<title>fclose@@GLIBC_2.2.5 (1,442,726,617 samples, 0.23%)</title><rect x="4002.3" y="2501" width="9.4" height="19.0" fill="rgb(251,213,51)" rx="2" ry="2" />
+<text  x="4005.30" y="2513.5" ></text>
+</g>
+<g >
+<title>[bash] (1,263,560,140 samples, 0.20%)</title><rect x="860.3" y="2421" width="8.3" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="863.30" y="2433.5" ></text>
+</g>
+<g >
+<title>execute_command (1,263,560,140 samples, 0.20%)</title><rect x="860.3" y="1781" width="8.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="863.30" y="1793.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (2,354,470,213 samples, 0.37%)</title><rect x="3023.8" y="2381" width="15.4" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="3026.79" y="2393.5" ></text>
+</g>
+<g >
+<title>dl_main (675,629,966 samples, 0.11%)</title><rect x="3015.5" y="2521" width="4.4" height="19.0" fill="rgb(236,145,34)" rx="2" ry="2" />
+<text  x="3018.51" y="2533.5" ></text>
+</g>
+<g >
+<title>perf_event_init_task (174,390,604 samples, 0.03%)</title><rect x="273.9" y="221" width="1.1" height="19.0" fill="rgb(254,225,53)" rx="2" ry="2" />
+<text  x="276.87" y="233.5" ></text>
+</g>
+<g >
+<title>execute_command (195,267,188 samples, 0.03%)</title><rect x="835.2" y="941" width="1.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="838.18" y="953.5" ></text>
+</g>
+<g >
+<title>[bash] (1,167,338,083 samples, 0.18%)</title><rect x="316.5" y="581" width="7.6" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="319.47" y="593.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (7,230,386,069 samples, 1.13%)</title><rect x="308.5" y="1101" width="47.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="311.53" y="1113.5" >exec..</text>
+</g>
+<g >
+<title>execute_command (849,509,116 samples, 0.13%)</title><rect x="895.3" y="1521" width="5.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="898.35" y="1533.5" ></text>
+</g>
+<g >
+<title>__get_user_pages (205,723,297 samples, 0.03%)</title><rect x="668.5" y="1181" width="1.4" height="19.0" fill="rgb(249,205,49)" rx="2" ry="2" />
+<text  x="671.53" y="1193.5" ></text>
+</g>
+<g >
+<title>bpf_lsm_file_open (180,101,188 samples, 0.03%)</title><rect x="3329.2" y="2201" width="1.1" height="19.0" fill="rgb(227,105,25)" rx="2" ry="2" />
+<text  x="3332.15" y="2213.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (180,216,075 samples, 0.03%)</title><rect x="878.5" y="1841" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="881.48" y="1853.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,261,220,789 samples, 0.20%)</title><rect x="860.3" y="641" width="8.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.32" y="653.5" ></text>
+</g>
+<g >
+<title>[bash] (307,981,940 samples, 0.05%)</title><rect x="282.1" y="201" width="2.0" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="285.11" y="213.5" ></text>
+</g>
+<g >
+<title>execute_command (480,699,859 samples, 0.08%)</title><rect x="276.9" y="621" width="3.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="279.94" y="633.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (717,313,739 samples, 0.11%)</title><rect x="280.1" y="2161" width="4.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.09" y="2173.5" ></text>
+</g>
+<g >
+<title>__close_nocancel (676,772,213 samples, 0.11%)</title><rect x="2178.6" y="2461" width="4.4" height="19.0" fill="rgb(228,109,26)" rx="2" ry="2" />
+<text  x="2181.58" y="2473.5" ></text>
+</g>
+<g >
+<title>vfs_fstat (184,801,127 samples, 0.03%)</title><rect x="2047.0" y="2341" width="1.2" height="19.0" fill="rgb(215,46,11)" rx="2" ry="2" />
+<text  x="2050.02" y="2353.5" ></text>
+</g>
+<g >
+<title>__mmput (1,177,257,662 samples, 0.18%)</title><rect x="288.3" y="2421" width="7.7" height="19.0" fill="rgb(205,3,0)" rx="2" ry="2" />
+<text  x="291.26" y="2433.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (705,583,873 samples, 0.11%)</title><rect x="296.5" y="1201" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.50" y="1213.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (578,068,287 samples, 0.09%)</title><rect x="884.6" y="2041" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="887.62" y="2053.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (190,482,118 samples, 0.03%)</title><rect x="895.4" y="261" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.39" y="273.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (849,509,116 samples, 0.13%)</title><rect x="895.3" y="2221" width="5.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.35" y="2233.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (158,744,410 samples, 0.02%)</title><rect x="875.9" y="1101" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="878.93" y="1113.5" ></text>
+</g>
+<g >
+<title>[sha256sum] (15,726,102,336 samples, 2.46%)</title><rect x="2540.2" y="2521" width="102.9" height="19.0" fill="rgb(216,53,12)" rx="2" ry="2" />
+<text  x="2543.17" y="2533.5" >[sha256sum]</text>
+</g>
+<g >
+<title>execute_command_internal (595,672,870 samples, 0.09%)</title><rect x="891.4" y="701" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.42" y="713.5" ></text>
+</g>
+<g >
+<title>execute_command (481,813,209 samples, 0.08%)</title><rect x="276.9" y="1481" width="3.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="279.93" y="1493.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (554,006,342 samples, 0.09%)</title><rect x="273.3" y="1801" width="3.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="276.29" y="1813.5" ></text>
+</g>
+<g >
+<title>kernel_clone (237,687,289 samples, 0.04%)</title><rect x="270.0" y="161" width="1.5" height="19.0" fill="rgb(248,199,47)" rx="2" ry="2" />
+<text  x="272.99" y="173.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (575,055,300 samples, 0.09%)</title><rect x="884.6" y="841" width="3.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="887.64" y="853.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (891,895,571 samples, 0.14%)</title><rect x="851.1" y="2441" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.08" y="2453.5" ></text>
+</g>
+<g >
+<title>syscall_return_via_sysret (385,406,086 samples, 0.06%)</title><rect x="1527.5" y="2421" width="2.5" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="1530.48" y="2433.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (154,468,837 samples, 0.02%)</title><rect x="362.3" y="201" width="1.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="365.26" y="213.5" ></text>
+</g>
+<g >
+<title>[bash] (181,671,832 samples, 0.03%)</title><rect x="282.8" y="141" width="1.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="285.76" y="153.5" ></text>
+</g>
+<g >
+<title>[bash] (513,428,353 samples, 0.08%)</title><rect x="856.9" y="1181" width="3.4" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="859.94" y="1193.5" ></text>
+</g>
+<g >
+<title>entry_SYSRETQ_unsafe_stack (313,311,695 samples, 0.05%)</title><rect x="218.6" y="2421" width="2.1" height="19.0" fill="rgb(213,37,8)" rx="2" ry="2" />
+<text  x="221.61" y="2433.5" ></text>
+</g>
+<g >
+<title>execute_command (1,793,310,882 samples, 0.28%)</title><rect x="835.1" y="2061" width="11.7" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="838.10" y="2073.5" ></text>
+</g>
+<g >
+<title>expand_string_assignment (209,570,028 samples, 0.03%)</title><rect x="325.4" y="501" width="1.3" height="19.0" fill="rgb(235,141,33)" rx="2" ry="2" />
+<text  x="328.37" y="513.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (704,492,242 samples, 0.11%)</title><rect x="296.5" y="981" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.51" y="993.5" ></text>
+</g>
+<g >
+<title>_dl_start (701,902,545 samples, 0.11%)</title><rect x="2117.4" y="2561" width="4.6" height="19.0" fill="rgb(237,151,36)" rx="2" ry="2" />
+<text  x="2120.40" y="2573.5" ></text>
+</g>
+<g >
+<title>execute_command (1,261,568,072 samples, 0.20%)</title><rect x="860.3" y="1301" width="8.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="863.31" y="1313.5" ></text>
+</g>
+<g >
+<title>[bash] (185,467,659 samples, 0.03%)</title><rect x="835.2" y="521" width="1.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="838.23" y="533.5" ></text>
+</g>
+<g >
+<title>execute_command (1,145,785,833 samples, 0.18%)</title><rect x="827.6" y="641" width="7.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="830.59" y="653.5" ></text>
+</g>
+<g >
+<title>execute_command (1,259,613,163 samples, 0.20%)</title><rect x="860.3" y="621" width="8.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="863.32" y="633.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (383,467,355 samples, 0.06%)</title><rect x="407.5" y="1061" width="2.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="410.52" y="1073.5" ></text>
+</g>
+<g >
+<title>__fopen_internal (3,459,565,351 samples, 0.54%)</title><rect x="2021.2" y="2461" width="22.6" height="19.0" fill="rgb(248,197,47)" rx="2" ry="2" />
+<text  x="2024.19" y="2473.5" >_..</text>
+</g>
+<g >
+<title>cat (442,482,230 samples, 0.07%)</title><rect x="900.9" y="2601" width="2.9" height="19.0" fill="rgb(248,198,47)" rx="2" ry="2" />
+<text  x="903.92" y="2613.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (713,521,499 samples, 0.11%)</title><rect x="296.5" y="1641" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.45" y="1653.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (717,313,739 samples, 0.11%)</title><rect x="280.1" y="2321" width="4.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.09" y="2333.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (860,104,616 samples, 0.13%)</title><rect x="829.4" y="401" width="5.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="832.44" y="413.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (436,055,112 samples, 0.07%)</title><rect x="888.5" y="2141" width="2.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="891.55" y="2153.5" ></text>
+</g>
+<g >
+<title>do_dentry_open (331,384,834 samples, 0.05%)</title><rect x="2137.7" y="2241" width="2.1" height="19.0" fill="rgb(249,205,49)" rx="2" ry="2" />
+<text  x="2140.66" y="2253.5" ></text>
+</g>
+<g >
+<title>execute_command (513,428,353 samples, 0.08%)</title><rect x="856.9" y="1081" width="3.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="859.94" y="1093.5" ></text>
+</g>
+<g >
+<title>ksys_read (4,935,019,864 samples, 0.77%)</title><rect x="3953.9" y="2401" width="32.3" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="3956.90" y="2413.5" >ks..</text>
+</g>
+<g >
+<title>read_builtin (497,161,439 samples, 0.08%)</title><rect x="311.3" y="521" width="3.3" height="19.0" fill="rgb(235,139,33)" rx="2" ry="2" />
+<text  x="314.34" y="533.5" ></text>
+</g>
+<g >
+<title>execute_command (1,261,220,789 samples, 0.20%)</title><rect x="860.3" y="821" width="8.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="863.32" y="833.5" ></text>
+</g>
+<g >
+<title>__fopen_internal (5,450,970,472 samples, 0.85%)</title><rect x="1466.6" y="2461" width="35.7" height="19.0" fill="rgb(248,197,47)" rx="2" ry="2" />
+<text  x="1469.65" y="2473.5" >__f..</text>
+</g>
+<g >
+<title>execute_command (1,263,560,140 samples, 0.20%)</title><rect x="860.3" y="1741" width="8.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="863.30" y="1753.5" ></text>
+</g>
+<g >
+<title>execute_command (849,509,116 samples, 0.13%)</title><rect x="895.3" y="1641" width="5.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="898.35" y="1653.5" ></text>
+</g>
+<g >
+<title>execute_command (891,895,571 samples, 0.14%)</title><rect x="851.1" y="2341" width="5.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="854.08" y="2353.5" ></text>
+</g>
+<g >
+<title>sum (52,731,055,937 samples, 8.26%)</title><rect x="3687.1" y="2601" width="345.2" height="19.0" fill="rgb(210,26,6)" rx="2" ry="2" />
+<text  x="3690.07" y="2613.5" >sum</text>
+</g>
+<g >
+<title>security_inode_permission (636,130,996 samples, 0.10%)</title><rect x="4168.9" y="2321" width="4.2" height="19.0" fill="rgb(215,47,11)" rx="2" ry="2" />
+<text  x="4171.89" y="2333.5" ></text>
+</g>
+<g >
+<title>__printf_buffer_write (307,693,043 samples, 0.05%)</title><rect x="3407.1" y="2441" width="2.0" height="19.0" fill="rgb(220,73,17)" rx="2" ry="2" />
+<text  x="3410.07" y="2453.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (354,998,378 samples, 0.06%)</title><rect x="840.5" y="1321" width="2.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="843.48" y="1333.5" ></text>
+</g>
+<g >
+<title>execute_command (481,813,209 samples, 0.08%)</title><rect x="276.9" y="1221" width="3.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="279.93" y="1233.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (179,777,548 samples, 0.03%)</title><rect x="878.5" y="1341" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="881.48" y="1353.5" ></text>
+</g>
+<g >
+<title>syscall_return_via_sysret (157,449,811 samples, 0.02%)</title><rect x="193.2" y="2381" width="1.0" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="196.19" y="2393.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (2,044,048,453 samples, 0.32%)</title><rect x="835.1" y="2281" width="13.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="838.10" y="2293.5" ></text>
+</g>
+<g >
+<title>lookup_fast (186,910,747 samples, 0.03%)</title><rect x="2133.9" y="2261" width="1.2" height="19.0" fill="rgb(226,97,23)" rx="2" ry="2" />
+<text  x="2136.88" y="2273.5" ></text>
+</g>
+<g >
+<title>openaux (197,264,625 samples, 0.03%)</title><rect x="2117.9" y="2461" width="1.3" height="19.0" fill="rgb(252,217,52)" rx="2" ry="2" />
+<text  x="2120.89" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (166,473,899 samples, 0.03%)</title><rect x="851.1" y="401" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.09" y="413.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (195,267,188 samples, 0.03%)</title><rect x="835.2" y="1161" width="1.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="838.18" y="1173.5" ></text>
+</g>
+<g >
+<title>__strchrnul_evex (160,644,018 samples, 0.03%)</title><rect x="2202.4" y="2461" width="1.1" height="19.0" fill="rgb(239,159,38)" rx="2" ry="2" />
+<text  x="2205.41" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (171,847,094 samples, 0.03%)</title><rect x="871.9" y="1681" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="874.89" y="1693.5" ></text>
+</g>
+<g >
+<title>copy_page_to_iter (3,346,767,671 samples, 0.52%)</title><rect x="3958.6" y="2341" width="21.9" height="19.0" fill="rgb(216,52,12)" rx="2" ry="2" />
+<text  x="3961.57" y="2353.5" >c..</text>
+</g>
+<g >
+<title>inherit_task_group.isra.0 (174,390,604 samples, 0.03%)</title><rect x="273.9" y="201" width="1.1" height="19.0" fill="rgb(218,62,14)" rx="2" ry="2" />
+<text  x="276.87" y="213.5" ></text>
+</g>
+<g >
+<title>execute_command (876,984,812 samples, 0.14%)</title><rect x="328.7" y="581" width="5.8" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="331.73" y="593.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (598,514,664 samples, 0.09%)</title><rect x="891.4" y="2521" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.40" y="2533.5" ></text>
+</g>
+<g >
+<title>dispose_command (278,788,607 samples, 0.04%)</title><rect x="840.5" y="401" width="1.8" height="19.0" fill="rgb(248,201,48)" rx="2" ry="2" />
+<text  x="843.48" y="413.5" ></text>
+</g>
+<g >
+<title>execute_command (554,006,342 samples, 0.09%)</title><rect x="273.3" y="2461" width="3.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="276.29" y="2473.5" ></text>
+</g>
+<g >
+<title>shmem_get_folio_gfp (335,568,480 samples, 0.05%)</title><rect x="215.7" y="2321" width="2.2" height="19.0" fill="rgb(219,67,16)" rx="2" ry="2" />
+<text  x="218.72" y="2333.5" ></text>
+</g>
+<g >
+<title>execute_command (475,657,449 samples, 0.07%)</title><rect x="276.9" y="581" width="3.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="279.94" y="593.5" ></text>
+</g>
+<g >
+<title>execute_command (1,263,560,140 samples, 0.20%)</title><rect x="860.3" y="2261" width="8.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="863.30" y="2273.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (584,793,218 samples, 0.09%)</title><rect x="4058.3" y="2381" width="3.9" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="4061.33" y="2393.5" ></text>
+</g>
+<g >
+<title>[bash] (188,687,597 samples, 0.03%)</title><rect x="325.4" y="461" width="1.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="328.40" y="473.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (717,313,739 samples, 0.11%)</title><rect x="280.1" y="2121" width="4.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.09" y="2133.5" ></text>
+</g>
+<g >
+<title>malloc (270,732,287 samples, 0.04%)</title><rect x="582.1" y="1261" width="1.8" height="19.0" fill="rgb(230,119,28)" rx="2" ry="2" />
+<text  x="585.09" y="1273.5" ></text>
+</g>
+<g >
+<title>do_truncate (153,204,788 samples, 0.02%)</title><rect x="345.6" y="501" width="1.0" height="19.0" fill="rgb(223,83,20)" rx="2" ry="2" />
+<text  x="348.58" y="513.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (207,539,560 samples, 0.03%)</title><rect x="835.1" y="1641" width="1.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="838.10" y="1653.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (323,768,179 samples, 0.05%)</title><rect x="351.6" y="701" width="2.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="354.61" y="713.5" ></text>
+</g>
+<g >
+<title>path_openat (224,712,711 samples, 0.04%)</title><rect x="320.0" y="401" width="1.5" height="19.0" fill="rgb(205,2,0)" rx="2" ry="2" />
+<text  x="323.04" y="413.5" ></text>
+</g>
+<g >
+<title>dispose_command (278,786,529 samples, 0.04%)</title><rect x="840.5" y="341" width="1.8" height="19.0" fill="rgb(248,201,48)" rx="2" ry="2" />
+<text  x="843.48" y="353.5" ></text>
+</g>
+<g >
+<title>__mmput (2,842,340,956 samples, 0.45%)</title><rect x="808.2" y="2461" width="18.6" height="19.0" fill="rgb(205,3,0)" rx="2" ry="2" />
+<text  x="811.16" y="2473.5" ></text>
+</g>
+<g >
+<title>[bash] (1,066,276,030 samples, 0.17%)</title><rect x="861.5" y="361" width="7.0" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="864.52" y="373.5" ></text>
+</g>
+<g >
+<title>__x64_sys_execve (1,616,473,241 samples, 0.25%)</title><rect x="662.1" y="1281" width="10.6" height="19.0" fill="rgb(253,223,53)" rx="2" ry="2" />
+<text  x="665.08" y="1293.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (849,509,116 samples, 0.13%)</title><rect x="895.3" y="1861" width="5.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.35" y="1873.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (3,734,350,352 samples, 0.58%)</title><rect x="2573.6" y="2441" width="24.5" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="2576.65" y="2453.5" >e..</text>
+</g>
+<g >
+<title>execute_command_internal (62,845,422,853 samples, 9.84%)</title><rect x="395.1" y="1801" width="411.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="398.09" y="1813.5" >execute_command_internal</text>
+</g>
+<g >
+<title>__fopen_internal (3,003,372,671 samples, 0.47%)</title><rect x="2124.9" y="2461" width="19.7" height="19.0" fill="rgb(248,197,47)" rx="2" ry="2" />
+<text  x="2127.91" y="2473.5" ></text>
+</g>
+<g >
+<title>main (76,571,541,207 samples, 11.99%)</title><rect x="306.9" y="2521" width="501.2" height="19.0" fill="rgb(243,179,42)" rx="2" ry="2" />
+<text  x="309.86" y="2533.5" >main</text>
+</g>
+<g >
+<title>[bash] (158,599,791 samples, 0.02%)</title><rect x="875.9" y="781" width="1.1" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="878.93" y="793.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (717,313,739 samples, 0.11%)</title><rect x="280.1" y="1841" width="4.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.09" y="1853.5" ></text>
+</g>
+<g >
+<title>_dl_start (530,319,574 samples, 0.08%)</title><rect x="3305.7" y="2561" width="3.4" height="19.0" fill="rgb(237,151,36)" rx="2" ry="2" />
+<text  x="3308.66" y="2573.5" ></text>
+</g>
+<g >
+<title>_IO_file_xsgetn (1,565,543,474 samples, 0.25%)</title><rect x="3938.1" y="2461" width="10.2" height="19.0" fill="rgb(207,11,2)" rx="2" ry="2" />
+<text  x="3941.09" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,261,568,072 samples, 0.20%)</title><rect x="860.3" y="1421" width="8.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.31" y="1433.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (889,542,281 samples, 0.14%)</title><rect x="851.1" y="721" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.09" y="733.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (713,521,499 samples, 0.11%)</title><rect x="296.5" y="1761" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.45" y="1773.5" ></text>
+</g>
+<g >
+<title>[libcrypto.so.3.2.2] (192,297,649 samples, 0.03%)</title><rect x="3012.2" y="2541" width="1.3" height="19.0" fill="rgb(244,181,43)" rx="2" ry="2" />
+<text  x="3015.21" y="2553.5" ></text>
+</g>
+<g >
+<title>[bash] (182,524,680 samples, 0.03%)</title><rect x="334.5" y="501" width="1.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="337.52" y="513.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (2,315,069,913 samples, 0.36%)</title><rect x="868.6" y="2421" width="15.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="871.57" y="2433.5" ></text>
+</g>
+<g >
+<title>[bash] (62,721,101,026 samples, 9.82%)</title><rect x="395.4" y="1621" width="410.6" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="398.45" y="1633.5" >[bash]</text>
+</g>
+<g >
+<title>execute_command_internal (180,216,075 samples, 0.03%)</title><rect x="878.5" y="1661" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="881.48" y="1673.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (483,985,097 samples, 0.08%)</title><rect x="276.9" y="2001" width="3.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="279.92" y="2013.5" ></text>
+</g>
+<g >
+<title>link_path_walk.part.0.constprop.0 (778,888,054 samples, 0.12%)</title><rect x="179.6" y="2261" width="5.1" height="19.0" fill="rgb(254,229,54)" rx="2" ry="2" />
+<text  x="182.56" y="2273.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (322,256,264 samples, 0.05%)</title><rect x="868.7" y="821" width="2.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="871.70" y="833.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (5,244,828,573 samples, 0.82%)</title><rect x="359.5" y="681" width="34.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="362.53" y="693.5" >ex..</text>
+</g>
+<g >
+<title>do_syscall_64 (188,002,607 samples, 0.03%)</title><rect x="3385.2" y="2401" width="1.2" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="3388.21" y="2413.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (164,731,865 samples, 0.03%)</title><rect x="836.5" y="921" width="1.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="839.46" y="933.5" ></text>
+</g>
+<g >
+<title>[bash] (190,014,181 samples, 0.03%)</title><rect x="837.6" y="601" width="1.2" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="840.56" y="613.5" ></text>
+</g>
+<g >
+<title>execute_command (215,132,849 samples, 0.03%)</title><rect x="842.8" y="1301" width="1.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="845.81" y="1313.5" ></text>
+</g>
+<g >
+<title>lookup_fast (319,330,135 samples, 0.05%)</title><rect x="3917.1" y="2241" width="2.1" height="19.0" fill="rgb(226,97,23)" rx="2" ry="2" />
+<text  x="3920.07" y="2253.5" ></text>
+</g>
+<g >
+<title>execute_command (5,906,494,952 samples, 0.93%)</title><rect x="356.1" y="1281" width="38.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="359.06" y="1293.5" >exe..</text>
+</g>
+<g >
+<title>execute_command_internal (215,126,890 samples, 0.03%)</title><rect x="842.8" y="681" width="1.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="845.81" y="693.5" ></text>
+</g>
+<g >
+<title>entry_SYSRETQ_unsafe_stack (167,091,551 samples, 0.03%)</title><rect x="2608.6" y="2441" width="1.1" height="19.0" fill="rgb(213,37,8)" rx="2" ry="2" />
+<text  x="2611.62" y="2453.5" ></text>
+</g>
+<g >
+<title>execute_command (483,985,097 samples, 0.08%)</title><rect x="276.9" y="2421" width="3.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="279.92" y="2433.5" ></text>
+</g>
+<g >
+<title>execute_command (550,598,300 samples, 0.09%)</title><rect x="273.3" y="941" width="3.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="276.32" y="953.5" ></text>
+</g>
+<g >
+<title>do_redirections (383,442,105 samples, 0.06%)</title><rect x="277.5" y="421" width="2.5" height="19.0" fill="rgb(247,193,46)" rx="2" ry="2" />
+<text  x="280.53" y="433.5" ></text>
+</g>
+<g >
+<title>execute_command (190,829,147 samples, 0.03%)</title><rect x="837.6" y="741" width="1.2" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="840.55" y="753.5" ></text>
+</g>
+<g >
+<title>alloc_empty_file (242,138,187 samples, 0.04%)</title><rect x="3907.3" y="2281" width="1.5" height="19.0" fill="rgb(215,49,11)" rx="2" ry="2" />
+<text  x="3910.25" y="2293.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (704,492,242 samples, 0.11%)</title><rect x="296.5" y="721" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.51" y="733.5" ></text>
+</g>
+<g >
+<title>execute_command (1,261,568,072 samples, 0.20%)</title><rect x="860.3" y="1401" width="8.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="863.31" y="1413.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (322,256,264 samples, 0.05%)</title><rect x="868.7" y="1241" width="2.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="871.70" y="1253.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,085,727,782 samples, 0.17%)</title><rect x="400.1" y="1081" width="7.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="403.08" y="1093.5" ></text>
+</g>
+<g >
+<title>kmem_cache_alloc_noprof (175,540,280 samples, 0.03%)</title><rect x="190.4" y="2281" width="1.1" height="19.0" fill="rgb(205,0,0)" rx="2" ry="2" />
+<text  x="193.35" y="2293.5" ></text>
+</g>
+<g >
+<title>security_inode_permission (410,201,236 samples, 0.06%)</title><rect x="2027.2" y="2241" width="2.6" height="19.0" fill="rgb(215,47,11)" rx="2" ry="2" />
+<text  x="2030.15" y="2253.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (196,351,612 samples, 0.03%)</title><rect x="833.2" y="141" width="1.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="836.22" y="153.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (17,128,252,047 samples, 2.68%)</title><rect x="398.6" y="1321" width="112.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="401.59" y="1333.5" >execute_comma..</text>
+</g>
+<g >
+<title>__vfprintf_internal (993,938,779 samples, 0.16%)</title><rect x="1652.5" y="2481" width="6.5" height="19.0" fill="rgb(232,125,30)" rx="2" ry="2" />
+<text  x="1655.46" y="2493.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (554,006,342 samples, 0.09%)</title><rect x="273.3" y="2401" width="3.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="276.29" y="2413.5" ></text>
+</g>
+<g >
+<title>[md5sum] (11,235,966,178 samples, 1.76%)</title><rect x="1589.5" y="2581" width="73.5" height="19.0" fill="rgb(229,113,27)" rx="2" ry="2" />
+<text  x="1592.47" y="2593.5" >[md5sum]</text>
+</g>
+<g >
+<title>posix_fadvise (568,696,322 samples, 0.09%)</title><rect x="2204.1" y="2501" width="3.8" height="19.0" fill="rgb(245,186,44)" rx="2" ry="2" />
+<text  x="2207.15" y="2513.5" ></text>
+</g>
+<g >
+<title>new_do_write (709,946,776 samples, 0.11%)</title><rect x="3384.3" y="2461" width="4.6" height="19.0" fill="rgb(206,5,1)" rx="2" ry="2" />
+<text  x="3387.27" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (713,987,302 samples, 0.11%)</title><rect x="280.1" y="1141" width="4.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="283.11" y="1153.5" ></text>
+</g>
+<g >
+<title>syscall_return_via_sysret (168,715,565 samples, 0.03%)</title><rect x="2206.8" y="2481" width="1.1" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="2209.76" y="2493.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (159,710,185 samples, 0.03%)</title><rect x="875.9" y="1721" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="878.92" y="1733.5" ></text>
+</g>
+<g >
+<title>shmem_alloc_and_add_folio (207,601,938 samples, 0.03%)</title><rect x="901.3" y="2321" width="1.3" height="19.0" fill="rgb(240,163,39)" rx="2" ry="2" />
+<text  x="904.28" y="2333.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (882,569,034 samples, 0.14%)</title><rect x="851.1" y="441" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.09" y="453.5" ></text>
+</g>
+<g >
+<title>execute_command (516,725,798 samples, 0.08%)</title><rect x="856.9" y="2441" width="3.4" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="859.92" y="2453.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (849,509,116 samples, 0.13%)</title><rect x="895.3" y="2141" width="5.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.35" y="2153.5" ></text>
+</g>
+<g >
+<title>execute_command (194,148,063 samples, 0.03%)</title><rect x="837.5" y="1621" width="1.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="840.54" y="1633.5" ></text>
+</g>
+<g >
+<title>execute_command (705,583,873 samples, 0.11%)</title><rect x="296.5" y="1061" width="4.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="299.50" y="1073.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (442,577,833 samples, 0.07%)</title><rect x="862.9" y="161" width="2.9" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="865.91" y="173.5" ></text>
+</g>
+<g >
+<title>selinux_inode_permission (380,062,180 samples, 0.06%)</title><rect x="3319.1" y="2221" width="2.5" height="19.0" fill="rgb(238,156,37)" rx="2" ry="2" />
+<text  x="3322.07" y="2233.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (178,861,417 samples, 0.03%)</title><rect x="407.7" y="981" width="1.2" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="410.74" y="993.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (849,509,116 samples, 0.13%)</title><rect x="895.3" y="1541" width="5.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="898.35" y="1553.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (516,725,798 samples, 0.08%)</title><rect x="856.9" y="2181" width="3.4" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="859.92" y="2193.5" ></text>
+</g>
+<g >
+<title>execute_command (194,148,063 samples, 0.03%)</title><rect x="837.5" y="1581" width="1.3" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="840.54" y="1593.5" ></text>
+</g>
+<g >
+<title>entry_SYSCALL_64_after_hwframe (214,959,318 samples, 0.03%)</title><rect x="1565.2" y="2421" width="1.4" height="19.0" fill="rgb(225,93,22)" rx="2" ry="2" />
+<text  x="1568.19" y="2433.5" ></text>
+</g>
+<g >
+<title>[bash] (891,895,571 samples, 0.14%)</title><rect x="851.1" y="2461" width="5.8" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="854.08" y="2473.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,261,220,789 samples, 0.20%)</title><rect x="860.3" y="681" width="8.3" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="863.32" y="693.5" ></text>
+</g>
+<g >
+<title>security_inode_permission (663,737,282 samples, 0.10%)</title><rect x="3912.0" y="2261" width="4.4" height="19.0" fill="rgb(215,47,11)" rx="2" ry="2" />
+<text  x="3915.01" y="2273.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (192,670,319 samples, 0.03%)</title><rect x="837.6" y="1161" width="1.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="840.55" y="1173.5" ></text>
+</g>
+<g >
+<title>syscall_return_via_sysret (219,244,359 samples, 0.03%)</title><rect x="2563.5" y="2381" width="1.4" height="19.0" fill="rgb(236,143,34)" rx="2" ry="2" />
+<text  x="2566.47" y="2393.5" ></text>
+</g>
+<g >
+<title>_dl_start_user (583,167,132 samples, 0.09%)</title><rect x="2534.8" y="2581" width="3.8" height="19.0" fill="rgb(236,145,34)" rx="2" ry="2" />
+<text  x="2537.77" y="2593.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (16,690,163,502 samples, 2.61%)</title><rect x="399.3" y="1201" width="109.2" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="402.28" y="1213.5" >execute_comma..</text>
+</g>
+<g >
+<title>_dl_relocate_object (385,817,916 samples, 0.06%)</title><rect x="3017.2" y="2501" width="2.5" height="19.0" fill="rgb(231,120,28)" rx="2" ry="2" />
+<text  x="3020.20" y="2513.5" ></text>
+</g>
+<g >
+<title>execute_command (156,045,605 samples, 0.02%)</title><rect x="324.2" y="581" width="1.0" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="327.18" y="593.5" ></text>
+</g>
+<g >
+<title>selinux_inode_permission (354,485,179 samples, 0.06%)</title><rect x="2548.5" y="2221" width="2.3" height="19.0" fill="rgb(238,156,37)" rx="2" ry="2" />
+<text  x="2551.53" y="2233.5" ></text>
+</g>
+<g >
+<title>execute_command (685,594,707 samples, 0.11%)</title><rect x="268.8" y="601" width="4.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="271.79" y="613.5" ></text>
+</g>
+<g >
+<title>execute_command (705,583,873 samples, 0.11%)</title><rect x="296.5" y="1221" width="4.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="299.50" y="1233.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (2,384,496,415 samples, 0.37%)</title><rect x="835.1" y="2481" width="15.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="838.10" y="2493.5" ></text>
+</g>
+<g >
+<title>do_exit (207,707,782 samples, 0.03%)</title><rect x="1585.8" y="2481" width="1.4" height="19.0" fill="rgb(238,151,36)" rx="2" ry="2" />
+<text  x="1588.83" y="2493.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (554,006,342 samples, 0.09%)</title><rect x="273.3" y="2321" width="3.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="276.29" y="2333.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,934,760,318 samples, 0.30%)</title><rect x="835.1" y="2161" width="12.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="838.10" y="2173.5" ></text>
+</g>
+<g >
+<title>__mem_cgroup_charge (170,026,517 samples, 0.03%)</title><rect x="767.5" y="1181" width="1.1" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="770.48" y="1193.5" ></text>
+</g>
+<g >
+<title>execute_command (595,672,870 samples, 0.09%)</title><rect x="891.4" y="721" width="3.9" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="894.42" y="733.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (222,750,014 samples, 0.03%)</title><rect x="354.2" y="841" width="1.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="357.21" y="853.5" ></text>
+</g>
+<g >
+<title>shmem_file_read_iter (2,963,981,186 samples, 0.46%)</title><rect x="2055.8" y="2361" width="19.5" height="19.0" fill="rgb(238,152,36)" rx="2" ry="2" />
+<text  x="2058.85" y="2373.5" ></text>
+</g>
+<g >
+<title>_int_malloc (170,552,815 samples, 0.03%)</title><rect x="580.7" y="1241" width="1.2" height="19.0" fill="rgb(215,47,11)" rx="2" ry="2" />
+<text  x="583.74" y="1253.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (433,500,595 samples, 0.07%)</title><rect x="888.6" y="1281" width="2.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="891.56" y="1293.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (62,736,953,819 samples, 9.83%)</title><rect x="395.4" y="1661" width="410.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="398.37" y="1673.5" >execute_command_internal</text>
+</g>
+<g >
+<title>execute_command_internal (595,672,870 samples, 0.09%)</title><rect x="891.4" y="941" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.42" y="953.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (1,143,630,623 samples, 0.18%)</title><rect x="827.6" y="461" width="7.5" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="830.59" y="473.5" ></text>
+</g>
+<g >
+<title>do_syscall_64 (261,869,242 samples, 0.04%)</title><rect x="3897.2" y="2381" width="1.7" height="19.0" fill="rgb(215,50,12)" rx="2" ry="2" />
+<text  x="3900.23" y="2393.5" ></text>
+</g>
+<g >
+<title>link_path_walk.part.0.constprop.0 (1,494,734,196 samples, 0.23%)</title><rect x="3909.4" y="2281" width="9.8" height="19.0" fill="rgb(254,229,54)" rx="2" ry="2" />
+<text  x="3912.38" y="2293.5" ></text>
+</g>
+<g >
+<title>[bash] (762,955,227 samples, 0.12%)</title><rect x="339.5" y="681" width="5.0" height="19.0" fill="rgb(250,209,50)" rx="2" ry="2" />
+<text  x="342.49" y="693.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (167,008,815 samples, 0.03%)</title><rect x="871.9" y="641" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="874.92" y="653.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (14,675,002,509 samples, 2.30%)</title><rect x="412.5" y="1181" width="96.0" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="415.47" y="1193.5" >execute_com..</text>
+</g>
+<g >
+<title>execute_command (551,359,579 samples, 0.09%)</title><rect x="273.3" y="1461" width="3.6" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="276.31" y="1473.5" ></text>
+</g>
+<g >
+<title>[sha224sum] (3,045,445,187 samples, 0.48%)</title><rect x="2124.7" y="2481" width="19.9" height="19.0" fill="rgb(248,201,48)" rx="2" ry="2" />
+<text  x="2127.65" y="2493.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (891,895,571 samples, 0.14%)</title><rect x="851.1" y="1921" width="5.8" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="854.08" y="1933.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (549,214,247 samples, 0.09%)</title><rect x="273.3" y="681" width="3.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="276.32" y="693.5" ></text>
+</g>
+<g >
+<title>__libc_fork (324,321,390 samples, 0.05%)</title><rect x="853.1" y="241" width="2.1" height="19.0" fill="rgb(220,70,16)" rx="2" ry="2" />
+<text  x="856.11" y="253.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (265,410,486 samples, 0.04%)</title><rect x="866.2" y="201" width="1.7" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="869.20" y="213.5" ></text>
+</g>
+<g >
+<title>dispose_command (274,041,340 samples, 0.04%)</title><rect x="840.5" y="181" width="1.8" height="19.0" fill="rgb(248,201,48)" rx="2" ry="2" />
+<text  x="843.49" y="193.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (596,118,643 samples, 0.09%)</title><rect x="891.4" y="1201" width="3.9" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="894.42" y="1213.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (713,521,499 samples, 0.11%)</title><rect x="296.5" y="2381" width="4.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="299.45" y="2393.5" ></text>
+</g>
+<g >
+<title>[unknown] (159,616,679 samples, 0.02%)</title><rect x="1467.4" y="2421" width="1.1" height="19.0" fill="rgb(210,24,5)" rx="2" ry="2" />
+<text  x="1470.41" y="2433.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (164,808,262 samples, 0.03%)</title><rect x="870.8" y="1541" width="1.1" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="873.81" y="1553.5" ></text>
+</g>
+<g >
+<title>entry_SYSRETQ_unsafe_stack (363,713,253 samples, 0.06%)</title><rect x="2172.5" y="2441" width="2.3" height="19.0" fill="rgb(213,37,8)" rx="2" ry="2" />
+<text  x="2175.46" y="2453.5" ></text>
+</g>
+<g >
+<title>unmap_page_range (1,410,861,877 samples, 0.22%)</title><rect x="817.4" y="2401" width="9.2" height="19.0" fill="rgb(212,35,8)" rx="2" ry="2" />
+<text  x="820.41" y="2413.5" ></text>
+</g>
+<g >
+<title>lookup_fast (172,124,775 samples, 0.03%)</title><rect x="1598.9" y="2261" width="1.1" height="19.0" fill="rgb(226,97,23)" rx="2" ry="2" />
+<text  x="1601.89" y="2273.5" ></text>
+</g>
+<g >
+<title>execute_command_internal (862,395,726 samples, 0.14%)</title><rect x="301.2" y="1181" width="5.6" height="19.0" fill="rgb(248,202,48)" rx="2" ry="2" />
+<text  x="304.15" y="1193.5" ></text>
+</g>
+<g >
+<title>execute_command (1,146,830,397 samples, 0.18%)</title><rect x="827.6" y="1041" width="7.5" height="19.0" fill="rgb(224,90,21)" rx="2" ry="2" />
+<text  x="830.59" y="1053.5" ></text>
+</g>
+</g>
+</svg>

--- a/forkrun.bash
+++ b/forkrun.bash
@@ -22,7 +22,7 @@ forkrun() {
 
 ############################ BEGIN FUNCTION ############################
 
-    trap - EXIT INT TERM HUP USR1 USR2
+    trap - EXIT INT TERM HUP USR1
 
     shopt -s extglob
 
@@ -30,6 +30,7 @@ forkrun() {
     local tmpDir fPath outStr delimiterVal delimiterReadStr delimiterRemoveStr exitTrapStr exitTrapStr_kill nLines0 nOrder nProcs nProcsMax nBytes tTimeout coprocSrcCode outCur tmpDirRoot returnVal tmpVar t0 readBytesProg nullDelimiterProg ddQuietStr trailingNullFlag inotifyFlag lseekFlag fallocateFlag nLinesAutoFlag nQueueFlag substituteStringFlag substituteStringIDFlag nOrderFlag readBytesFlag readBytesExactFlag nullDelimiterFlag subshellRunFlag stdinRunFlag pipeReadFlag rmTmpDirFlag exportOrderFlag noFuncFlag unescapeFlag optParseFlag continueFlag doneIndicatorFlag FORCE_allowCarriageReturnsFlag ddAvailableFlag fd_continue fd_inotify fd_inotify0 fd_nAuto fd_nAuto0 fd_nOrder fd_nOrder0 fd_read fd_read0 fd_write fd_stdout fd_stdin fd_stdin0 fd_stderr pWrite pOrder pAuto pQueue pWrite_PID pNotify_PID pOrder_PID pAuto_PID pQueue_PID fd_read_pos fd_read_pos_old fd_write_pos DEBUG_FORKRUN
     local -i PID0 nLines nLinesCur nLinesNew nLinesMax nRead nWait nOrder0 nBytesRead nQueue nQueueLast nQueueMin nQueueLastCount nCPU v9 kkMax kkCur kk kkProcs verboseLevel pLOAD_max pAdd
     local -a A p_PID runCmd outHave outPrint pLOADA
+    local -A pMap
 
     # # # # # PARSE OPTIONS # # # # #
 
@@ -149,6 +150,10 @@ forkrun() {
                 [[ "${1:0:1}" == '-' ]] && nOrderFlag=true || nOrderFlag=false
             ;;
 
+            [+-]?([+-])K?(EEP?(?(-)ORDER?(ING)?(?(-)INFO))))
+                [[ "${1:0:1}" == '-' ]] && exportOrderFlag=true || exportOrderFlag=false
+            ;;
+
             [+-]?([+-])@(0|z?(ero)|null))
                 [[ "${1:0:1}" == '-' ]] && nullDelimiterFlag=true || nullDelimiterFlag=false
             ;;
@@ -167,10 +172,6 @@ forkrun() {
 
             [+-]?([+-])@(D|[Dd]elete))
                 [[ "${1:0:1}" == '-' ]] && rmTmpDirFlag=true || rmTmpDirFlag=false
-            ;;
-
-            [+-]?([+-])n?(umber)?(-)?(line?(s)))
-                [[ "${1:0:1}" == '-' ]] && exportOrderFlag=true || exportOrderFlag=false
             ;;
 
             [+-]?([+-])@(N?(O)|[Nn][Oo]?(-)func))
@@ -1856,3 +1857,30 @@ _forkrun_get_load() (
     ${echoFlag} && printf 'Current System CPU Load = %s\n' "${pLOAD}" >&2
 )
 
+_forkrun_getVal() {
+    ## expands IEC and SI prefixed to get the numeric value they represent
+	#
+	# IEC prefixes (1024^N) are used by default are used to be consistent with other linux tools
+	# SI prefixes (1000^N) can be used by adding a '+' to the start of the number
+	#
+	# neither capatalization nor trailing -i's and -b's have any effect
+	#     1k =  1K =  1kb =  1KB =  1kib =  1KiB = 1024
+    #    +1k = +1K = +1kb = +1KB = +1kib = +1KiB = 1000
+
+    local +i nn;
+
+    (( ${#pMap[@]} > 0 )) || pMap=([k]=1 [m]=2 [g]=3 [t]=4 [p]=5 [e]=6 [z]=7 [y]=8 [r]=9 [q]=10)
+     
+    for nn in "${@,,}"; do	
+        nn="${nn%%[ib]*}";
+          
+        case "${nn:0:1}" in
+            '+')
+                echo "$(( ${nn//[^0-9]/} * ( 1000 ** ${pMap[${nn: -1}]:-0} ) ))"
+            ;;
+            *)
+                echo "$(( ${nn//[^0-9]/} << ( 10 * ${pMap[${nn: -1}]:-0} ) ))"
+            ;;
+        esac
+    done
+}

--- a/forkrun.bash
+++ b/forkrun.bash
@@ -27,10 +27,11 @@ forkrun() {
     shopt -s extglob
 
     # make all variables local
-    local tmpDir fPath outStr delimiterVal delimiterReadStr delimiterRemoveStr exitTrapStr exitTrapStr_kill nLines0 nOrder nProcs nProcsMax nBytes tTimeout coprocSrcCode outCur tmpDirRoot returnVal tmpVar t0 readBytesProg nullDelimiterProg ddQuietStr trailingNullFlag inotifyFlag lseekFlag fallocateFlag nLinesAutoFlag nQueueFlag substituteStringFlag substituteStringIDFlag nOrderFlag readBytesFlag readBytesExactFlag nullDelimiterFlag subshellRunFlag stdinRunFlag pipeReadFlag rmTmpDirFlag exportOrderFlag noFuncFlag unescapeFlag optParseFlag continueFlag doneIndicatorFlag FORCE_allowCarriageReturnsFlag ddAvailableFlag fd_continue fd_inotify fd_inotify0 fd_nAuto fd_nAuto0 fd_nOrder fd_nOrder0 fd_read fd_read0 fd_write fd_stdout fd_stdin fd_stdin0 fd_stderr pWrite pOrder pAuto pQueue pWrite_PID pNotify_PID pOrder_PID pAuto_PID pQueue_PID fd_read_pos fd_read_pos_old fd_write_pos DEBUG_FORKRUN
-    local -i PID0 nLines nLinesCur nLinesNew nLinesMax nRead nWait nOrder0 nBytesRead nQueue nQueueLast nQueueMin nQueueLastCount nCPU v9 kkMax kkCur kk kkProcs verboseLevel pLOAD_max pAdd
+    local +i nLines nLines0 nBytes nProcs
+    local tmpDir fPath outStr delimiterVal delimiterReadStr delimiterRemoveStr exitTrapStr exitTrapStr_kill nLinesMax nQueueMin nOrder nProcsMax tTimeout coprocSrcCode outCur tmpDirRoot returnVal tmpVar t0 readBytesProg nullDelimiterProg ddQuietStr trailingNullFlag inotifyFlag lseekFlag fallocateFlag nLinesAutoFlag nQueueFlag substituteStringFlag substituteStringIDFlag nOrderFlag readBytesFlag readBytesExactFlag nullDelimiterFlag subshellRunFlag stdinRunFlag pipeReadFlag rmTmpDirFlag exportOrderFlag noFuncFlag unescapeFlag optParseFlag continueFlag doneIndicatorFlag FORCE_allowCarriageReturnsFlag ddAvailableFlag fd_continue fd_inotify fd_inotify0 fd_nAuto fd_nAuto0 fd_nOrder fd_nOrder0 fd_read fd_read0 fd_write fd_stdout fd_stdin fd_stdin0 fd_stderr pWrite pOrder pAuto pQueue pWrite_PID pNotify_PID pOrder_PID pAuto_PID pQueue_PID fd_read_pos fd_read_pos_old fd_write_pos DEBUG_FORKRUN
+    local -i PID0 nLinesCur nLinesNew nRead nWait nOrder0 nBytesRead nQueue nQueueLast nQueueLastCount nCPU v9 kkMax kkCur kk kkProcs verboseLevel pLOAD_max pAdd
     local -a A p_PID runCmd outHave outPrint pLOADA
-    local -A pMap
+    #local -Ax pMap
 
     # # # # # PARSE OPTIONS # # # # #
 
@@ -41,51 +42,51 @@ forkrun() {
     while ${optParseFlag} && (( $# > 0  )) && [[ "$1" == [-+]* ]]; do
         case "${1}" in
 
-            -?(-)@([jP]|?(n)[Pp]roc?(s)?)?(?([= ])?([+-])*([0-9])@([0-9,])*([0-9])?(,*([0-9]))))
-                if [[ "${1}" == -?(-)@([jP]|?(n)[Pp]roc?(s)?)?([= ])?([+-])*([0-9])@([0-9,])*([0-9])?(,*([0-9])) ]]; then
+            -?(-)@([jP]|?(n)[Pp]roc?(s)?)?(?([= ])?([+-])*([0-9])*@([0-9,])**([0-9])*?(,*([0-9])*)))
+                if [[ "${1}" == -?(-)@([jP]|?(n)[Pp]roc?(s)?)?([= ])?([+-])*([0-9])*@([0-9,])**([0-9])*?(,*([0-9])*) ]]; then
                     nProcs="${1##@(-?(-)@([jP]|?(n)[Pp]roc?(s)?)?([= ])?(+))}"
-                elif [[ "${1}" == -?(-)@([jP]|?(n)[Pp]roc?(s)?) ]] && [[ "${2}" == ?([+-])*([0-9])@([0-9,-])*([0-9])?(,*([0-9])) ]]; then
+                elif [[ "${1}" == -?(-)@([jP]|?(n)[Pp]roc?(s)?) ]] && [[ "${2}" == ?([+-])*([0-9])*@([0-9,-])**([0-9])*?(,*([0-9])*) ]]; then
                     nProcs="${2#'+'}"
                     shift 1
                 fi
             ;;
 
-            -?(-)?(n)l?(ine?(s))?(?([= ])+([0-9])))
-                if [[ "${1}" == -?(-)?(n)l?(ine?(s))?([= ])+([0-9]) ]]; then
+            -?(-)?(n)l?(ine?(s))?(?([= ])+([0-9])*))
+                if [[ "${1}" == -?(-)?(n)l?(ine?(s))?([= ])+([0-9])* ]]; then
                     nLines="${1##@(-?(-)?(n)l?(ine?(s))?([= ]))}"
                     nLinesAutoFlag=false
-                elif [[ "${1}" == -?(-)?(n)l?(ine?(s)) ]] && [[ "${2}" == +([0-9]) ]]; then
+                elif [[ "${1}" == -?(-)?(n)l?(ine?(s)) ]] && [[ "${2}" == +([0-9])* ]]; then
                     nLines="${2}"
                     nLinesAutoFlag=false
                     shift 1
                 fi
             ;;
 
-            -?(-)?(N)L?(INE?(S))?(?([= ])+([0-9])?(,+([0-9]))))
-                if [[ "${1}" == -?(-)?(N)L?(INE?(S))?([= ])+([0-9])?(,+([0-9])) ]]; then
+            -?(-)?(N)L?(INE?(S))?(?([= ])+([0-9])*?(,+([0-9])*)))
+                if [[ "${1}" == -?(-)?(N)L?(INE?(S))?([= ])+([0-9])*?(,+([0-9])*) ]]; then
                     nLines0="${1##@(-?(-)?(N)L?(INE?(S))?([= ]))}"
                     nLinesAutoFlag=true
-                elif [[ "${1}" == -?(-)?(N)L?(INE?(S)) ]] && [[ "${2}" == +([0-9])?(,+([0-9])) ]]; then
+                elif [[ "${1}" == -?(-)?(N)L?(INE?(S)) ]] && [[ "${2}" == +([0-9])*?(,+([0-9])*) ]]; then
                     nLines0="${2}"
                     nLinesAutoFlag=true
                     shift 1
                 else
                     continue
                 fi
-                if [[ "${nLines0}" == +([0-9])','+([0-9]) ]]; then
-                    nLinesMax="${nLines0##*,}"
+                if [[ "${nLines0}" == +([0-9])*','+([0-9])* ]]; then
+                    nLinesMax="$(_forkrun_getVal "${nLines0##*,}")"
                     nLines="${nLines0%%,*}"
                 else
                     nLines="${nLines0}"
                 fi
             ;;
 
-            -?(-)b?(yte?(s))?(?([= ])+([0-9])?([KkMmGgTtPp])?(i)?([Bb])))
-                if [[ "${1}" == -?(-)b?(yte?(s))?([= ])+([0-9])?([KkMmGgTtPp])?(i)?([Bb]) ]]; then
-                    nBytes="${1##@(+([0-9])?([KkMmGgTtPp])?(i)?([Bb]))}"
+            -?(-)b?(yte?(s))?(?([= ])+([0-9])*))
+                if [[ "${1}" == -?(-)b?(yte?(s))?([= ])+([0-9])* ]]; then
+                    nBytes="${1##@(+([0-9])*)}"
                     readBytesFlag=true
                     readBytesExactFlag=false
-                elif [[ "${1}" == -?(-)b?(yte?(s)) ]] && [[ "${2}" == +([0-9])?([KkMmGgTtPp])?(i)?([Bb]) ]]; then
+                elif [[ "${1}" == -?(-)b?(yte?(s)) ]] && [[ "${2}" == +([0-9])* ]]; then
                     nBytes="${2}"
                     readBytesFlag=true
                     readBytesExactFlag=false
@@ -93,12 +94,12 @@ forkrun() {
                 fi
             ;;
 
-            -?(-)B?(YTE?(S))?(?([= ])+([0-9])?([KkMmGgTtPp])?(i)?([Bb])?(,+([0-9])?(.+([0-9])))))
-                if [[ "${1}" == -?(-)B?(YTE?(S))?([= ])+([0-9])?([KkMmGgTtPp])?(i)?([Bb])?(,+([0-9])?(.+([0-9]))) ]]; then
-                    nBytes="${1##@(+([0-9])?([KkMmGgTtPp])?(i)?([Bb])?(,+([0-9])?(.+([0-9]))))}"
+            -?(-)B?(YTE?(S))?(?([= ])+([0-9])*?(,+([0-9])*?(.+([0-9])*))))
+                if [[ "${1}" == -?(-)B?(YTE?(S))?([= ])+([0-9])*?(,+([0-9])*?(.+([0-9])*)) ]]; then
+                    nBytes="${1##@(+([0-9])*?(,+([0-9])*?(.+([0-9])*)))}"
                     readBytesFlag=true
                     readBytesExactFlag=true
-                elif [[ "${1}" == -?(-)B?(YTE?(S)) ]] && [[ "${2}" == +([0-9])?([KkMmGgTtPp])?(i)?([Bb])?(,+([0-9])?(.+([0-9]))) ]]; then
+                elif [[ "${1}" == -?(-)B?(YTE?(S)) ]] && [[ "${2}" == +([0-9])*?(,+([0-9])*?(.+([0-9])*)) ]]; then
                     nBytes="${2}"
                     readBytesFlag=true
                     readBytesExactFlag=true
@@ -282,7 +283,7 @@ forkrun() {
         fi
 
         # determine what forkrun is using lines on stdin for
-        if ${FORCE_allowCarriageReturnsFlag}; then
+        if ${FORCE_allowCarriageReturnsFlag:-false}; then
             # NOTE: allowing carriage returns in parFunC (or its initial args) is DANGEROUS. Dont do this unless you know what you are doing.
             # As such, `FORCE_allowCarriageReturnsFlag` can only be enabled (set to `true`) using the DEBUG_FORKRUN environment variable
             runCmd=("${@}") 
@@ -307,22 +308,13 @@ forkrun() {
             nBytes="${nBytes,,}"
             nBytes="${nBytes//' '/}"
 
-            [[ "${nBytes}" == +([0-9])?([KkMmGgTtPp])?(i)?([Bb]),+([0-9])?(.+([0-9])) ]] && {
+            [[ "${nBytes}" == +([0-9])?([kmgtpezyrq])?(i)?([b]),+([0-9])?(.+([0-9])) ]] && {
                 tTimeout="${nBytes##*,}"
                 [[ "${tTimeout}" == +([0-9]).*([0-9]) ]] && { tTimeout="${tTimeout%%.*}"; ((tTimeout++)); }
                 nBytes="${nBytes%,*}"
             }
 
-            nBytes="${nBytes%b}"
-            [[ "${nBytes}" == +([0-9])@([kmgtp])?(i) ]] && {
-                local -A nBytesParser=([k]=1 [m]=2 [g]=3 [t]=4 [p]=5)
-
-                if [[ ${nBytes: -1:1} == 'i' ]]; then
-                    nBytes="$(( ${nBytes%[kmgtp]i} * ( 1024 ** ${nBytesParser[${nBytes: -2:1}]} ) ))"
-                else
-                    nBytes="$(( ${nBytes%[kmgtp]} * ( 1000 ** ${nBytesParser[${nBytes: -1:1}]} ) ))"
-                fi
-            }
+            nBytes="$(_forkrun_getVal "${nBytes}")"
 
             # make sure nBytes is only digits
             [[ "${nBytes//[0-9]/}" ]] && (( ${verboseLevel} >= 0 )) && { 
@@ -366,7 +358,7 @@ forkrun() {
 
         else
             # set batch size
-            { [[ ${nLines} ]]  && (( ${nLines} > 0 )) && : "${nLinesAutoFlag:=false}"; } || : "${nLinesAutoFlag:=true}"
+            { [[ ${nLines} ]] && { nLines="$(_forkrun_getVal "${nLines}")"; (( ${nLines} > 0 )) && : "${nLinesAutoFlag:=false}"; }; } || : "${nLinesAutoFlag:=true}"
             { [[ -z ${nLines} ]] || [[ ${nLines} == 0 ]]; } && nLines=1
         fi
 
@@ -379,16 +371,13 @@ forkrun() {
         [[ "${nProcs}" == *','* ]] && {
             : "${nQueueFlag:=true}"
             nProcsMax="${nProcs#*,}"
-            nProcs="${nProcs%%,*}"
-            [[ "${nProcsMax}" == *','* ]] && {
-                nQueueMin="${nProcsMax#*,}"
-                nProcsMax="${nProcsMax%%,*}"
-            }
+            [[ "${nProcsMax}" == *','* ]] && nQueueMin="$(_forkrun_getVal "${nProcsMax#*,}")"
+            nProcsMax="$(_forkrun_getVal "${nProcsMax%%,*}")"
         }
+        nProcs="$(_forkrun_getVal "${nProcs%%,*}")"
 
         : "${nQueueFlag:=false}" "${nQueueMin:=1}"
-
-        local -i nProcs="${nProcs}" nProcsMax="${nProcsMax}"
+     
         nCPU="$({ type -a nproc &>/dev/null && nproc; } || { type -a grep &>/dev/null && grep -cE '^processor.*: ' /proc/cpuinfo; } || { mapfile -t tmpA  </proc/cpuinfo && tmpA=("${tmpA[@]//processor*/$'\034'}") && tmpA=("${tmpA[@]//!($'\034')/}") && tmpA=("${tmpA[@]//$'\034'/1}") && tmpA="${tmpA[*]}" && tmpA="${tmpA// /}" && echo ${#tmpA}; } || printf '8')";
         { [[ ${nProcs} ]] && (( ${nProcs:-0} > 0 )); } || { ${nQueueFlag} && nProcs=$(( ${nCPU} / 2  )) || nProcs=${nCPU}; }
 
@@ -404,6 +393,12 @@ forkrun() {
 
         # set defaults for control flags/parameters
         : "${nOrderFlag:=false}" "${rmTmpDirFlag:=true}" "${nLinesMax:=1024}" "${subshellRunFlag:=false}" "${pipeReadFlag:=false}" "${substituteStringFlag:=false}" "${substituteStringIDFlag:=false}" "${exportOrderFlag:=false}" "${unescapeFlag:=false}" "${stdinRunFlag:=false}" 
+
+        local -i nProcs="${nProcs}" nProcsMax="${nProcsMax}" nQueueMin="${nQueueMin}" nLines="${nLines}" nLinesMax="${nLinesMax}"
+
+        # ensure sensible nLinesMax
+         ${nLinesAutoFlag} && {  (( nLinesMax < 2 * nLines )) && nLinesMax=$(( 2 * nLines )); } || { (( nLinesMax < nLines )) && nLinesMax=nLines; }
+
         doneIndicatorFlag=false
 
         # check for inotifywait
@@ -486,7 +481,7 @@ forkrun() {
             ${fallocateFlag} && echo 'using fallocate to shrink the tmpfile containing stdin as forkrun runs'
             ${lseekFlag} && echo 'using "lseek" loadable builtin to read data faster and more efficiently'
             ${nQueueFlag} && printf '(-j|-P) initial / max workers: %s / %s. workers will be dynamically spawned (up to a %s workers max) whenever read queue depth is less than %s\n' "${nProcs}" "${nProcsMax}" "${nProcsMax}" "${nQueueMin}" || printf '(-j|-P) using %s coproc workers\n' ${nProcs}
-            ${nLinesAutoFlag} && printf '(-L) automatically adjusting batch size (lines per function call). initial = %s line(s). maximum = %s line(s).\n' "${nLines}" "${nLinesMax}"
+            ${nLinesAutoFlag} && printf '(-L) automatically adjusting batch size (lines per function call). initial = %s line(s). maximum = %s line(s).\n' "${nLines}" "${nLinesMax}" || printf '(-l) using %s lines per function call (batch size) \n' "${nLines}"
             printf '(-t) forkrun tmpdir will be under %s\n' "${tmpDirRoot}"
             ${readBytesFlag} && printf '(-%s) data will be read in chunks of %s %s bytes using %s\n' "$(${readBytesExactFlag} && echo 'B' || echo 'b')" "$(${readBytesExactFlag} && echo 'exactly' || echo 'up to')" "${nBytes}" "${readBytesProg}"
             ${nOrderFlag} && echo '(-k) output will be ordered the same as if the inputs were run sequentially'
@@ -1064,10 +1059,10 @@ p_PID+=(\${p{<#>}_PID})""" )"
                 kkProcs=${nProcs}                
 
                 p_PID=()
-		pLOADA=()
+                pLOADA=()
 
                 nQueue=0
-		nQueueLastCount=0
+                nQueueLastCount=0
                 
                 (( "${nQueueMin}" <= 0 )) && nQueueMin=1
                 
@@ -1075,7 +1070,7 @@ p_PID+=(\${p{<#>}_PID})""" )"
 
                 mapfile -t pLOADA < <(_forkrun_get_load -i)
                             
-		(( ${verboseLevel} > 2 )) && printf 'pLOADA = ( %s %s %s %s )\n' "${pLOADA[@]}" >&${fd_stderr}
+               (( ${verboseLevel} > 2 )) && printf 'pLOADA = ( %s %s %s %s )\n' "${pLOADA[@]}" >&${fd_stderr}
 
                 until [[ -f "${tmpDir}"/.quit ]] || (( ${kkProcs} >= ${nProcsMax} )); do
                     nQueueLast=${nQueue}
@@ -1097,14 +1092,14 @@ p_PID+=(\${p{<#>}_PID})""" )"
 
                     if (( ( ${nQueue} + ${nQueueLast} ) < ( 2 * ${nQueueMin} ) )); then
 
-			    if (( ${nQueueLastCount} < ( ${nQueueLastCountGoal} * ( 1 + ( kkProcs /  nCPU ) ) ) )); then
+                        if (( ${nQueueLastCount} < ( ${nQueueLastCountGoal} * ( 1 + ( kkProcs /  nCPU ) ) ) )); then
                             ((nQueueLastCount++))
                         else
                             nQueueLastCount=0
 
                             mapfile -t pLOADA < <(_forkrun_get_load "${pLOADA[@]}")
 
-		            (( ${verboseLevel} > 2 )) && printf 'pLOADA = ( %s %s %s %s )\n' "${pLOADA[@]}" >&${fd_stderr}
+                            (( ${verboseLevel} > 2 )) && printf 'pLOADA = ( %s %s %s %s )\n' "${pLOADA[@]}" >&${fd_stderr}
 
                             (( ${pLOADA} >= ${pLOAD_max} )) || {
 
@@ -1133,7 +1128,7 @@ p_PID+=(\${p{<#>}_PID})""" )"
                             }
                         fi
                     else
-			    nQueueLastCount=0
+                nQueueLastCount=0
                     fi
                     
                 done
@@ -1249,7 +1244,7 @@ _forkrun_complete() {
             ;;
 
             # forkrun option with arg or for displaying help - 1 input
-            -?(-)@(@([jP]|?(n)[Pp]roc?(s)?)@([= ])+([0-9])|?(n)l?(ine?(s))@([= ])+([0-9])|?(N)L?(INE?(S))@([= ])+([0-9])?(,+([0-9]))|b?(yte?(s))@([= ])+([0-9])?([KkMmGgTtPp])?(i)?([Bb])|B?(YTE?(S))@([= ])+([0-9])?([KkMmGgTtPp])?(i)?([Bb])?(,+([0-9])?(.+([0-9])))|t?(mp?(?(-)dir))@([= ])*@([[:graph:]])*|d?(elim?(iter))@([= ])@([[:graph:]])*|help?(=@(a?(ll)|f?(lag?(s))|s?(hort)))|usage|[h?]))
+            -?(-)@(@([jP]|?(n)[Pp]roc?(s)?)@([= ])+([0-9])|?(n)l?(ine?(s))@([= ])+([0-9])|?(N)L?(INE?(S))@([= ])+([0-9])?(,+([0-9]))|b?(yte?(s))@([= ])+([0-9])*|B?(YTE?(S))@([= ])+([0-9])*?(,+([0-9])?(.+([0-9])))|t?(mp?(?(-)dir))@([= ])*@([[:graph:]])*|d?(elim?(iter))@([= ])@([[:graph:]])*|help?(=@(a?(ll)|f?(lag?(s))|s?(hort)))|usage|[h?]))
                 ((kk++))
             ;;
 
@@ -1297,7 +1292,7 @@ _forkrun_complete() {
 
         # generate array with possible completions
         mapfile -t compsA < <(printf '%s ' '' -{,-}{j,P,nprocs}{,=} $'\n' \
-echo -t{,=} --{tmp,tmpdir}{,=} --t{,=} -{tmp,tmpdir}{,=} $'\n' \
+-t{,=} --{tmp,tmpdir}{,=} --t{,=} -{tmp,tmpdir}{,=} $'\n' \
 -l{,=} --{,n}line{s,}{,=} --l{,=} -{,n}line{s,}{,=} $'\n' \
 -L{,=} --{,N}LINE{S,}{,=} --L{,=} -{,N}LINE{S,}{,=} $'\n' \
 -b{,=} --byte{s,}{,=} --b{,=} -byte{s,}{,=} $'\n' \
@@ -1307,9 +1302,9 @@ echo -t{,=} --{tmp,tmpdir}{,=} --t{,=} -{tmp,tmpdir}{,=} $'\n' \
 {-,+}i {--,++}insert {--,++}i {-,+}insert {-+,+-}i {-+,+-}insert $'\n' \
 {-,+}I {--,++}INSERT{,-ID,ID} {--,++}I {-,+}INSERT{,-ID,ID}{-+,+-}I {-+,+-}INSERT{,-ID,ID} $'\n' \
 {-,+}k {--,++}keep{,-order,order} {--,++}k {-,+}keep{,-order,order} {-+,+-}k {-+,+-}keep{,-order,order} $'\n' \
-{-,+}n {--,++}number{-,}line{,s} {--,++}n {-,+}number{-,}line{,s} {-+,+-}n {-+,+-}number{-,}line{,s} $'\n' \
+{-,+}K {--,++}KEEP{,ORDER,ORDERING,-ORDER,-ORDERING}{,INFO,-INFO} {--,++}K {-,+}KEEP{,ORDER,ORDERING,-ORDER,-ORDERING}{,INFO,-INFO} {-+,+-}K {-+,+-}KEEP{,ORDER,ORDERING,-ORDER,-ORDERING}{,INFO,-INFO} $'\n' \
 {-,+}{z,0} {--,++}{zero,null} {--,++}{z,0} {-,+}{zero,null} {-+,+-}{z,0} {-+,+-}{zero,null} $'\n' \
-{-,+}s {--,++}sub{,-}shell{-,}run {--,++}s {-,+}sub{,-}shell{-,}run {-+,+-}s {-+,+-}sub{,-}shell{-,}run $'\n' \
+{-,+}s {--,++}sub{,-}shell{-,}run {-v-,++}s {-,+}sub{,-}shell{-,}run {-+,+-}s {-+,+-}sub{,-}shell{-,}run $'\n' \
 {-,+}S {--,++}{S,s}tdin{,-run,run} {--,++}S {-,+}{S,s}tdin{,-run,run} {-+,+-}S {-+,+-}{S,s}tdin{,-run,run} $'\n' \
 {-,+}p {--,++}pipe{,-read,read} {--,++}p {-,+}pipe{,-read,read} {-+,+-}p {-+,+-}pipe{,-read,read} $'\n' \
 {-,+}D {--,++}{D,d}elete {--,++}D {-,+}{D,d}elete {-+,+-}D {-+,+-}{D,d}elete $'\n' \
@@ -1804,13 +1799,13 @@ _forkrun_get_load() (
                 }
             ;;
             [0-9]*)
-		    case "${argCount}" in
-			    0)  [[ ${1} == 0 ]] && pLOAD0=1 || pLOAD0="${1}"  ;;
-			    1)  cpu_ALL0="${1}"  ;;
-			    2)  cpu_LOAD0="${1}"  ;;
-			    3)  tALL0="${1}"  ;;
-		    esac
-		    ((argCount++))
+            case "${argCount}" in
+                0)  [[ ${1} == 0 ]] && pLOAD0=1 || pLOAD0="${1}"  ;;
+                1)  cpu_ALL0="${1}"  ;;
+                2)  cpu_LOAD0="${1}"  ;;
+                3)  tALL0="${1}"  ;;
+            esac
+            ((argCount++))
             ;;
         esac
         shift 1
@@ -1826,10 +1821,10 @@ _forkrun_get_load() (
     cpu_ALL=$(( cpu_LOAD + cpu_idle + cpu_IOwait ))
     
     ${initFlag} && {
-	cpu_ALL0="${cpu_ALL}"
+    cpu_ALL0="${cpu_ALL}"
         cpu_LOAD0="${cpu_LOAD}"
 
-	( read -r -u $fd_sleep -t 0.01; ) {fd_sleep}<><(:)
+    ( read -r -u $fd_sleep -t 0.01; ) {fd_sleep}<><(:)
 
         read -r _ cpu_user cpu_nice cpu_system cpu_idle cpu_IOwait cpu_irq cpu_softirq cpu_steal cpu_guest cpu_guestnice </proc/stat
     
@@ -1858,31 +1853,29 @@ _forkrun_get_load() (
 )
 
 _forkrun_getVal() {
-    ## expands IEC and SI prefixed to get the numeric value they represent
-	#
-	# IEC prefixes (1024^N) are used by default are used to be consistent with other linux tools
-	# SI prefixes (1000^N) can be used by adding a '+' to the start of the number
-	#
-	# neither capatalization nor trailing -i's and -b's have any effect
-	#     1k =  1K =  1kb =  1KB =  1kib =  1KiB = 1024
-    #    +1k = +1K = +1kb = +1KB = +1kib = +1KiB = 1000
+    ## Expands IEC and SI prefixes to get the numeric value they represent
+    #
+    # IEC PREFIC (1024^N) is used if the prefix has a trailing '-i' (Ki/Mi/Gi). This is is the case without exception.
+    #  SI PREFIX (1000^N) is used if the prefix is a single letter (K/M/G/...), UNLESS the number is prefaced with a '+'.
+    #
+    # NOTE: neither capatalization nor a trailing -b/-B have any effect. full word prefixes (e.g., '1 kilobyte') are not supported.
+    #
+    #  PARSING EXAMPLES:
+    #        +1k = +1K = +1kb = +1KB = 1kib = 1KiB = +1kib = +1KiB = 1024
+    #         1k =  1K =  1kb =  1KB = 1000
 
-    local +i nn
-    local -AI pMap
+    local +i -l nn
 
-    (( ${#pMap[@]} > 0 )) || pMap=([k]=1 [m]=2 [g]=3 [t]=4 [p]=5 [e]=6 [z]=7 [y]=8 [r]=9 [q]=10)
+    (( ${#pMap[@]} == 20 )) || local -Ag pMap=([k]=1 [m]=2 [g]=3 [t]=4 [p]=5 [e]=6 [z]=7 [y]=8 [r]=9 [q]=10 [ki]=1 [mi]=2 [gi]=3 [ti]=4 [pi]=5 [ei]=6 [zi]=7 [yi]=8 [ri]=9 [qi]=10)
      
-    for nn in "${@,,}"; do	
-        nn="${nn%b}";
-        [[ "${nn:0:1}${nn: -1}"  == '+i' ]] && nn="${nn:1}"
-        nn="${nn%i}";
-
-        case "${nn:0:1}" in
-            '+')
-                echo "$(( ${nn//[^0-9]/} * ( 1000 ** ${pMap[${nn: -1}]:-0} ) ))"
+    for nn in "${@%%[Bb]*}"; do    
+        [[ ${nn} ]] || continue
+        case "${nn// /}" in
+            *'i'|'+'*)
+                printf '%s\n' "$(( ${nn//[^0-9]/} << ( 10 * ${pMap[${nn##*[0-9]}]:-0} ) ))"
             ;;
             *)
-                echo "$(( ${nn//[^0-9]/} << ( 10 * ${pMap[${nn: -1}]:-0} ) ))"
+                printf '%s\n' "$(( ${nn//[^0-9]/} * ( 1000 ** ${pMap[${nn: -1}]:-0} ) ))"
             ;;
         esac
     done

--- a/forkrun.bash
+++ b/forkrun.bash
@@ -28,9 +28,11 @@ forkrun() {
 
     # make all variables local
     local +i nLines nLines0 nLinesMax nBytes nProcs nProcsMax nQueueMin
-    local tmpDir fPath outStr delimiterVal delimiterReadStr delimiterRemoveStr exitTrapStr exitTrapStr_kill nOrder tTimeout coprocSrcCode outCur tmpDirRoot returnVal tmpVar t0 readBytesProg nullDelimiterProg ddQuietStr trailingNullFlag inotifyFlag lseekFlag fallocateFlag nLinesAutoFlag nQueueFlag substituteStringFlag substituteStringIDFlag nOrderFlag readBytesFlag readBytesExactFlag nullDelimiterFlag subshellRunFlag stdinRunFlag pipeReadFlag rmTmpDirFlag exportOrderFlag noFuncFlag unescapeFlag optParseFlag continueFlag doneIndicatorFlag FORCE_allowCarriageReturnsFlag ddAvailableFlag fd_continue fd_inotify fd_inotify0 fd_nAuto fd_nAuto0 fd_nOrder fd_nOrder0 fd_read fd_read0 fd_write fd_stdout fd_stdin fd_stdin0 fd_stderr pWrite pOrder pAuto pQueue pWrite_PID pNotify_PID pOrder_PID pAuto_PID pQueue_PID fd_read_pos fd_read_pos_old fd_write_pos DEBUG_FORKRUN
-    local -i PID0 nLinesCur nLinesNew nRead nWait nOrder0 nBytesRead nQueue nQueueLast nQueueLastCount nCPU v9 kkMax kkCur kk kkProcs verboseLevel pLOAD_max pAdd
-    local -a A p_PID runCmd outHave outPrint pLOADA
+    local tmpDir fPath outStr delimiterVal delimiterReadStr delimiterRemoveStr exitTrapStr exitTrapStr_kill nOrder tTimeout coprocSrcCode outCur tmpDirRoot returnVal tmpVar t0 readBytesProg nullDelimiterProg ddQuietStr nLinesRead pLOAD0 pLOAD1 trailingNullFlag inotifyFlag lseekFlag fallocateFlag nLinesAutoFlag nQueueFlag substituteStringFlag substituteStringIDFlag nOrderFlag readBytesFlag readBytesExactFlag nullDelimiterFlag subshellRunFlag stdinRunFlag pipeReadFlag rmTmpDirFlag exportOrderFlag noFuncFlag unescapeFlag optParseFlag continueFlag doneIndicatorFlag FORCE_allowCarriageReturnsFlag ddAvailableFlag fd_continue fd_inotify fd_inotify0 fd_nAuto fd_nAuto0 fd_nOrder fd_nOrder0 fd_read fd_read0 fd_write fd_stdout fd_stdin fd_stdin0 fd_stderr pWrite pOrder pAuto pQueue pWrite_PID pNotify_PID pOrder_PID pAuto_PID pQueue_PID fd_read_pos fd_read_pos_old fd_write_pos DEBUG_FORKRUN
+    local -i PID0 nLinesCur nLinesNew nRead nWait nOrder0 nBytesRead nQueue nQueueLast nQueueLastCount nCPU v9 kkMax kkCur kk kkProcs verboseLevel pLOAD_max pAdd tStart tStart0
+    local -a A p_PID runCmd outHave outPrint pLOADA pLOADA0
+    local -a -i runTimeA runLinesA
+
 
     # # # # # PARSE OPTIONS # # # # #
 
@@ -504,6 +506,8 @@ forkrun() {
 
         # # # # # FORK "HELPER" PROCESSES # # # # #
 
+        tStart="${EPOCHREALTIME//./}"
+
         # start building exit trap string
         exitTrapStr=': >"'"${tmpDir}"'"/.done;
 : >"'"${tmpDir}"'"/.quit;
@@ -538,6 +542,9 @@ kill -USR1 $(cat </dev/null "'"${tmpDir}"'"/.run/p* 2>/dev/null) 2>/dev/null; '$
             exitTrapStr_kill+="${pWrite_PID} "
 
         }
+
+                
+
 
         # setup (ordered) output. This uses the same naming scheme as `split -d` to ensure a simple `cat /path/*` always orders things correctly.
         if ${nOrderFlag}; then
@@ -584,7 +591,7 @@ kill -USR1 $(cat </dev/null "'"${tmpDir}"'"/.run/p* 2>/dev/null) 2>/dev/null; '$
         fi
 
         # setup automatic dynamic nLines adjustment and/or fallocate pre-truncation of (already processed) stdin
-        if ${nLinesAutoFlag} || ${fallocateFlag}; then
+        if ${nLinesAutoFlag} || ${fallocateFlag} || ${nQueueFlag}; then
 
             printf '%s\n' ${nLines} >"${tmpDir}"/.nLines
 
@@ -608,35 +615,49 @@ kill -USR1 $(cat </dev/null "'"${tmpDir}"'"/.run/p* 2>/dev/null) 2>/dev/null; '$
                     nWait=$(( 16 + ( ${nProcs} / 2 ) ))
                     fd_read_pos_old=0
                 }
-                ${nLinesAutoFlag} && nRead=0
+                ${nLinesAutoFlag} && nLinesRead=0
 
-                while ${fallocateFlag} || ${nLinesAutoFlag}; do
+                while ${fallocateFlag} || ${nLinesAutoFlag} || ${nQueueFlag}; do
 
-                    read -u ${fd_nAuto} -t 0.1
+                    read -u ${fd_nAuto} -t 0.1 || continue
 
                     case ${REPLY} in
                         0)
                             nLinesAutoFlag=false
                             fallocateFlag=false
+                            nQueueFlag=false
                             break
                         ;;
-
-                        '')
+                        x)
                             nLinesAutoFlag=false
+                        ;;
+                        q)
+                            nQueueFlag=false
                         ;;
                     esac
 
-                    read -r fd_read_pos </proc/self/fdinfo/${fd_read}
-                    fd_read_pos=${fd_read_pos##*$'\t'}
+                    if ${fallocateFlag} || ${nLinesAutoFlag} || ${nQueueFlag}; then
 
-                    if ${nLinesAutoFlag}; then
+                        read -r fd_read_pos </proc/self/fdinfo/${fd_read}
+                        fd_read_pos=${fd_read_pos##*$'\t'}
+
+                    fi
+
+                    if ${nLinesAutoFlag} || ${nQueueFlag}; then
 
                         read fd_write_pos </proc/self/fdinfo/${fd_write}
                         fd_write_pos=${fd_write_pos##*$'\t'}
 
-                        nRead+=${REPLY}
+                        [[ "${REPLY}" == +([0-9]) ]] && nLinesRead=$(( nLinesRead + ${REPLY} ))
 
-                        nLinesNew=$(( 1 + ( ${nLinesCur} + ( ( 1 + ${nRead} ) * ( ${fd_write_pos} - ${fd_read_pos} ) ) / ( ${nProcs} * ( 1 + ${fd_read_pos} ) ) ) ))
+                        nLinesEst=$(( ( ( 1 + ${nLinesRead} ) * ( 1 + ${fd_write_pos} ) ) / ( 1 + ${fd_read_pos} ) ))
+                    fi
+
+                    ${nQueueFlag} && printf '%s %s\n' "${nLinesEst}" "$(( ${EPOCHREALTIME//./} - tStart ))" >"${tmpDir}"/.stdin_lines_time
+
+                    if ${nLinesAutoFlag}; then
+
+                        nLinesNew=$(( 1 + ( ( nLinesEst - nLinesRead ) / ${nProcs} ) ))
 
                         (( ${nLinesNew} > ${nLinesCur} )) && {
 
@@ -645,7 +666,7 @@ kill -USR1 $(cat </dev/null "'"${tmpDir}"'"/.run/p* 2>/dev/null) 2>/dev/null; '$
                             printf '%s\n' ${nLinesNew} >"${tmpDir}"/.nLines
 
                             # verbose output
-                            (( ${verboseLevel} > 2 )) && printf '\nCHANGING nLines from %s to %s!!!  --  ( nRead = %s ; write pos = %s ; read pos = %s )\n' ${nLinesCur} ${nLinesNew} ${nRead} ${fd_write_pos} ${fd_read_pos} >&${fd_stderr}
+                            (( ${verboseLevel} > 2 )) && printf '\nCHANGING nLines from %s to %s!!!  --  ( nLinesRead = %s ; write pos = %s ; read pos = %s )\n' ${nLinesCur} ${nLinesNew} ${nLinesRead} ${fd_write_pos} ${fd_read_pos} >&${fd_stderr}
 
                             nLinesCur=${nLinesNew}
                         }
@@ -671,6 +692,7 @@ kill -USR1 $(cat </dev/null "'"${tmpDir}"'"/.run/p* 2>/dev/null) 2>/dev/null; '$
                     [[ -f "${tmpDir}"/.quit ]] && {
                         nLinesAutoFlag=false
                         fallocateFlag=false
+                        nQueueFlag=false
                     }
 
                 done
@@ -705,12 +727,191 @@ kill -USR1 $(cat </dev/null "'"${tmpDir}"'"/.run/p* 2>/dev/null) 2>/dev/null; '$
                 pNotify_PID="$(<"${tmpDir}"/.run/pNotify)"
             } 2>/dev/null {fd_inotify0}>&${fd_inotify}
 
-
             exitTrapStr+=': > "'"${tmpDir}"'"/.stdin; '$'\n'
             ${nOrderFlag} && exitTrapStr+=': >"'"${tmpDir}"'"/.out/.quit; '$'\n'
             exitTrapStr_kill+="${pNotify_PID} "
         }
 
+        # setup dynamically spawning new worker coprocs
+        # dynamic spawning is decided using 3 criteria:
+        #    1) total worker coproc count must not exceed the maximum worker coproc count (by default 2 * nCPU).
+        #    2) coprocs will spawn until total system cpu load is at >=90% (for all cpu cores) OR until one of the other criteria is violated. If spawning new coproc(s) lowers system load, the target (90%) will be reduced.
+        #    3) coprocs will spawn until ( the average time it takes to get N lines on stdin ) >= ( ( the time it takes to process N lines ) / ( num worker coprocs ) OR until one of the other criteria is violated.
+        ${nQueueFlag} && {
+            export -f _forkrun_get_load
+            { coproc pQueue {
+
+                # set traps and global vars
+                export LC_ALL=C LANG=C IFS=
+                trap 'printf '"'"'\n'"'"' >&'"${fd_nQueue0}"'; [[ -f "'"${tmpDir}"'"/.run/pQueue ]] && \rm -f "'"${tmpDir}"'"/.run/pQueue' EXIT
+                trap 'trap - TERM INT HUP USR1; kill -USR1 "${p_PID[@]}"; kill -INT '"${PID0}"' ${BASHPID} "${p_PID[@]}"' INT
+                trap 'trap - TERM INT HUP USR1; kill -USR1 "${p_PID[@]}";  kill -TERM '"${PID0}"' ${BASHPID} "${p_PID[@]}"' TERM
+                trap 'trap - TERM INT HUP USR1; kill -USR1 "${p_PID[@]}";  kill -HUP '"${PID0}"' ${BASHPID} "${p_PID[@]}"' HUP
+                trap 'trap - TERM INT HUP USR1' USR1
+
+    
+                # get estimate of pre-forkrun baxkgrounfd system load (/proc/loadavg) and
+                # get initial measurement for system cpu load calculation (/proc/stat)
+#                IFS=' .'
+#                read -r pLOAD00 pLOAD01 _ </proc/loadavg
+#                IFS=
+#                pLOAD0=$(( ( ( 10000 * pLOAD00 ) + ( 100 * ${pLOAD01##+([0])} ) ) / nCPU ))
+#                pLOAD0=0
+
+	        ${nQueueFlag} && mapfile -t pLOADA0 < <(_forkrun_get_load -i)
+
+                # wait for the helper coprocs spawned by the main thread to be spawned
+                read -r -u ${fd_nQueue0}
+
+		# get background load
+                mapfile -t pLOADA0 < <(_forkrun_get_load "${pLOADA0[@]}")
+		pLOAD0="(( pLOADA0 / 4 ))"
+
+                # set some initial values
+                kkProcs=${nProcs}                
+                p_PID=()
+                : "${pLOAD_max:=9000}" "${nProcsMax:=$((2*${nCPU}))}" 
+                
+                # wait for the worker coprocs spawned by the main thread to be spawned
+                read -r -u ${fd_nQueue0}
+
+                # get "extra" load from coprocs forken from main thread and use it to estimate extra CPU load per coproc worker
+                mapfile -t pLOADA0 < <(_forkrun_get_load "${pLOADA0[@]}")
+                pLOAD1=$(( ( pLOADA0 - pLOAD0 ) / ( kkProcs ) ))
+                #pLOAD1=$(( 10000 / nCPU ))
+
+                # record the average load at the current worker coproc count
+                pLOAD0=${pLOADA0}
+                kkProcs0=${kkProcs}
+
+                (( ${verboseLevel} > 3 )) && printf 'pLOADA = ( %s %s %s %s )\nAverage load per worker coproc: %s\n' "${pLOADA[@]}" "${pLOAD1}" >&${fd_stderr}
+
+                # start dynamic spawning now that nProcs workers have already spawned
+                # begin main loop
+                until [[ -f "${tmpDir}"/.quit ]] || (( ${kkProcs} >= ${nProcsMax} )); do
+
+                    # wait for new info to get average run time per batch at current batch size arrives
+                    IFS=' '
+                    read -r -u ${fd_nQueue} runLines runTime
+                    (( ${runLines} < 0 )) && (( ${runTime} < 0 )) && { IFS=; break; }
+                    read -r inLines inTime <"${tmpDir}"/.stdin_lines_time
+                    IFS=
+
+                    # update counts of lines run and run times for the current batch size
+                    runLinesA[${runLines}]=$(( runLinesA[${runLines}] + runLines ))
+                    runTimeA[${runLines}]=$(( runTimeA[${runLines}] + runTime ))
+
+                    # get average system load since the last time a new worker coproc was spawned
+                    mapfile -t pLOADA < <(_forkrun_get_load "${pLOADA0[@]}")
+
+                    # abort if system load is above threshold
+                    (( pLOADA > pLOAD_max )) && continue
+
+                    # figure out the max  numer of new workers to add on this loop
+                    pAddMax=$(( nProcsMax - kkProcs ))
+                    (( pAddMax > ( 1 + ( nCPU / 4 ) ) )) && pAddMax=$(( 1 + ( nCPU / 4 ) ))
+
+                    # estimate out how many new workers it would take to increase systsem load up to threshold
+                    #echo "pAdd=\$(( ( pLOAD_max - pLOADA ) / pLOAD1 ))=\$(( ( $pLOAD_max - $pLOADA ) / $pLOAD1 ))=$(( ( pLOAD_max - pLOADA ) / pLOAD1 ))" >&${fd_stderr}
+                    pAdd=$(( ( pLOAD_max - pLOADA ) / pLOAD1 ))
+
+                    # make sure estimate is between [0::pAddMax]
+                    (( pAdd < 1 )) && pAdd=0
+                    (( pAdd > pAddMax )) && pAdd=${pAddMax}
+
+                    #{ declare -p inTime inLines runTime runLines runTimeA runLinesA kkProcs pAdd pAdd1 pLOAD1 pLOADA; echo; } >&${fd_stderr}
+
+                    # check if "time for N lines to arrive on stdin (t_in)" is less than "time to process N lines (t_run) / numWorkers (kkProcs)"
+                    # since only one worker can read data at a time, bhaving these be equal is ideal since
+                    # data is read as fast as it is comming in and workers arent sitting idle in a wait queue
+                    if (( ( inTime * kkProcs * runLinesA[${runLines}] ) < ( runTimeA[${runLines}] * inLines ) )); then
+
+                        # estimate num workers to add to make t_in = t_run / kkProcs
+                        #echo "pAdd1=\$(( ( ( runTimeA[${runLines}] * inLines ) / ( inTime * runLinesA[${runLines}] ) ) - kkProcs ))=\$(( ( ( ${runTimeA[${runLines}]} * $inLines ) / ( $inTime * ${runLinesA[${runLines}]} ) ) - $kkProcs ))=$(( ( ( runTimeA[${runLines}] * inLines ) / ( inTime * runLinesA[${runLines}] ) ) - kkProcs ))" >&${fd_stderr}
+                        pAdd1=$(( ( ( runTimeA[${runLines}] * inLines ) / ( inTime * runLinesA[${runLines}] ) ) - kkProcs ))
+
+                        # make sure estimate is between [0::pAddMax]
+                        (( pAdd1 < 1 )) && pAdd1=0
+                        (( pAdd1 > pAddMax )) && pAdd1=${pAddMax}
+
+                        # combine this estimate with the opne that maximizes system load
+                        # if only one of these is >0 keep that one, otherwise average with more weight on the smaller estimate
+                        if (( pAdd > 0 )) && (( pAdd1 > 0 )); then
+                            pAdd0=$(( ( ( pAdd * pAdd ) + ( pAdd1 * pAdd1 ) ) / ( pAdd + pAdd1 ) ))
+                            if (( pAdd < pAdd1 )); then
+                                pAdd=$(( ( ( 3 * pAdd ) + pAdd0 ) / 4 ))
+                            elif (( pAdd1 < pAdd )); then
+                                pAdd=$(( ( ( 3 * pAdd1 ) + pAdd0 ) / 4 ))
+                            fi
+                        elif (( pAdd < 0 )) && (( pAdd1 > 0 )); then
+                            pAdd=${pAdd1}
+                        fi
+                    fi
+
+                    # move on to next iteration if we arent adding new workers
+                    (( pAdd < 1 )) && continue 
+
+                    # reduce the number of new workers to spawn a bit, since we cant unspawn them if we spawn too many
+                    # the closer the current worker count is to the max worker count limit, the more this is reduced
+		    pAdd=$(( ( ( ( 4 * nProcsMax ) - ( 3 * kkProcs ) ) * pAdd ) / ( 16 * nProcsMax ) ))
+                    (( pAdd < 1 )) && pAdd=1
+                    (( pAdd > pAddMax )) && pAdd=${pAddMax}
+
+                    # update when system load is measured from since we are about to spawn new workers
+                    #mapfile -t pLOADA0 < <(_forkrun_get_load "${pLOADA0[@]}")
+
+                    # compare system load now to what it was just before the previous most recent group of new coprocs was spawned
+                    if (( pLOADA > pLOAD0 )); then
+
+                        # system load increased (as expected). update "previous load" + "worker count" variables
+                        (( kkProcs > kkProcs0 )) && {
+                            pLOAD1=$(( 1 + ( pLOAD1 * ( kkProcs - kkProcs0 ) + ( pLOADA - pLOAD0 ) ) / ( ( kkProcs - kkProcs0 ) ) ))
+                            pLOAD0=${pLOADA}
+                            kkProcs0=${kkProcs}
+			    (( pLOAD_max < 9000 )) && pLOAD_max=$(( ( ( 3 * nProcsMax * pLOAD_max ) + ( pAdd * 9000 ) ) / ( ( 3 * nProcsMax ) + pAdd ) ))
+                        }
+                    else
+
+                        # system load dropped with spawning new coprocs. This probably means our target maximum system load is too high.
+                        # cut number of new coprocs to spawn to 1 and lower system load target
+                        # How much load target increases depends on how many new coprocs were last spawned that resulted in lowered system load.
+                        if (( kkProcs > kkProcs0 )); then
+                            pLOAD_max=$(( ( ( kkProcs * pLOAD_max ) + ( ( kkProcs-kkProcs0 ) * pLOADA0 ) ) / ( ( 2 * kkProcs ) - kkProcs0 ) ))
+                        else
+                            pLOAD_max=$(( (  pLOAD_max + pLOADA0 ) / 2 ))
+                        fi
+			#pAdd=1
+			continue
+                    fi
+                    
+                    #echo "pAdd (final) = $pAdd" >&${fd_stderr}
+                    (( ${verboseLevel} > 3 )) && printf 'pAdd: %s \n' "${pAdd}" >&${fd_stderr}
+
+                    # spawn the new coproc workers
+                    for (( kk=0; kk<${pAdd}; kk++ )); do
+                        source /proc/self/fd/0 <<<"${coprocSrcCode//'{<#>}'/"${kkProcs}"}"
+                        (( ${verboseLevel} > 2 )) && printf '\nSPAWNING A NEW WORKER COPROC (%s/%s). There are now %s coprocs.\n' "${kk}" "${pAdd}" "${kkProcs}" >&${fd_stderr}
+                        ((kkProcs++))
+                    done
+
+                    # update public worker count info file
+                    echo "${kkProcs}" >"${tmpDir}"/.nWorkers
+                    
+                done
+
+                # tell pAuto that the main nQueue loop is done
+                ${nLinesAutoFlag} && printf 'q\n' >&${fd_nAuto}
+
+                # wait for spawned coproc workers to finish
+                [[ ${#p_PID[@]} == 0 ]] || wait "${p_PID[@]}"
+
+              } 2>&${fd_stderr}
+            } 2>/dev/null
+
+            exitTrapStr+='echo "-1 -1" >&'"${fd_nQueue}"'; '$'\n'
+            printf '%s\n' "${pQueue_PID}" > "${tmpDir}"/.run/pQueue
+
+        }
         # # # # # DYNAMICALLY GENERATE COPROC SOURCE CODE # # # # #
 
         # Due to how the coproc code is dynamically generated and sourced, it cannot directly contain comments. A very brief overview of their function is below.
@@ -751,7 +952,6 @@ trap 'trap - TERM INT HUP USR1' USR1
 
 while true; do"""
 ${nLinesAutoFlag} && echo "\${nLinesAutoFlag} && read -r <\"${tmpDir}\"/.nLines && [[ \${REPLY} == +([0-9]) ]] && nLinesCur=\${REPLY}"
-${nQueueFlag}  && echo "printf '%s' '+' >&${fd_nQueue}"
 echo """
     read -u ${fd_continue}
     [[ -f \"${tmpDir}\"/.quit ]] && {
@@ -899,7 +1099,6 @@ ${pipeReadFlag} || { ${nullDelimiterFlag} && [[ -z ${nullDelimiterProg} ]]; } ||
 ${nOrderFlag} && echo "read -u ${fd_nOrder} nOrder"
 echo """
     printf '\\n' >&${fd_continue}"""
-${nQueueFlag} && echo "printf '%s' '-' >&${fd_nQueue}"
 echo """
     [[ \${#A[@]} == 0 ]] && {
         \${doneIndicatorFlag} || { 
@@ -910,7 +1109,7 @@ echo """
           }
         }
         if \${doneIndicatorFlag} || [[ -f \"${tmpDir}\"/.quit ]]; then"""
-${nLinesAutoFlag} && echo "printf '\\n' >&\${fd_nAuto0}"
+${nLinesAutoFlag} && echo "printf 'x\\n' >&\${fd_nAuto0}"
 ${nOrderFlag} && echo ": >\"${tmpDir}\"/.out/.quit{<#>}"
 ${nQueueFlag} && echo "\printf '%s' '0' >&${fd_nQueue}"
 ${inotifyFlag} && echo 'kill -9 '"${pNotify_PID}"' 2>/dev/null'
@@ -925,7 +1124,8 @@ echo """
         fi
         continue
     }"""
-${nLinesAutoFlag} && { printf '%s' """
+${nQueueFlag} && echo 'tStart0=${EPOCHREALTIME//./}'
+{ ${nLinesAutoFlag} || ${nQueueFlag}; } && { printf '%s' """
     \${nLinesAutoFlag} && {
         printf '%s\\n' \${#A[@]} >&\${fd_nAuto0}
         (( \${nLinesCur} < ${nLinesMax} )) || nLinesAutoFlag=false
@@ -980,6 +1180,7 @@ ${noFuncFlag} && echo 'IFS='
 ${subshellRunFlag} && printf '\n%s ' ')' || printf '\n%s ' '}'
 echo "${outStr}"
 ${nOrderFlag} && echo "printf '%s\n' \"\${nOrder}\" >&${fd_nOrder0}"
+${nQueueFlag} && echo "printf '%s %s\\n' \${#A[@]} \$(( \${EPOCHREALTIME//./} - tStart0 )) >&${fd_nQueue}"
 echo """
 done
 } 2>&${fd_stderr} {fd_nAuto0}>&${fd_nAuto}
@@ -1022,6 +1223,8 @@ p_PID+=(\${p{<#>}_PID})""" )"
         (( ${verboseLevel} > 1 )) && printf '\n\nALL HELPER COPROCS FORKED\n\n' >&${fd_stderr}
         (( ${verboseLevel} > 3 )) && { printf '\nSET TRAPS:\n\n'; trap -p; } >&${fd_stderr}
 
+        ${nQueueFlag} && printf '\n' >&${fd_nQueue0}
+
         # # # # # FORK COPROC "WORKERS" # # # # #
 
         # initialize read lock {fd_continue} will act as an exclusive read lock (so lines from stdin are read atomically):
@@ -1030,117 +1233,17 @@ p_PID+=(\${p{<#>}_PID})""" )"
         #     when that process writes a '\n' back to the pipe it releases the read lock
         printf '\n' >&${fd_continue};
 
-
         # source the coproc code for each coproc worker
         for (( kkProcs=0 ; kkProcs<${nProcs} ; kkProcs++ )); do
             [[ -f "${tmpDir}"/.quit ]] && break
             source /proc/self/fd/0 <<<"${coprocSrcCode//'{<#>}'/"${kkProcs}"}"
         done
+
         echo "${kkProcs}" >"${tmpDir}"/.nWorkers                    
         : >"${tmpDir}"/.spawned
+        ${nQueueFlag} && printf '\n' >&${fd_nQueue0}
 
         (( ${verboseLevel} > 1 )) && printf '\n\n%s WORKER COPROCS FORKED\n\n' "${nProcs}" >&${fd_stderr}
-
-        # setup dynamically coproc to spawn new workers based on read queue length
-        ${nQueueFlag} && ! [[ -f "${tmpDir}"/.quit ]] && {
-            export -f _forkrun_get_load
-            { coproc pQueue {
-
-                export LC_ALL=C LANG=C IFS=
-
-                trap '[[ -f "'"${tmpDir}"'"/.run/pQueue ]] && \rm -f "'"${tmpDir}"'"/.run/pQueue' EXIT
-                trap 'trap - TERM INT HUP USR1; kill -USR1 "${p_PID[@]}"; kill -INT '"${PID0}"' ${BASHPID} "${p_PID[@]}"' INT
-                trap 'trap - TERM INT HUP USR1; kill -USR1 "${p_PID[@]}";  kill -TERM '"${PID0}"' ${BASHPID} "${p_PID[@]}"' TERM
-                trap 'trap - TERM INT HUP USR1; kill -USR1 "${p_PID[@]}";  kill -HUP '"${PID0}"' ${BASHPID} "${p_PID[@]}"' HUP
-                trap 'trap - TERM INT HUP USR1' USR1
-
-                # start spawning after nProcs workers already forked
-                kkProcs=${nProcs}                
-
-                p_PID=()
-                pLOADA=()
-
-                nQueue=0
-                nQueueLastCount=0
-                
-                (( "${nQueueMin}" <= 0 )) && nQueueMin=1
-                
-                : "${pLOAD_max:=9500}" "${nProcsMax:=$((2*${nCPU}))}" "${nQueueLastCountGoal:=5}"
-
-                mapfile -t pLOADA < <(_forkrun_get_load -i)
-                            
-               (( ${verboseLevel} > 2 )) && printf 'pLOADA = ( %s %s %s %s )\n' "${pLOADA[@]}" >&${fd_stderr}
-
-                until [[ -f "${tmpDir}"/.quit ]] || (( ${kkProcs} >= ${nProcsMax} )); do
-                    nQueueLast=${nQueue}
-
-                    # read from fd_queue pipe. 
-                    #      '+' --> increase queue depth by 1. 
-                    #      '-' --> decrease queue depth by 1.
-                    #      '0' --> quit
-                    read -r -u ${fd_nQueue} -N 1 
-        
-                    case "${REPLY}" in
-                        '+')  ((nQueue++))  ;;
-                        '-')  ((nQueue--))  ;;
-                        0)      break       ;;
-                        *)     continue     ;;
-                    esac
-
-                    # (( ${verboseLevel} > 3 )) && { printf '\nnQueue  = %s (nProcs = %s)\n' "${nQueue}" "${kkProcs}"; cat /proc/self/schedstat; } >&${fd_stderr}
-
-                    if (( ( ${nQueue} + ${nQueueLast} ) < ( 2 * ${nQueueMin} ) )); then
-
-                        if (( ${nQueueLastCount} < ( ${nQueueLastCountGoal} * ( 1 + ( kkProcs /  nCPU ) ) ) )); then
-                            ((nQueueLastCount++))
-                        else
-                            nQueueLastCount=0
-
-                            mapfile -t pLOADA < <(_forkrun_get_load "${pLOADA[@]}")
-
-                            (( ${verboseLevel} > 2 )) && printf 'pLOADA = ( %s %s %s %s )\n' "${pLOADA[@]}" >&${fd_stderr}
-
-                            (( ${pLOADA} >= ${pLOAD_max} )) || {
-
-                                if (( ${nCPU} > ${kkProcs} )); then
-
-                                    pAdd=$(( 1 + ( ( ${nCPU} - ${kkProcs} ) * ( ${pLOAD_max} - ${pLOADA} ) ) / ( 1 + ${pLOADA} ) ))
-
-                                    (( ${verboseLevel} > 3 )) && printf '(pLOAD=%s  --  initial pAdd: %s ' "${pLOADA}" "${pAdd}" >&${fd_stderr}
-
-                                    (( ${pAdd} > ( ( ${nProcsMax} - ${kkProcs} ) - ( ( ${nProcsMax} - ${kkProcs} ) / ( 1 + ( 3 * ${nQueueMin} ) - ( 2 * ${nQueue} ) - ${nQueueLast} ) ) ) )) && pAdd=$(( ( ${nProcsMax} - ${kkProcs} ) - ( ( ${nProcsMax} - ${kkProcs} ) / ( 1 + ( 3 * ${nQueueMin} ) - ( 2 * ${nQueue} ) - ${nQueueLast} ) ) ))
-                                    (( ${pAdd} > ( 1 + ( ${nCPU} / 16 ) ) )) && pAdd=$(( 1 + ( ${nCPU} / 16 ) ))
-
-                                    (( ${pAdd} < 1 )) && pAdd=1
-                                else
-                                    pAdd=1
-                                fi
-
-                                (( ${verboseLevel} > 3 )) && printf 'final pAdd: %s \n' "${pAdd}" >&${fd_stderr}
-
-                                for (( kk=0; kk<${pAdd}; kk++ )); do
-                                    source /proc/self/fd/0 <<<"${coprocSrcCode//'{<#>}'/"${kkProcs}"}"
-                                    (( ${verboseLevel} > 2 )) && printf '\nSPAWNING A NEW WORKER COPROC (%s/%s). There are now %s coprocs. (read queue depth = %s)\n' "${kk}" "${pAdd}" "${kkProcs}" "${nQueue}" >&${fd_stderr}
-                                    ((kkProcs++))
-                                done
-                                echo "${kkProcs}" >"${tmpDir}"/.nWorkers
-                            }
-                        fi
-                    else
-                nQueueLastCount=0
-                    fi
-                    
-                done
-
-                [[ ${#p_PID[@]} == 0 ]] || wait "${p_PID[@]}"
-
-              } 2>&${fd_stderr}
-            } 2>/dev/null
-
-            exitTrapStr+='echo "0" >&'"${fd_nQueue}"'; '$'\n'
-            printf '%s\n' "${pQueue_PID}" > "${tmpDir}"/.run/pQueue
-
-        }
 
         (( ${verboseLevel} > 3 )) && { 
             printf '\n\nDYNAMICALLY GENERATED COPROC CODE:\n\n%s\n\n' "${coprocSrcCode}"
@@ -1212,16 +1315,19 @@ p_PID+=(\${p{<#>}_PID})""" )"
         #p_PID=($(_forkrun_rmdups "${p_PID[@]}" $(cat </dev/null "${tmpDir}"/.run/p[0-9]* 2>/dev/null)))
         p_PID+=($(cat </dev/null "${tmpDir}"/.run/p[0-9]* 2>/dev/null))
         wait "${p_PID[@]}" "${pQueue_PID}" &>/dev/null; 
+        ${nQueueFlag} && read -r -u ${fd_nQueue0}
 
         # print final nLines count
         (( ${verboseLevel} > 1 )) && {
             ${nLinesAutoFlag} && printf 'nLines (final) = %s    ( max = %s )\n'  "$(<"${tmpDir}"/.nLines)" "${nLinesMax}"
-            ${nQueueFlag} && printf 'final worker process count: %s    ( min read queue: %s )\n' "$(<"${tmpDir}"/.nWorkers)" "${nQueueMin}" 
+            # ${nQueueFlag} && printf 'final worker process count: %s\n' "$(<"${tmpDir}"/.nWorkers)"
         } >&${fd_stderr} 
+        
+	${nQueueFlag} && printf 'final worker process count: %s\n' "$(<"${tmpDir}"/.nWorkers)" >&${fd_stderr}
 
 
     # open anonymous pipes + other misc file descriptors for the above code block
-    ) {fd_continue}<><(:) {fd_inotify}<><(:) {fd_nAuto}<><(:) {fd_nOrder}<><(:) {fd_nOrder0}<><(:) {fd_nQueue}<><(:) {fd_read}<"${fPath}" {fd_read0}<"${fPath}" {fd_write}>"${fPath}" {fd_stdin}<&${fd_stdin0} {fd_stdout}>&1 {fd_stderr}>&2
+    ) {fd_continue}<><(:) {fd_inotify}<><(:) {fd_nAuto}<><(:) {fd_nOrder}<><(:) {fd_nOrder0}<><(:) {fd_nQueue}<><(:) {fd_nQueue0}<><(:) {fd_read}<"${fPath}" {fd_read0}<"${fPath}" {fd_write}>"${fPath}" {fd_stdin}<&${fd_stdin0} {fd_stdout}>&1 {fd_stderr}>&2
 
 }
 
@@ -1804,6 +1910,8 @@ _forkrun_get_load() (
         shift 1
     done
 
+    : "${tALL0:=0}"
+
 #    if [[ ${pLOAD0} == 0 ]] || [[ ${cpu_ALL0} == 0 ]] || [[ ${cpu_LOAD0} == 0 ]] || [[ ${tALL0} == 0 ]] || [[ -z ${pLOAD0} ]] || [[ -z ${cpu_ALL0} ]] || [[ -z ${cpu_LOAD0} ]] || [[ -z ${tALL0} ]]; then
 #        initFlag=true
 #    fi
@@ -1814,36 +1922,29 @@ _forkrun_get_load() (
     cpu_ALL=$(( cpu_LOAD + cpu_idle + cpu_IOwait ))
     
     ${initFlag} && {
-    cpu_ALL0="${cpu_ALL}"
-        cpu_LOAD0="${cpu_LOAD}"
-
-    ( read -r -u $fd_sleep -t 0.01; ) {fd_sleep}<><(:)
-
-        read -r _ cpu_user cpu_nice cpu_system cpu_idle cpu_IOwait cpu_irq cpu_softirq cpu_steal cpu_guest cpu_guestnice </proc/stat
-    
-        cpu_LOAD=$(( cpu_user + cpu_nice + cpu_system + cpu_irq + cpu_softirq + cpu_steal + cpu_guest + cpu_guestnice ))
-        cpu_ALL=$(( cpu_LOAD + cpu_idle + cpu_IOwait ))
+        pLOADA=(-1 "${cpu_ALL}" "${cpu_LOAD}" 0)
+        printf '%s\n' "${pLOADA[@]}"   
+        return 0
     }
 
     tALL=$(( cpu_ALL - cpu_ALL0 ))
 
     pLOAD=$(( ( loadMaxVal * ( cpu_LOAD - cpu_LOAD0 ) ) / ( 1 + cpu_ALL - cpu_ALL0 ) ))
 
-    ${initFlag} || {
-
-        tLOAD=$(( cpu_LOAD - cpu_LOAD0 ))
+    tLOAD=$(( cpu_LOAD - cpu_LOAD0 ))
         
-        (( tALL0 > ( 10 * tALL ) )) && tALL0=$(( 10 * tALL ))
+    (( tALL0 > ( 10 * tALL ) )) && tALL0=$(( 10 * tALL ))
 
-        pLOAD=$(( ( loadMaxVal * tLOAD ) / ( 1 + tALL ) ))
-        pLOAD=$(( ( ( ( 1 + tALL + tALL0 ) * pLOAD ) + ( tALL0 * pLOAD0 ) ) / ( 1 + tALL + ( 2 * tALL0 ) ) ))
+    pLOAD=$(( ( loadMaxVal * tLOAD ) / ( 1 + tALL ) ))
+    pLOAD=$(( ( ( ( 1 + tALL + tALL0 ) * pLOAD ) + ( tALL0 * pLOAD0 ) ) / ( 1 + tALL + ( 2 * tALL0 ) ) ))
 
-    }
 
     pLOADA=("${pLOAD}" "${cpu_ALL}" "${cpu_LOAD}" "${tALL}")
     printf '%s\n' "${pLOADA[@]}"
     ${echoFlag} && printf 'Current System CPU Load = %s\n' "${pLOAD}" >&2
 )
+
+export -fp _forkrun_getVal &>/dev/null && export -nf _forkrun_getVal
 
 _forkrun_getVal() {
     ## Expands IEC and SI prefixes to get the numeric value they represent

--- a/forkrun.bash
+++ b/forkrun.bash
@@ -1867,13 +1867,16 @@ _forkrun_getVal() {
 	#     1k =  1K =  1kb =  1KB =  1kib =  1KiB = 1024
     #    +1k = +1K = +1kb = +1KB = +1kib = +1KiB = 1000
 
-    local +i nn;
+    local +i nn
+    local -AI pMap
 
     (( ${#pMap[@]} > 0 )) || pMap=([k]=1 [m]=2 [g]=3 [t]=4 [p]=5 [e]=6 [z]=7 [y]=8 [r]=9 [q]=10)
      
     for nn in "${@,,}"; do	
-        nn="${nn%%[ib]*}";
-          
+        nn="${nn%b}";
+        [[ "${nn:0:1}${nn: -1}"  == '+i' ]] && nn="${nn:1}"
+        nn="${nn%i}";
+
         case "${nn:0:1}" in
             '+')
                 echo "$(( ${nn//[^0-9]/} * ( 1000 ** ${pMap[${nn: -1}]:-0} ) ))"

--- a/forkrun.bash
+++ b/forkrun.bash
@@ -27,11 +27,10 @@ forkrun() {
     shopt -s extglob
 
     # make all variables local
-    local +i nLines nLines0 nBytes nProcs
-    local tmpDir fPath outStr delimiterVal delimiterReadStr delimiterRemoveStr exitTrapStr exitTrapStr_kill nLinesMax nQueueMin nOrder nProcsMax tTimeout coprocSrcCode outCur tmpDirRoot returnVal tmpVar t0 readBytesProg nullDelimiterProg ddQuietStr trailingNullFlag inotifyFlag lseekFlag fallocateFlag nLinesAutoFlag nQueueFlag substituteStringFlag substituteStringIDFlag nOrderFlag readBytesFlag readBytesExactFlag nullDelimiterFlag subshellRunFlag stdinRunFlag pipeReadFlag rmTmpDirFlag exportOrderFlag noFuncFlag unescapeFlag optParseFlag continueFlag doneIndicatorFlag FORCE_allowCarriageReturnsFlag ddAvailableFlag fd_continue fd_inotify fd_inotify0 fd_nAuto fd_nAuto0 fd_nOrder fd_nOrder0 fd_read fd_read0 fd_write fd_stdout fd_stdin fd_stdin0 fd_stderr pWrite pOrder pAuto pQueue pWrite_PID pNotify_PID pOrder_PID pAuto_PID pQueue_PID fd_read_pos fd_read_pos_old fd_write_pos DEBUG_FORKRUN
+    local +i nLines nLines0 nLinesMax nBytes nProcs nProcsMax nQueueMin
+    local tmpDir fPath outStr delimiterVal delimiterReadStr delimiterRemoveStr exitTrapStr exitTrapStr_kill nOrder tTimeout coprocSrcCode outCur tmpDirRoot returnVal tmpVar t0 readBytesProg nullDelimiterProg ddQuietStr trailingNullFlag inotifyFlag lseekFlag fallocateFlag nLinesAutoFlag nQueueFlag substituteStringFlag substituteStringIDFlag nOrderFlag readBytesFlag readBytesExactFlag nullDelimiterFlag subshellRunFlag stdinRunFlag pipeReadFlag rmTmpDirFlag exportOrderFlag noFuncFlag unescapeFlag optParseFlag continueFlag doneIndicatorFlag FORCE_allowCarriageReturnsFlag ddAvailableFlag fd_continue fd_inotify fd_inotify0 fd_nAuto fd_nAuto0 fd_nOrder fd_nOrder0 fd_read fd_read0 fd_write fd_stdout fd_stdin fd_stdin0 fd_stderr pWrite pOrder pAuto pQueue pWrite_PID pNotify_PID pOrder_PID pAuto_PID pQueue_PID fd_read_pos fd_read_pos_old fd_write_pos DEBUG_FORKRUN
     local -i PID0 nLinesCur nLinesNew nRead nWait nOrder0 nBytesRead nQueue nQueueLast nQueueLastCount nCPU v9 kkMax kkCur kk kkProcs verboseLevel pLOAD_max pAdd
     local -a A p_PID runCmd outHave outPrint pLOADA
-    #local -Ax pMap
 
     # # # # # PARSE OPTIONS # # # # #
 
@@ -1230,8 +1229,7 @@ p_PID+=(\${p{<#>}_PID})""" )"
 _forkrun_complete() {
     local -i kk jj
     local cmdFlag 
-    local -a compsA comps0 compsT
-    local -A comps
+    local -a compsA comps0 compsT comps
 
     cmdFlag=false
 
@@ -1318,20 +1316,15 @@ _forkrun_complete() {
 {--,-}help={a,all} $'\n' \
 --)
 
-        # generate possible complertions
-        mapfile -t comps0 < <( IFS=' '; compgen -W "${compsA[*]}" -- "${COMP_WORDS[${COMP_CWORD}]}"; )
-
-        # for each possible match, use 1 match from each type of option that forkrun supports. This prevents multiple aliases for a given option being suggested together.
-        for kk in "${!comps0[@]}"; do
-            for jj in "${!compsA[@]}"; do
-                if [[ "${compsA[$jj]}" == *" ${comps0[$kk]} "* ]]; then
-                    mapfile -t compsT < <( IFS=' '; compgen -W "${compsA[$jj]}" -- "${COMP_WORDS[${COMP_CWORD}]}"; )
-                    comps[${compsT[0]}]=''
-                fi
-            done
+        # for each possible option alias group, generate completions and use the 1st match. This prevents multiple aliases for a given option being suggested together.
+        for jj in "${!compsA[@]}"; do
+            if [[ "${compsA[$jj]}" == *\ "${COMP_WORDS[${COMP_CWORD}]}"* ]]; then
+                mapfile -t -n 1 compsT < <( IFS=' '; compgen -W "${compsA[$jj]}" -- "${COMP_WORDS[${COMP_CWORD}]}"; )
+                comps+=("${compsT[0]}")
+            fi
         done
 
-        COMPREPLY=("${!comps[@]}")
+        COMPREPLY=("${comps[@]}")
 
     fi
 }

--- a/hyperfine_benchmark/forkrun.speedtest.hyperfine.bash
+++ b/hyperfine_benchmark/forkrun.speedtest.hyperfine.bash
@@ -12,10 +12,13 @@ renice --priority -20 --pid $$
 }
 
 declare -F forkrun &>/dev/null || { 
-    [[ -f ./forkrun.bash ]] || wget  https://raw.githubusercontent.com/jkool702/forkrun/main/forkrun.bash
+    #[[ -f ./forkrun.bash ]] || wget  https://raw.githubusercontent.com/jkool702/forkrun/main/forkrun.bash
+    [[ -f ./forkrun.bash ]] || wget https://raw.githubusercontent.com/jkool702/forkrun/refs/heads/forkrun_testing_nQueue/forkrun.bash
     . ./forkrun.bash
 }
 #export -f forkrun
+
+: <<EOC
 source /proc/self/fd/0 <<EOI
 _forkrun_export() {
 shopt -s extglob
@@ -35,12 +38,13 @@ EeEOoOFfF
 EOI
 
 export -f _forkrun_export
-
+EOC
 
 findDirDefault='/usr'
 
 findDir='/mnt/ramdisk/usr'
 ramdiskTransferFlag=false
+nullFlag=true
 
 [[ -n "$1" ]] && [[ -d "$1" ]] && findDir="$1"
 : ${findDir:="${findDirDefault}"} ${ramdiskTransferFlag:=true}
@@ -70,6 +74,8 @@ else
 
 fi
 "${testParallelFlag:=true}"
+testParallelFlag=false
+
 declare -a C0 C1
 
 C0[0]=''
@@ -92,29 +98,49 @@ C1[5]=' >/dev/null'
 
 mkdir -p "${hfdir0}"/file_lists
 
-nArgs=(1024 4096 16384 65536 262144 1048576)
+find "${findDir}" -type f $(${nullFlag} && printf '%s' '-print0') >"${hfdir0}"/file_lists/f0
+
+nArgsMax="$(tr '\0' '\n' <"${hfdir0}"/file_lists/f0 | wc -l)"
+nArgs=('' 1024 )
+until (( ( 4 * nArgs[-1] ) >= nArgsMax )); do
+	nArgs+=($((4 * nArgs[-1])))
+done
+nArgs+=(${nArgsMax})
+
 cksumAlgsA=(sha1sum sha256sum sha512sum sha224sum sha384sum md5sum  "sum -s" "sum -r" cksum b2sum "cksum -a sm3" xxhsum "xxhsum -H3")
-find "${findDir}" -type f >"${hfdir0}"/file_lists/f6
-for kk in {1..5}; do
-	shuf -n ${nArgs[$(($kk-1))]} >"${hfdir0}"/file_lists/f${kk} <"${hfdir0}"/file_lists/f6
+
+
+#if ${nullFlag}; then
+#    nArgsMax="$(tr $'\x00' $'\n' <"${hfdir0}"/file_lists/f0 | wc -l)"
+#else
+#    nArgsMax="$(wc -l <"${hfdir0}"/file_lists/f0)"
+#fi
+for (( kk=1; kk<${#nArgs[@]}; kk++ )); do
+
+	shuf $(${nullFlag} && printf '%s' '-z') -n ${nArgs[$kk]} >"${hfdir0}"/file_lists/f${kk} <"${hfdir0}"/file_lists/f0
+
+#    (( nArgs[$kk] >= nArgsMax )) && {
+#        nArgs=("${nArgs[@]:0:$((kk+1))}")
+#        break
+#    }
 done
 
-for jj in ${!C0[@]}; do
+for jj in "${!C0[@]}"; do
         
     hfdir="${hfdir0}/C${jj}"
 
     mkdir -p "${hfdir}"/results
 
-    for kk in {1..6}; do 
-        printf '\n-------------------------------- %s values --------------------------------\n\n' $(wc -l <"${hfdir0}"/file_lists/f${kk}); 
+    for (( kk=1; kk<${#nArgs[@]}; kk++ )); do
+        printf '\n-------------------------------- STARTING TESTING FOR %s VALUES --------------------------------\n\n' "${nArgs[$kk]}"; 
 
         for c in "${cksumAlgsA[@]}"; do 
-            printf '\n---------------- %s ----------------\n\n' "$c"; 
+            printf '\n---------------- %s (%s) ----------------\n\n' "$c" "${nArgs[$kk]}"; 
 
             if ${testParallelFlag}; then
-               hyperfine -w 1 -i --shell=bash --parameter-list cmd 'forkrun -j - --','forkrun --','xargs -P '"$(nproc)"' -d $'"'"'\n'"'"' --','parallel -m --' --export-json ""${hfdir}"/results/forkrun.${c// /_}.f${kk}.hyperfine.results" --style=full --setup 'shopt -s extglob && renice --priority -20 --pid $$' --prepare 'shopt -s extglob && renice --priority -20 --pid $$' '. /mnt/ramdisk/forkrun/forkrun.bash && '"${C0[$jj]//'${kk}'/${kk}}"' {cmd} '"${c}"' '"${C1[$jj]//'${kk}'/${kk}}"
+		       hyperfine -w 1 -i --shell=bash --parameter-list cmd 'forkrun -j - '"$(${nullFlag} && printf '%s' '-z ')"'--','forkrun '"$(${nullFlag} && printf '%s' '-z ')"'--','xargs -P '"$(nproc)"' '"$(${nullFlag} && printf '%s' '-0 '|| printf '%s' '-d $'"'"'\n'"'")"' --','parallel -m --' --export-json ""${hfdir}"/results/forkrun.${c// /_}.f${kk}.hyperfine.results" --style=full --setup 'shopt -s extglob && renice --priority -20 --pid $$' --prepare 'shopt -s extglob && renice --priority -20 --pid $$' '. /mnt/ramdisk/forkrun/forkrun.bash && '"${C0[$jj]//'${kk}'/${kk}}"' {cmd} '"${c}"' '"${C1[$jj]//'${kk}'/${kk}}"
             else
-               hyperfine -w 1 -i --shell=bash --parameter-list cmd 'forkrun -j - --','forkrun --','xargs -P '"$(nproc)"' -d $'"'"'\n'"'"' --' --export-json ""${hfdir}"/results/forkrun.${c// /_}.f${kk}.hyperfine.results" --style=full --setup 'shopt -s extglob && renice --priority -20 --pid $$' --prepare 'shopt -s extglob && renice --priority -20 --pid $$' '. /mnt/ramdisk/forkrun/forkrun.bash && '"${C0[$jj]//'${kk}'/${kk}}"' {cmd} '"${c}"' '"${C1[$jj]//'${kk}'/${kk}}"
+               hyperfine -w 1 -i --shell=bash --parameter-list cmd 'forkrun -j - '"$(${nullFlag} && printf '%s' '-z ')"'--','forkrun '"$(${nullFlag} && printf '%s' '-z ')"'--','xargs -P '"$(nproc)"' '"$(${nullFlag} && printf '%s' '-0 '|| printf '%s' '-d $'"'"'\n'"'")"' --' --export-json ""${hfdir}"/results/forkrun.${c// /_}.f${kk}.hyperfine.results" --style=full --setup 'shopt -s extglob && renice --priority -20 --pid $$' --prepare 'shopt -s extglob && renice --priority -20 --pid $$' '. /mnt/ramdisk/forkrun/forkrun.bash && '"${C0[$jj]//'${kk}'/${kk}}"' {cmd} '"${c}"' '"${C1[$jj]//'${kk}'/${kk}}"
             fi
 
         done
@@ -130,8 +156,8 @@ for jj in ${!C0[@]}; do
 	    printf '%0.12s    \t' '(forkrun)' '(xargs)' "$(${testParallelFlag} && echo '(parallel)')"; 
         done; 
         printf '\n\n'; 
-        for kk in {1..6}; do
-            printf '%s\t' $(wc -l <"${hfdir0}"/file_lists/f$kk)
+        for kk in "${!nArgs[@]}"; do [[ "$kk" == 0 ]] && continue
+            printf '%s\t' "${nArgs[$kk]}"
             for c in "${cksumAlgsA[@]}"; do
                 printf '%0.12s\t' $(grep -F "$t" < "${hfdir}"/results/forkrun."${c// /_}".f${kk}.hyperfine.results | sed -E s/'^.*\:'//)
             done
@@ -166,7 +192,7 @@ for jj in ${!C0[@]}; do
 
         padStr="$(source /proc/self/fd/0 <<<"printf '%.0s ' {1..${padMax}}")"
 
-        for kk in ${!val[@]}; do
+        for kk in "${!val[@]}"; do
             val[$kk]+="${padStr:0:${pad[$kk]}}"
         done
 
@@ -193,9 +219,9 @@ for jj in ${!C0[@]}; do
     {
     printf '\n\n||-----------------------------------------------------------------------------------------------------------------------------------------------------------||\n||------------------------------------------------------------------- RUN_TIME_IN_SECONDS -------------------------------------------------------------------||\n||-----------------------------------------------------------------------------------------------------------------------------------------------------------||\n'  
 
-    for kk in {1..6}; do
+    for (( kk=1; kk<${#nArgs[@]}; kk++ )); do
 
-        printf '\n\n\n%.157s|| \n\n' "$(printf '||----------------------------------------------------------------- NUM_CHECKSUMS=%s -------------------------------------------------------------------------' $(wc -l <"${hfdir0}/file_lists/f${kk}"))"
+        printf '\n\n\n%.157s|| \n\n' "$(printf '||----------------------------------------------------------------- NUM_CHECKSUMS=%s -------------------------------------------------------------------------' ${nArgs[$kk]})"
         printf0 8:'(algorithm)' 
         if ${testParallelFlag}; then
 		printf0 12:'(forkrun -j -)' 12:'(forkrun)' 12:'(xargs)' 12:'(parallel)' 44:'(relative performance vs xargs)' 44:'(relative performance vs parallel)'

--- a/lseek_builtin/lseek.c
+++ b/lseek_builtin/lseek.c
@@ -77,24 +77,22 @@ static int lseek_main(int argc, char **argv) {
         return 1;
     }
 
-    // get SEEK_TYPE and call lseek to move fd byte offset 
-    if (argc == 4 && strcmp(argv[3], "SEEK_SET") == 0) {
-        if (lseek(fd, offset, SEEK_SET) == (off_t) -1) {
-            fprintf(stderr, "\nERROR: %s\n", strerror(errno));
-            return 1;
-        }
-    } else if (argc == 4 && strcmp(argv[3], "SEEK_END") == 0) {
-        if (lseek(fd, offset, SEEK_END) == (off_t) -1) {
-            fprintf(stderr, "\nERROR: %s\n", strerror(errno));
-            return 1;
-        }
-    } else {
-        if (lseek(fd, offset, SEEK_CUR) == (off_t) -1) {
-            fprintf(stderr, "\nERROR: %s\n", strerror(errno));
-            return 1;
+    // get SEEK_TYPE 
+    int whence = SEEK_CUR; 
+    if (argc == 4) {
+        if (strcmp(argv[3], "SEEK_SET") == 0) {
+            whence = SEEK_SET;
+        } else if (strcmp(argv[3], "SEEK_END") == 0) {
+            whence = SEEK_END;
         }
     }
 
+    // call lseek to move fd byte offset 
+    if (lseek(fd, offset, whence) == (off_t) -1) {
+        fprintf(stderr, "\nERROR: %s\n", strerror(errno));
+        return 1;
+    }
+    
     return 0;
 }
 

--- a/lseek_builtin/lseek.c
+++ b/lseek_builtin/lseek.c
@@ -28,13 +28,17 @@ extern char **make_builtin_argv();
 static char *lseek_doc[] = {
     "",
     "----------------------------------------------",
-    "USAGE:    lseek <FD> <REL_OFFSET>",
+    "USAGE:    lseek <FD> <REL_OFFSET> [<SEEK_TYPE>]",
     "",
     "Move the file descriptor <FD> by <REL_OFFSET>",
     "bytes relative to its current byte offset.",
     "",
     "positive <REL_OFFSET> advances the <FD>",
     "negative <REL_OFFSET> rewinds the <FD>",
+    "",
+    "SEEK_TYPE is optional and can take the value of:",
+    "   'SEEK_SET'   'SEEK_CUR'    'SEEK_END'",
+    " If omitted or invalid, SEEK_CUR is used.",
     "----------------------------------------------",
     "",
     NULL
@@ -46,15 +50,15 @@ struct builtin lseek_struct = {
     lseek_builtin,        // Function to call
     BUILTIN_ENABLED,      // Default status
     lseek_doc,            // Documentation strings
-    "lseek <FD> <REL_OFFSET>",  // Usage string
+    "lseek <FD> <REL_OFFSET> [<SEEK_TYPE>]",  // Usage string
     0                     // Number of long options
 };
 
 // main function
 static int lseek_main(int argc, char **argv) {
-    // check for exactly 2 args passed to lseek
-    if (argc != 3) {
-        fprintf(stderr, "\nIncorrect number of arguments.\nUSAGE: lseek <FD> <REL_OFFSET>\n");
+    // check for exactly 2 or 3 args passed to lseek
+    if (argc != 3 && argc != 4) {
+        fprintf(stderr, "\nIncorrect number of arguments.\nUSAGE: lseek <FD> <REL_OFFSET> [<SEEK_TYPE>]\n");
         return 1;
     }
 
@@ -65,7 +69,7 @@ static int lseek_main(int argc, char **argv) {
         return 1;
     }
 
-     // get + validate (relative) offset
+    // get + validate (relative) offset
     errno = 0;
     off_t offset = atoll(argv[2]);
     if (errno == ERANGE) {
@@ -73,10 +77,22 @@ static int lseek_main(int argc, char **argv) {
         return 1;
     }
 
-    // call lseek to move fd byte offset 
-    if (lseek(fd, offset, SEEK_CUR) == (off_t) -1) {
-        fprintf(stderr, "\nERROR: %s\n", strerror(errno));
-        return 1;
+    // get SEEK_TYPE and call lseek to move fd byte offset 
+    if (argc == 4 && strcmp(argv[3], "SEEK_SET") == 0) {
+        if (lseek(fd, offset, SEEK_SET) == (off_t) -1) {
+            fprintf(stderr, "\nERROR: %s\n", strerror(errno));
+            return 1;
+        }
+    } else if (argc == 4 && strcmp(argv[3], "SEEK_END") == 0) {
+        if (lseek(fd, offset, SEEK_END) == (off_t) -1) {
+            fprintf(stderr, "\nERROR: %s\n", strerror(errno));
+            return 1;
+        }
+    } else {
+        if (lseek(fd, offset, SEEK_CUR) == (off_t) -1) {
+            fprintf(stderr, "\nERROR: %s\n", strerror(errno));
+            return 1;
+        }
     }
 
     return 0;


### PR DESCRIPTION
add support to the lseek loadable builtin to use SEEK_SET and SEEK_END

## Summary by Sourcery

New Features:
- Add support for the `SEEK_SET` and `SEEK_END` flags to the lseek builtin.