### PR TITLE
remove beta versions from docs

### DIFF
--- a/DOCS/INVARIANTS.md
+++ b/DOCS/INVARIANTS.md
@@ -1,6 +1,6 @@
 ### `INVARIANTS.md`
 
-# FORKRUN INVARIANTS (v9.8.0-NUMA Golden Master)
+# FORKRUN INVARIANTS
 
 These are the rules that **must never be broken**. If they hold, the system is correct regardless of batching heuristics, NUMA count, or workload shape.
 


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Update the FORKRUN invariants documentation to use a version-agnostic title without beta version information.