### PR TITLE
Fix: Add null checks for malloc/realloc and eventfd return values

### DIFF
--- a/forkrun_ring.c
+++ b/forkrun_ring.c
@@ -1489,6 +1489,16 @@ static int ring_init_main(int argc, char **argv) {
     return EXECUTION_FAILURE;
   }
 
+  // Initialize all eventfds to -1 (invalid) before attempting to create them
+  for (uint32_t n = 0; n < global_num_nodes; n++) {
+    evfd_data_arr[n] = -1;
+    evfd_eof_arr[n] = -1;
+    evfd_indexer_arr[n] = -1;
+    evfd_meta_arr[n] = -1;
+    fd_escrow_r[n] = -1;
+    fd_escrow_w[n] = -1;
+  }
+
   for (uint32_t n = 0; n < global_num_nodes; n++) {
     evfd_data_arr[n] = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK | EFD_SEMAPHORE);
     evfd_eof_arr[n] = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
@@ -1504,15 +1514,18 @@ static int ring_init_main(int argc, char **argv) {
       fcntl(pfd[1], F_SETPIPE_SZ, 1048576);
       fd_escrow_r[n] = pfd[0];
       fd_escrow_w[n] = pfd[1];
-    } else {
-      fd_escrow_r[n] = -1;
-      fd_escrow_w[n] = -1;
     }
   }
 
   evfd_ingest_data = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
   evfd_ingest_eof = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
   evfd_chunk_done = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK | EFD_SEMAPHORE);
+
+  // Check that critical eventfds were created successfully
+  if (evfd_ingest_data < 0 || evfd_ingest_eof < 0 || evfd_chunk_done < 0) {
+    builtin_error("forkrun: eventfd creation failed");
+    return EXECUTION_FAILURE;
+  }
 
   evfd_data = evfd_data_arr[0];
   fd_escrow[0] = fd_escrow_r[0];
@@ -3650,7 +3663,10 @@ static void heap_push(struct HeapNode **heap_ptr, int *sz, int *cap,
                       uint64_t key, struct OrderPacket pkt) {
   if (*sz >= *cap) {
     *cap = (*cap) * 2;
-    *heap_ptr = realloc(*heap_ptr, (*cap) * sizeof(struct HeapNode));
+    struct HeapNode *new_heap = realloc(*heap_ptr, (*cap) * sizeof(struct HeapNode));
+    if (!new_heap)
+      return; // Silent failure - preserve existing heap
+    *heap_ptr = new_heap;
   }
   struct HeapNode *heap = *heap_ptr;
   int i = (*sz)++;
@@ -4205,6 +4221,12 @@ static int ring_fetcher_main(int argc, char **argv) {
         copy_file_range(fd_global, &off_in, fd_local, &off_out, pp.len, 0);
     if (ret < 0) {
       char *buf = malloc(65536);
+      if (!buf) {
+        uint64_t one = 1;
+        sys_write(fd_local_sig, &one, 8);
+        robust_pipe_write(fd_global_ack, &pp, sizeof(pp));
+        continue;
+      }
       uint64_t copied = 0;
       lseek(fd_global, pp.off, SEEK_SET);
       lseek(fd_local, 0, SEEK_END);
@@ -4276,13 +4298,15 @@ static int ring_fallow_phys_main(int argc, char **argv) {
         }
       } else if (pp->off > limit) {
         struct Interval *n = malloc(sizeof(struct Interval));
-        n->s = pp->off;
-        n->e = pp->off + pp->len;
-        struct Interval **curr = &head;
-        while (*curr && (*curr)->s < n->s)
-          curr = &((*curr)->next);
-        n->next = *curr;
-        *curr = n;
+        if (n) {
+          n->s = pp->off;
+          n->e = pp->off + pp->len;
+          struct Interval **curr = &head;
+          while (*curr && (*curr)->s < n->s)
+            curr = &((*curr)->next);
+          n->next = *curr;
+          *curr = n;
+        }
       }
     }
 


### PR DESCRIPTION
This commit fixes several potential crashes and memory leaks:

## 1. heap_push() - realloc result was not checked
- If realloc fails, it returns NULL but the original pointer is still valid
- By assigning directly to *heap_ptr, we lose the original pointer (memory leak)
- Now checks realloc result and silently preserves existing heap on failure

## 2. ring_fetcher_main() - malloc(65536) was not checked
- Using NULL pointer would cause crash
- Now checks malloc result and skips the copy operation on failure

## 3. ring_fallow_phys_main() - malloc(sizeof(struct Interval)) was not checked  
- Using NULL pointer would cause crash
- Now checks malloc result before dereferencing

## 4. ring_init_main() - eventfd() return values were not checked
- If eventfd() fails, it returns -1, but the code would use -1 as an fd
- Now initializes all fd arrays to -1 and checks critical eventfds

These issues could cause crashes under low memory conditions or when eventfd creation fails.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

## Summary by Sourcery

Improve robustness of ring initialization and heap operations by handling allocation and eventfd failures safely.

Bug Fixes:
- Initialize all ring-related eventfd and escrow file descriptor arrays to -1 before creation to avoid using uninitialized or stale descriptors.
- Validate creation of critical eventfd descriptors in ring initialization and abort with an error on failure instead of proceeding with invalid fds.
- Guard heap expansion in heap_push against realloc failure to prevent memory leaks and preserve the existing heap state.
- Check malloc failures in the fetcher path before using the buffer and fall back to signaling and acknowledgment logic when allocation fails.
- Check malloc when allocating Interval structures in the fallow-phys path and skip interval insertion if allocation fails.