### PR TITLE
HOTFIX - fix signal handling in frun.bash

### DIFF
--- a/META
+++ b/META
@@ -1,2 +1,2 @@
 NAME: forkrun
-VERSION: v3.4.0
+VERSION: v3.4.1

--- a/UNIT_TESTS/RESULTS.md
+++ b/UNIT_TESTS/RESULTS.md
@@ -1,4 +1,4 @@
-=== forkrun v3.4.0 C Plugin Test Suite ===
+=== forkrun v3.4.1 C Plugin Test Suite ===
 UNIT_TESTS_DIR : /mnt/ramdisk/forkrun/UNIT_TESTS
 FRUN_SCRIPT    : /mnt/ramdisk/forkrun/UNIT_TESTS/frun.bash
 Sourcing frun.bash...
@@ -39,7 +39,7 @@ Cmd : frun -k -C ./test_basic.so:test_basic < input_1M.txt
 
 === All C Plugin Tests Completed Successfully ===
 
-=== forkrun v3.4.0 C Plugin Rigorous Test Suite ===
+=== forkrun v3.4.1 C Plugin Rigorous Test Suite ===
 Compiling Native Plugins...
 Generating Deterministic Test Inputs...
 ------------------------------------------------------
@@ -312,7 +312,7 @@ Verifying run_test_sorted catches duplicate lines...
   [0;32m✓[0m Q3: Concurrent frun with separate checkpoints
   [0;32m✓[0m Q4: Sequential frun reuse, 10 iterations
 
-[1;34m[1m▶ Section R: v3.4.0 New Features (TUI, SLURM, Halt, Sweeps)[0m
+[1;34m[1m▶ Section R: v3.4.1 New Features (TUI, SLURM, Halt, Sweeps)[0m
 [1;34m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━[0m
   [0;32m✓[0m R1: TUI flag accepted and pipeline completes (headless safe)
   [0;32m✓[0m R2: SLURM SIGUSR1 triggers checkpoint and exit 138

--- a/UNIT_TESTS/test_c_plugins.sh
+++ b/UNIT_TESTS/test_c_plugins.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # =============================================================================
-# forkrun v3.4.0 - C Plugin Test Suite
+# forkrun v3.4.1 - C Plugin Test Suite
 # =============================================================================
 
 set -o pipefail
@@ -13,7 +13,7 @@ HEADER="${UNIT_TESTS_DIR}/../ring_loadables/forkrun_plugin.h"
 mkdir -p "$TEST_DIR"
 cd "$TEST_DIR"
 
-echo "=== forkrun v3.4.0 C Plugin Test Suite ==="
+echo "=== forkrun v3.4.1 C Plugin Test Suite ==="
 echo "UNIT_TESTS_DIR : $UNIT_TESTS_DIR"
 echo "FRUN_SCRIPT    : $FRUN_SCRIPT"
 

--- a/UNIT_TESTS/test_c_plugins_v2.sh
+++ b/UNIT_TESTS/test_c_plugins_v2.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # =============================================================================
-# forkrun v3.4.0 - C Plugin Rigorous Test Suite
+# forkrun v3.4.1 - C Plugin Rigorous Test Suite
 # =============================================================================
 
 set -o pipefail
@@ -13,7 +13,7 @@ HEADER="${UNIT_TESTS_DIR}/../ring_loadables/forkrun_plugin.h"
 mkdir -p "$TEST_DIR"
 cd "$TEST_DIR"
 
-echo "=== forkrun v3.4.0 C Plugin Rigorous Test Suite ==="
+echo "=== forkrun v3.4.1 C Plugin Rigorous Test Suite ==="
 
 # Source frun
 . "$FRUN_SCRIPT"

--- a/UNIT_TESTS/test_frun.sh
+++ b/UNIT_TESTS/test_frun.sh
@@ -549,7 +549,7 @@ run_test_regex "Dry run (-N)" \
 
 run_test "Version (-V)" \
   "frun -V" \
-  "forkrun v3.4.0"
+  "forkrun v3.4.1"
 
 # FIXED: Check for USAGE string explicitly without exact match
 run_test_regex "Help (--help)" \

--- a/UNIT_TESTS/test_frun.sh.txt
+++ b/UNIT_TESTS/test_frun.sh.txt
@@ -549,7 +549,7 @@ run_test_regex "Dry run (-N)" \
 
 run_test "Version (-V)" \
   "frun -V" \
-  "forkrun v3.4.0"
+  "forkrun v3.4.1"
 
 # FIXED: Check for USAGE string explicitly without exact match
 run_test_regex "Help (--help)" \

--- a/UNIT_TESTS/test_frun_comprehensive.sh
+++ b/UNIT_TESTS/test_frun_comprehensive.sh
@@ -2884,9 +2884,9 @@ if in_section Q; then
 fi
 
 # ============================================================================
-# SECTION R: v3.4.0 NEW FEATURES (TUI, SLURM, Halt, Sweeps)
+# SECTION R: v3.4.1 NEW FEATURES (TUI, SLURM, Halt, Sweeps)
 # ============================================================================
-print_section R "v3.4.0 New Features (TUI, SLURM, Halt, Sweeps)"
+print_section R "v3.4.1 New Features (TUI, SLURM, Halt, Sweeps)"
 
 # --- R1: TUI flag accepted and pipeline completes (headless safe) ---
 # Even without a /dev/tty, frun should gracefully skip the TUI and run normally.

--- a/UNIT_TESTS/test_frun_comprehensive.sh.txt
+++ b/UNIT_TESTS/test_frun_comprehensive.sh.txt
@@ -2884,9 +2884,9 @@ if in_section Q; then
 fi
 
 # ============================================================================
-# SECTION R: v3.4.0 NEW FEATURES (TUI, SLURM, Halt, Sweeps)
+# SECTION R: v3.4.1 NEW FEATURES (TUI, SLURM, Halt, Sweeps)
 # ============================================================================
-print_section R "v3.4.0 New Features (TUI, SLURM, Halt, Sweeps)"
+print_section R "v3.4.1 New Features (TUI, SLURM, Halt, Sweeps)"
 
 # --- R1: TUI flag accepted and pipeline completes (headless safe) ---
 # Even without a /dev/tty, frun should gracefully skip the TUI and run normally.

--- a/forkrun_ring.c
+++ b/forkrun_ring.c
@@ -1,4 +1,4 @@
-// forkrun_ring.c v3.4.0
+// forkrun_ring.c v3.4.1
 // ======================================================================================
 // ARCHITECTURE OVERVIEW:
 //
@@ -376,7 +376,7 @@ fast_count_delim(const char *p, const char *end, char delim) {
 #define DAMPING_OFFSET 6
 
 #ifndef FORKRUN_RING_VERSION
-#define FORKRUN_RING_VERSION "v3.4.0"
+#define FORKRUN_RING_VERSION "v3.4.1"
 #endif
 
 #define atomic_load_acquire(ptr) __atomic_load_n(ptr, __ATOMIC_ACQUIRE)

--- a/frun.bash
+++ b/frun.bash
@@ -1275,7 +1275,7 @@ _forkrun_checkpoint_signal() {
   _ring_registered=false
 
   trap '"'"'
-    status=$?
+    (( status = ${status:-0} + $? ))
     ${_ring_registered} && { ring_worker dec; ring_cleanup_waiter; }
 
     if (( status != 0 && ${FRUN_CLAIM_BYTES:-0} > 0 )); then
@@ -1300,8 +1300,16 @@ _forkrun_checkpoint_signal() {
   trap '"'"'ring_abort; trap - INT; kill -INT ${BASHPID}'"'"' INT
   trap '"'"'ring_abort; trap - HUP; kill -HUP ${BASHPID}'"'"' HUP
   trap '"'"'ring_abort; trap - QUIT; kill -QUIT ${BASHPID}'"'"' QUIT
-  trap "" USR1 TERM
-
+  '
+    if (( preempt_mode == 1 )); then
+       worker_func_src+='trap "" USR1 TERM
+'
+    else
+       worker_func_src+='trap '"'"'status=143; trap - TERM; kill -TERM ${BASHPID}'"'"' TERM
+trap '"'"'status=138; trap - USR1; kill -USR1 ${BASHPID}'"'"' USR1
+'
+    fi
+worker_func_src+='
   {
     ID="$1" # ID is passed purely for user payload compatibility/insertion
     RING_NUM_KILLS=0

--- a/frun.bash
+++ b/frun.bash
@@ -1299,6 +1299,7 @@ _forkrun_checkpoint_signal() {
 
   trap '"'"'ring_abort; trap - INT; kill -INT ${BASHPID}'"'"' INT
   trap '"'"'ring_abort; trap - HUP; kill -HUP ${BASHPID}'"'"' HUP
+  trap '"'"'trap_status=131; trap - QUIT; kill -QUIT ${BASHPID}'"'"' QUIT
   '
     if (( preempt_mode == 1 )); then
        worker_func_src+='trap "" USR1 TERM

--- a/frun.bash
+++ b/frun.bash
@@ -1299,7 +1299,6 @@ _forkrun_checkpoint_signal() {
 
   trap '"'"'ring_abort; trap - INT; kill -INT ${BASHPID}'"'"' INT
   trap '"'"'ring_abort; trap - HUP; kill -HUP ${BASHPID}'"'"' HUP
-  trap '"'"'ring_abort; trap - QUIT; kill -QUIT ${BASHPID}'"'"' QUIT
   '
     if (( preempt_mode == 1 )); then
        worker_func_src+='trap "" USR1 TERM

--- a/frun.bash
+++ b/frun.bash
@@ -615,7 +615,7 @@ EOF
             # help system
             -h|-\?|--help|--help=*|--usage)  _frun_displayHelp "$1";  return 0  ;;
 
-            -V|--version|--VERSION)           echo 'forkrun v3.4.0';  return 0  ;;
+            -V|--version|--VERSION)           echo 'forkrun v3.4.1';  return 0  ;;
 
             --) shift; break ;;
 

--- a/frun.bash
+++ b/frun.bash
@@ -1300,10 +1300,8 @@ _forkrun_checkpoint_signal() {
   trap '"'"'ring_abort; trap - INT; kill -INT ${BASHPID}'"'"' INT
   trap '"'"'ring_abort; trap - HUP; kill -HUP ${BASHPID}'"'"' HUP
   trap '"'"'ring_abort; trap - QUIT; kill -QUIT ${BASHPID}'"'"' QUIT
-  '
-   (( preempt_mode == 1 )) && worker_func_src+='trap "" USR1 TERM
-'
-worker_func_src+='
+  trap "" USR1 TERM
+
   {
     ID="$1" # ID is passed purely for user payload compatibility/insertion
     RING_NUM_KILLS=0

--- a/frun.bash
+++ b/frun.bash
@@ -175,7 +175,7 @@ frun __exec__ "$@"
     fi
 
     # # # # # SETUP # # # # #
-    local cmdline_str ring_ack_str done_str delimiter_val pCode extglob_was_set worker_func_src nn N nWorkers0 arg fd0 fd1 fd2 numa_map_str parsed_numa_nodes_arg have_taskset_flag last_conflict numa_map_str exact_lines_val array_var resume_file order_mode unsafe_flag stdin_flag byte_mode_flag dry_run_flag checkpoint_file safe_checkpoint_file prefer_external_flag NORMAL_EXIT_FLAG c_plugin_arg tui_flag TUI_PID preempt_mode is_sweep
+    local cmdline_str ring_ack_str done_str delimiter_val pCode extglob_was_set worker_func_src nn N nWorkers0 arg fd0 fd1 fd2 numa_map_str parsed_numa_nodes_arg have_taskset_flag last_conflict numa_map_str exact_lines_val array_var resume_file order_mode unsafe_flag stdin_flag byte_mode_flag dry_run_flag checkpoint_file safe_checkpoint_file prefer_external_flag NORMAL_EXIT_FLAG c_plugin_arg tui_flag TUI_PID preempt_mode is_sweep status trap_status
     local -g fd_spawn_r fd_spawn_w fd_fallow_r fd_fallow_w fd_order_r fd_order_w ingress_memfd fd_write fd_scan nWorkers nWorkersMax tStart
     local -gx LC_ALL
     local -a fallow_args
@@ -1275,7 +1275,7 @@ _forkrun_checkpoint_signal() {
   _ring_registered=false
 
   trap '"'"'
-    (( status = ${status:-0} + $? ))
+    status=${trap_status:-$?}
     ${_ring_registered} && { ring_worker dec; ring_cleanup_waiter; }
 
     if (( status != 0 && ${FRUN_CLAIM_BYTES:-0} > 0 )); then
@@ -1305,8 +1305,8 @@ _forkrun_checkpoint_signal() {
        worker_func_src+='trap "" USR1 TERM
 '
     else
-       worker_func_src+='trap '"'"'status=143; trap - TERM; kill -TERM ${BASHPID}'"'"' TERM
-trap '"'"'status=138; trap - USR1; kill -USR1 ${BASHPID}'"'"' USR1
+       worker_func_src+='trap '"'"'trap_status=143; trap - TERM; kill -TERM ${BASHPID}'"'"' TERM
+trap '"'"'trap_status=138; trap - USR1; kill -USR1 ${BASHPID}'"'"' USR1
 '
     fi
 worker_func_src+='

--- a/ring_loadables/forkrun_ring.c.txt
+++ b/ring_loadables/forkrun_ring.c.txt
@@ -1,4 +1,4 @@
-// forkrun_ring.c v3.4.0
+// forkrun_ring.c v3.4.1
 // ======================================================================================
 // ARCHITECTURE OVERVIEW:
 //
@@ -376,7 +376,7 @@ fast_count_delim(const char *p, const char *end, char delim) {
 #define DAMPING_OFFSET 6
 
 #ifndef FORKRUN_RING_VERSION
-#define FORKRUN_RING_VERSION "v3.4.0"
+#define FORKRUN_RING_VERSION "v3.4.1"
 #endif
 
 #define atomic_load_acquire(ptr) __atomic_load_n(ptr, __ATOMIC_ACQUIRE)

--- a/ring_loadables/frun.nob64.bash
+++ b/ring_loadables/frun.nob64.bash
@@ -175,7 +175,7 @@ frun __exec__ "$@"
     fi
 
     # # # # # SETUP # # # # #
-    local cmdline_str ring_ack_str done_str delimiter_val pCode extglob_was_set worker_func_src nn N nWorkers0 arg fd0 fd1 fd2 numa_map_str parsed_numa_nodes_arg have_taskset_flag last_conflict numa_map_str exact_lines_val array_var resume_file order_mode unsafe_flag stdin_flag byte_mode_flag dry_run_flag checkpoint_file safe_checkpoint_file prefer_external_flag NORMAL_EXIT_FLAG c_plugin_arg tui_flag TUI_PID preempt_mode is_sweep
+    local cmdline_str ring_ack_str done_str delimiter_val pCode extglob_was_set worker_func_src nn N nWorkers0 arg fd0 fd1 fd2 numa_map_str parsed_numa_nodes_arg have_taskset_flag last_conflict numa_map_str exact_lines_val array_var resume_file order_mode unsafe_flag stdin_flag byte_mode_flag dry_run_flag checkpoint_file safe_checkpoint_file prefer_external_flag NORMAL_EXIT_FLAG c_plugin_arg tui_flag TUI_PID preempt_mode is_sweep status trap_status
     local -g fd_spawn_r fd_spawn_w fd_fallow_r fd_fallow_w fd_order_r fd_order_w ingress_memfd fd_write fd_scan nWorkers nWorkersMax tStart
     local -gx LC_ALL
     local -a fallow_args
@@ -1275,7 +1275,7 @@ _forkrun_checkpoint_signal() {
   _ring_registered=false
 
   trap '"'"'
-    status=$?
+    status=${trap_status:-$?}
     ${_ring_registered} && { ring_worker dec; ring_cleanup_waiter; }
 
     if (( status != 0 && ${FRUN_CLAIM_BYTES:-0} > 0 )); then
@@ -1301,8 +1301,14 @@ _forkrun_checkpoint_signal() {
   trap '"'"'ring_abort; trap - HUP; kill -HUP ${BASHPID}'"'"' HUP
   trap '"'"'ring_abort; trap - QUIT; kill -QUIT ${BASHPID}'"'"' QUIT
   '
-   (( preempt_mode == 1 )) && worker_func_src+='trap "" USR1 TERM
+    if (( preempt_mode == 1 )); then
+       worker_func_src+='trap "" USR1 TERM
 '
+    else
+       worker_func_src+='trap '"'"'trap_status=143; trap - TERM; kill -TERM ${BASHPID}'"'"' TERM
+trap '"'"'trap_status=138; trap - USR1; kill -USR1 ${BASHPID}'"'"' USR1
+'
+    fi
 worker_func_src+='
   {
     ID="$1" # ID is passed purely for user payload compatibility/insertion

--- a/ring_loadables/frun.nob64.bash
+++ b/ring_loadables/frun.nob64.bash
@@ -615,7 +615,7 @@ EOF
             # help system
             -h|-\?|--help|--help=*|--usage)  _frun_displayHelp "$1";  return 0  ;;
 
-            -V|--version|--VERSION)           echo 'forkrun v3.4.0';  return 0  ;;
+            -V|--version|--VERSION)           echo 'forkrun v3.4.1';  return 0  ;;
 
             --) shift; break ;;
 

--- a/ring_loadables/frun.nob64.bash.txt
+++ b/ring_loadables/frun.nob64.bash.txt
@@ -175,7 +175,7 @@ frun __exec__ "$@"
     fi
 
     # # # # # SETUP # # # # #
-    local cmdline_str ring_ack_str done_str delimiter_val pCode extglob_was_set worker_func_src nn N nWorkers0 arg fd0 fd1 fd2 numa_map_str parsed_numa_nodes_arg have_taskset_flag last_conflict numa_map_str exact_lines_val array_var resume_file order_mode unsafe_flag stdin_flag byte_mode_flag dry_run_flag checkpoint_file safe_checkpoint_file prefer_external_flag NORMAL_EXIT_FLAG c_plugin_arg tui_flag TUI_PID preempt_mode is_sweep
+    local cmdline_str ring_ack_str done_str delimiter_val pCode extglob_was_set worker_func_src nn N nWorkers0 arg fd0 fd1 fd2 numa_map_str parsed_numa_nodes_arg have_taskset_flag last_conflict numa_map_str exact_lines_val array_var resume_file order_mode unsafe_flag stdin_flag byte_mode_flag dry_run_flag checkpoint_file safe_checkpoint_file prefer_external_flag NORMAL_EXIT_FLAG c_plugin_arg tui_flag TUI_PID preempt_mode is_sweep status trap_status
     local -g fd_spawn_r fd_spawn_w fd_fallow_r fd_fallow_w fd_order_r fd_order_w ingress_memfd fd_write fd_scan nWorkers nWorkersMax tStart
     local -gx LC_ALL
     local -a fallow_args
@@ -1275,7 +1275,7 @@ _forkrun_checkpoint_signal() {
   _ring_registered=false
 
   trap '"'"'
-    status=$?
+    status=${trap_status:-$?}
     ${_ring_registered} && { ring_worker dec; ring_cleanup_waiter; }
 
     if (( status != 0 && ${FRUN_CLAIM_BYTES:-0} > 0 )); then
@@ -1301,8 +1301,14 @@ _forkrun_checkpoint_signal() {
   trap '"'"'ring_abort; trap - HUP; kill -HUP ${BASHPID}'"'"' HUP
   trap '"'"'ring_abort; trap - QUIT; kill -QUIT ${BASHPID}'"'"' QUIT
   '
-   (( preempt_mode == 1 )) && worker_func_src+='trap "" USR1 TERM
+    if (( preempt_mode == 1 )); then
+       worker_func_src+='trap "" USR1 TERM
 '
+    else
+       worker_func_src+='trap '"'"'trap_status=143; trap - TERM; kill -TERM ${BASHPID}'"'"' TERM
+trap '"'"'trap_status=138; trap - USR1; kill -USR1 ${BASHPID}'"'"' USR1
+'
+    fi
 worker_func_src+='
   {
     ID="$1" # ID is passed purely for user payload compatibility/insertion

--- a/ring_loadables/frun.nob64.bash.txt
+++ b/ring_loadables/frun.nob64.bash.txt
@@ -615,7 +615,7 @@ EOF
             # help system
             -h|-\?|--help|--help=*|--usage)  _frun_displayHelp "$1";  return 0  ;;
 
-            -V|--version|--VERSION)           echo 'forkrun v3.4.0';  return 0  ;;
+            -V|--version|--VERSION)           echo 'forkrun v3.4.1';  return 0  ;;
 
             --) shift; break ;;
 


### PR DESCRIPTION
## Summary by Sourcery

Adjust frun worker signal handling so checkpoint cleanup uses the correct exit status and propagates TERM/USR1/QUIT signals reliably in both regular and nob64 variants.

Bug Fixes:
- Ensure checkpoint trap logic uses a preserved trap_status when set instead of always relying on $?, avoiding incorrect status reporting after signal handling.
- Fix handling of QUIT, TERM, and USR1 signals so workers either ignore them in preempt mode or propagate them with consistent, expected exit codes.