### PR TITLE
use `head` to speed up `-n <#>` flag when possible + fix whitespace option parsing

### DIFF
--- a/forkrun.bash
+++ b/forkrun.bash
@@ -28,8 +28,8 @@ forkrun() {
 
     # make all variables local
     local +i nLines nLines0 nLinesMax nBytes nProcs nProcsMax nQueueMin 
-    local tmpDir fPath outStr delimiterVal delimiterReadStr delimiterRemoveStr exitTrapStr exitTrapStr_kill nOrder tTimeout coprocSrcCode outCur tmpDirRoot returnVal tmpVar t0 writeFileProgStr readBytesProg nullDelimiterProg ddQuietStr pLOAD0 pLOAD1 trailingNullFlag inotifyFlag lseekFlag fallocateFlag nLinesAutoFlag nLinesReadLimitFlag nQueueFlag substituteStringFlag substituteStringIDFlag nOrderFlag readBytesFlag readBytesExactFlag nullDelimiterFlag subshellRunFlag stdinRunFlag pipeReadFlag rmTmpDirFlag exportOrderFlag noFuncFlag unescapeFlag optParseFlag continueFlag doneIndicatorFlag FORCE_allowCarriageReturnsFlag ddAvailableFlag fd_continue fd_inotify fd_inotify0 fd_nAuto fd_nAuto0 fd_nOrder fd_nOrder0 fd_read fd_read0 fd_write fd_stdout fd_stdin fd_stdin0 fd_stderr pWrite pOrder pAuto pQueue pWrite_PID pNotify_PID pOrder_PID pAuto_PID pQueue_PID  DEBUG_FORKRUN
-    local -i PID0 nLinesCur nLinesNew nLinesRead nLinesReadLimit nRead nWait nOrder0 nBytesRead nQueue nQueueLast nQueueLastCount nCPU v9 kkMax kkCur kk kkProcs verboseLevel pLOAD_max pAdd tStart tStart0 fd_read_pos fd_read_pos0 fd_read_pos_old fd_write_pos pAdd0 pAdd1 inLines inTime pAddCount pAddMin pAddSum pAddMax
+    local tmpDir fPath outStr delimiterVal delimiterReadStr delimiterRemoveStr exitTrapStr exitTrapStr_kill nOrder tTimeout coprocSrcCode outCur tmpDirRoot returnVal tmpVar t0 readBytesProg nullDelimiterProg ddQuietStr pLOAD0 pLOAD1 trailingNullFlag inotifyFlag lseekFlag fallocateFlag nLinesAutoFlag nLinesReadLimitFlag nQueueFlag substituteStringFlag substituteStringIDFlag nOrderFlag readBytesFlag readBytesExactFlag nullDelimiterFlag subshellRunFlag stdinRunFlag pipeReadFlag rmTmpDirFlag exportOrderFlag noFuncFlag unescapeFlag optParseFlag continueFlag doneIndicatorFlag FORCE_allowCarriageReturnsFlag ddAvailableFlag fd_continue fd_inotify fd_inotify0 fd_nAuto fd_nAuto0 fd_nOrder fd_nOrder0 fd_read fd_read0 fd_write fd_stdout fd_stdin fd_stdin0 fd_stderr pWrite pOrder pAuto pQueue pWrite_PID pNotify_PID pOrder_PID pAuto_PID pQueue_PID  DEBUG_FORKRUN
+    local -i PID0 nLinesCur nLinesNew nLinesRead nLinesReadLimit nRead nWait nOrder0 nBytesRead nQueue nQueueLast nQueueLastCount nCPU writeFileProgType v9 kkMax kkCur kk kkProcs verboseLevel pLOAD_max pAdd tStart tStart0 fd_read_pos fd_read_pos0 fd_read_pos_old fd_write_pos pAdd0 pAdd1 inLines inTime pAddCount pAddMin pAddSum pAddMax
     local -a A p_PID runCmd outHave outPrint pLOADA pLOADA0
     local -a -i runTimeA runLinesA
 
@@ -533,15 +533,15 @@ kill -USR1 $(cat </dev/null "'"${tmpDir}"'"/.run/p* 2>/dev/null) 2>/dev/null; '$
         } || {
             ${nLinesReadLimitFlag} && type -a head &>/dev/null && { 
                 if ${nullDelimiterFlag}; then
-                    writeFileProgStr=2
+                    writeFileProgType=2
                     nLinesReadLimitFlag=false
                 elif [[ "${delimiterVal}" == '$'"'"'\n'"'" ]]; then
-                    writeFileProgStr=3
+                    writeFileProgType=3
                     nLinesReadLimitFlag=false
                 fi
             }
             
-            : "${writeFileProgStr:=1}"
+            : "${writeFileProgType:=1}"
         
             # spawn a coproc to write stdin to a tmpfile
             # After we are done reading all of stdin indicate this by touching .done
@@ -555,7 +555,7 @@ kill -USR1 $(cat </dev/null "'"${tmpDir}"'"/.run/p* 2>/dev/null) 2>/dev/null; '$
                 trap 'trap - TERM INT HUP USR1; kill -HUP '"${PID0}"' ${BASHPID}' HUP
                 trap 'trap - TERM INT HUP USR1' USR1
 
-                case ${writeFileProgStr} in
+                case ${writeFileProgType} in
                     1) cat <&${fd_stdin} >&${fd_write} ;;
                     2) head -z -n ${nLinesReadLimit} <&${fd_stdin} >&${fd_write} ;;
                     3) head -n ${nLinesReadLimit} <&${fd_stdin} >&${fd_write} ;;

--- a/forkrun.bash
+++ b/forkrun.bash
@@ -260,7 +260,7 @@ forkrun() {
             head -n ${nLinesReadLimit} <&${fd_head0} >&${fd_stdin0}
           } &
         } {fd_stdin0}<><(:) {fd_head0}<&0
-        trap 'exec {'"${fd_head0}"'}>&-; exec {'"${fd_stdin0}"'}>&-; trap - EXIT' EXIT
+        trap 'exec {fd_head0}>&-; exec {fd_stdin0}>&-; trap - EXIT' EXIT
         nLinesReadLimitFlag=false
     fi
 

--- a/forkrun.bash
+++ b/forkrun.bash
@@ -28,7 +28,7 @@ forkrun() {
 
     # make all variables local
     local +i nLines nLines0 nLinesMax nBytes nProcs nProcsMax nQueueMin 
-    local tmpDir fPath outStr delimiterVal delimiterReadStr delimiterRemoveStr exitTrapStr exitTrapStr_kill nOrder tTimeout coprocSrcCode outCur tmpDirRoot returnVal tmpVar t0 readBytesProg nullDelimiterProg ddQuietStr pLOAD0 pLOAD1 trailingNullFlag inotifyFlag lseekFlag fallocateFlag nLinesAutoFlag nLinesReadLimitFlag nQueueFlag substituteStringFlag substituteStringIDFlag nOrderFlag readBytesFlag readBytesExactFlag nullDelimiterFlag subshellRunFlag stdinRunFlag pipeReadFlag rmTmpDirFlag exportOrderFlag noFuncFlag unescapeFlag optParseFlag continueFlag doneIndicatorFlag FORCE_allowCarriageReturnsFlag ddAvailableFlag fd_continue fd_inotify fd_inotify0 fd_nAuto fd_nAuto0 fd_nOrder fd_nOrder0 fd_read fd_read0 fd_write fd_stdout fd_stdin fd_stdin0 fd_stderr pWrite pOrder pAuto pQueue pWrite_PID pNotify_PID pOrder_PID pAuto_PID pQueue_PID  DEBUG_FORKRUN
+    local tmpDir fPath outStr delimiterVal delimiterReadStr delimiterRemoveStr exitTrapStr exitTrapStr_kill nOrder tTimeout coprocSrcCode outCur tmpDirRoot returnVal tmpVar t0 writeFileProgStr readBytesProg nullDelimiterProg ddQuietStr pLOAD0 pLOAD1 trailingNullFlag inotifyFlag lseekFlag fallocateFlag nLinesAutoFlag nLinesReadLimitFlag nQueueFlag substituteStringFlag substituteStringIDFlag nOrderFlag readBytesFlag readBytesExactFlag nullDelimiterFlag subshellRunFlag stdinRunFlag pipeReadFlag rmTmpDirFlag exportOrderFlag noFuncFlag unescapeFlag optParseFlag continueFlag doneIndicatorFlag FORCE_allowCarriageReturnsFlag ddAvailableFlag fd_continue fd_inotify fd_inotify0 fd_nAuto fd_nAuto0 fd_nOrder fd_nOrder0 fd_read fd_read0 fd_write fd_stdout fd_stdin fd_stdin0 fd_stderr pWrite pOrder pAuto pQueue pWrite_PID pNotify_PID pOrder_PID pAuto_PID pQueue_PID  DEBUG_FORKRUN
     local -i PID0 nLinesCur nLinesNew nLinesRead nLinesReadLimit nRead nWait nOrder0 nBytesRead nQueue nQueueLast nQueueLastCount nCPU v9 kkMax kkCur kk kkProcs verboseLevel pLOAD_max pAdd tStart tStart0 fd_read_pos fd_read_pos0 fd_read_pos_old fd_write_pos pAdd0 pAdd1 inLines inTime pAddCount pAddMin pAddSum pAddMax
     local -a A p_PID runCmd outHave outPrint pLOADA pLOADA0
     local -a -i runTimeA runLinesA
@@ -42,10 +42,10 @@ forkrun() {
     while ${optParseFlag} && (( $# > 0  )) && [[ "$1" == [-+]* ]]; do
         case "${1}" in
 
-            -?(-)@([jP]|?(n)[Pp]roc?(s)?)?(?([= $'\t'$'\n'])?([+-])*([0-9])*@([0-9,-])**([0-9])*?(,*([0-9])*)))
-                if [[ "${1}" == -?(-)@([jP]|?(n)[Pp]roc?(s)?)?([= $'\t'$'\n'])?([+-])*([0-9])*@([0-9,-])**([0-9])*?(,*([0-9])*) ]]; then
-                    nProcs="${1##@(-?(-)@([jP]|?(n)[Pp]roc?(s)?)?([= $'\t'$'\n'])?(+))}"
-                elif [[ "${1}" == -?(-)@([jP]|?(n)[Pp]roc?(s)?) ]] && [[ "${2}" == ?([+-])*([0-9])*@([0-9,-])**([0-9])*?(,*([0-9])*) ]]; then
+            -?(-)@([jP]|?(n)[Pp]roc?(s))?(?([= $'\t'$'\n'])?([+-])*([0-9])*@([0-9,-])**([0-9])*?(,*([0-9])*)))
+                if [[ "${1}" == -?(-)@([jP]|?(n)[Pp]roc?(s))?([= $'\t'$'\n'])?([+-])*([0-9])*@([0-9,-])**([0-9])*?(,*([0-9])*) ]]; then
+                    nProcs="${1##@(-?(-)@([jP]|?(n)[Pp]roc?(s))?([= $'\t'$'\n'])?(+))}"
+                elif [[ "${1}" == -?(-)@([jP]|?(n)[Pp]roc?(s)) ]] && [[ "${2}" == ?([+-])*([0-9])*@([0-9,-])**([0-9])*?(,*([0-9])*) ]]; then
                     nProcs="${2#'+'}"
                     shift 1
                 fi
@@ -252,17 +252,6 @@ forkrun() {
 
     mkdir -p "${tmpDir}"/.run
     : >"${fPath}"
-
-    # if we were passed the -n flag and we have `head` then use it
-    if ${nLinesReadLimitFlag} && type -a head &>/dev/null; then
-        { 
-          {
-            head -n ${nLinesReadLimit} <&${fd_head0} >&${fd_stdin0}
-          } &
-        } {fd_stdin0}<><(:) {fd_head0}<&0
-        trap 'exec {fd_head0}>&-; exec {fd_stdin0}>&-; trap - EXIT' EXIT
-        nLinesReadLimitFlag=false
-    fi
 
     # # # # # BEGIN MAIN SUBSHELL # # # # #
 
@@ -538,10 +527,22 @@ forkrun() {
 : >"'"${tmpDir}"'"/.quit;
 kill -USR1 $(cat </dev/null "'"${tmpDir}"'"/.run/p* 2>/dev/null) 2>/dev/null; '$'\n'
 
-       ${pipeReadFlag} && {
+        ${pipeReadFlag} && {
             # '.done'  file makes no sense when reading from a pipe
             : >"${tmpDir}"/.done
         } || {
+            ${nLinesReadLimitFlag} && type -a head &>/dev/null && { 
+                if ${nullDelimiterFlag}; then
+                    writeFileProgStr="head -z -n ${nLinesReadLimit}"
+                    nLinesReadLimitFlag=false
+                elif [[ "${delimiterVal}" == '$'"'"'\n'"'" ]]; then
+                    writeFileProgStr="head -n ${nLinesReadLimit}"
+                    nLinesReadLimitFlag=false
+                fi
+            }
+            
+            : "${writeFileProgStr:=cat}"
+        
             # spawn a coproc to write stdin to a tmpfile
             # After we are done reading all of stdin indicate this by touching .done
             { coproc pWrite {
@@ -554,7 +555,8 @@ kill -USR1 $(cat </dev/null "'"${tmpDir}"'"/.run/p* 2>/dev/null) 2>/dev/null; '$
                 trap 'trap - TERM INT HUP USR1; kill -HUP '"${PID0}"' ${BASHPID}' HUP
                 trap 'trap - TERM INT HUP USR1' USR1
 
-                cat <&${fd_stdin} >&${fd_write}
+                ${writeFileProgStr} <&${fd_stdin} >&${fd_write}
+                    
                 : >"${tmpDir}"/.done
                 (( ${verboseLevel} > 1 )) && printf '\nINFO: pWrite has finished - all of stdin has been saved to the tmpfile at %s\n' "${fPath}" >&${fd_stderr}
                 ${inotifyFlag} && {

--- a/forkrun.bash
+++ b/forkrun.bash
@@ -296,7 +296,7 @@ forkrun() {
         shopt -s nullglob
 
         # dynamically set defaults for a few flags
-        : "${noFuncFlag:=false}""${readBytesFlag:=false}" "${readBytesExactFlag:=false}" "${nullDelimiterFlag:=false}" "${FORCE_allowCarriageReturnsFlag:=false}" 
+        : "${noFuncFlag:=false}" "${readBytesFlag:=false}" "${readBytesExactFlag:=false}" "${nullDelimiterFlag:=false}" "${FORCE_allowCarriageReturnsFlag:=false}" 
 
         if enable lseek &>/dev/null; then
             : "${lseekFlag:=true}"

--- a/forkrun.bash
+++ b/forkrun.bash
@@ -533,15 +533,15 @@ kill -USR1 $(cat </dev/null "'"${tmpDir}"'"/.run/p* 2>/dev/null) 2>/dev/null; '$
         } || {
             ${nLinesReadLimitFlag} && type -a head &>/dev/null && { 
                 if ${nullDelimiterFlag}; then
-                    writeFileProgStr="head -z -n ${nLinesReadLimit}"
+                    writeFileProgStr=2
                     nLinesReadLimitFlag=false
                 elif [[ "${delimiterVal}" == '$'"'"'\n'"'" ]]; then
-                    writeFileProgStr="head -n ${nLinesReadLimit}"
+                    writeFileProgStr=3
                     nLinesReadLimitFlag=false
                 fi
             }
             
-            : "${writeFileProgStr:=cat}"
+            : "${writeFileProgStr:=1}"
         
             # spawn a coproc to write stdin to a tmpfile
             # After we are done reading all of stdin indicate this by touching .done
@@ -555,7 +555,11 @@ kill -USR1 $(cat </dev/null "'"${tmpDir}"'"/.run/p* 2>/dev/null) 2>/dev/null; '$
                 trap 'trap - TERM INT HUP USR1; kill -HUP '"${PID0}"' ${BASHPID}' HUP
                 trap 'trap - TERM INT HUP USR1' USR1
 
-                ${writeFileProgStr} <&${fd_stdin} >&${fd_write}
+                case ${writeFileProgStr} in
+                    1) cat <&${fd_stdin} >&${fd_write} ;;
+                    2) head -z -n ${nLinesReadLimit} <&${fd_stdin} >&${fd_write} ;;
+                    3) head -n ${nLinesReadLimit} <&${fd_stdin} >&${fd_write} ;;
+                esac
                     
                 : >"${tmpDir}"/.done
                 (( ${verboseLevel} > 1 )) && printf '\nINFO: pWrite has finished - all of stdin has been saved to the tmpfile at %s\n' "${fPath}" >&${fd_stderr}

--- a/forkrun.bash
+++ b/forkrun.bash
@@ -35,7 +35,7 @@ forkrun() {
 
     # # # # # PARSE OPTIONS # # # # #
 
-    : "${verboseLevel:=0}" "${returnVal:=0}" "${fd_stdin0:=0}"
+    : "${verboseLevel:=0}" "${returnVal:=0}" "${fd_stdin0:=0}" "${nLinesReadLimitFlag:=false}" 
 
     # check inputs and set defaults if needed
     [[ $# == 0 ]] && optParseFlag=false || optParseFlag=true
@@ -253,6 +253,17 @@ forkrun() {
     mkdir -p "${tmpDir}"/.run
     : >"${fPath}"
 
+    # if we were passed the -n flag and we have `head` then use it
+    if ${nLinesReadLimitFlag} && type -a head &>/dev/null; then
+        { 
+          {
+            head -n ${nLinesReadLimit} <&${fd_head0} >&${fd_stdin0}
+          } &
+        } {fd_stdin0}<><(:) {fd_head0}<&0
+        trap 'exec {'"${fd_head0}"'}>&-; exec {'"${fd_stdin0}"'}>&-; trap - EXIT' EXIT
+        nLinesReadLimitFlag=false
+    fi
+
     # # # # # BEGIN MAIN SUBSHELL # # # # #
 
     # several file descriptors are opened for use by things running in this subshell. See closing`)` near the end of this function.
@@ -285,7 +296,7 @@ forkrun() {
         shopt -s nullglob
 
         # dynamically set defaults for a few flags
-        : "${noFuncFlag:=false}""${readBytesFlag:=false}" "${readBytesExactFlag:=false}" "${nullDelimiterFlag:=false}" "${nLinesReadLimitFlag:=false}" "${FORCE_allowCarriageReturnsFlag:=false}" 
+        : "${noFuncFlag:=false}""${readBytesFlag:=false}" "${readBytesExactFlag:=false}" "${nullDelimiterFlag:=false}" "${FORCE_allowCarriageReturnsFlag:=false}" 
 
         if enable lseek &>/dev/null; then
             : "${lseekFlag:=true}"


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix a bug where whitespace characters in option arguments were not handled correctly.